### PR TITLE
#59 Return "" instead of null

### DIFF
--- a/Source/com/drew/metadata/iptc/IptcReader.java
+++ b/Source/com/drew/metadata/iptc/IptcReader.java
@@ -189,7 +189,7 @@ public class IptcReader implements JpegSegmentMetadataReader
         // NOTE that there's a chance we've already loaded the value as a string above, but failed to parse the value
         if (string == null) {
             String encoding = directory.getString(IptcDirectory.TAG_CODED_CHARACTER_SET);
-            if (encoding != null) {
+            if (encoding != null && !encoding.isEmpty()) {
                 string = reader.getString(tagByteCount, encoding);
             } else {
                 byte[] bytes = reader.getBytes(tagByteCount);

--- a/Source/com/drew/metadata/iptc/Iso2022Converter.java
+++ b/Source/com/drew/metadata/iptc/Iso2022Converter.java
@@ -34,7 +34,7 @@ public final class Iso2022Converter
         if (bytes.length > 3 && bytes[0] == ESC && (bytes[3] & 0xFF | ((bytes[2] & 0xFF) << 8) | ((bytes[1] & 0xFF) << 16)) == DOT && bytes[4] == LATIN_CAPITAL_A)
             return ISO_8859_1;
 
-        return null;
+        return "";
     }
 
     /**


### PR DESCRIPTION
@drewnoakes 
We could also write the actual value instead of an empty string into the directory and use Charset.isSupported() in IptcReader to determine if TAG_CODED_CHARACTER_SET is a valid java encoding. Although I don't think this would be much of a benefit. Additionally it would require the correct handling of characters like 'ESC' so they don't appear as question marks.
