### PR TITLE
Fixes errors in javadoc

### DIFF
--- a/Source/com/drew/imaging/ImageMetadataReader.java
+++ b/Source/com/drew/imaging/ImageMetadataReader.java
@@ -42,7 +42,7 @@ import java.util.Collection;
 
 /**
  * Obtains {@link Metadata} from all supported file formats.
- * <p/>
+ * <p>
  * This class a lightweight wrapper around specific file type processors:
  * <ul>
  *     <li>{@link JpegMetadataReader} for JPEG files</li>
@@ -69,7 +69,7 @@ public class ImageMetadataReader
 
     /**
      * Reads metadata from an {@link InputStream}.
-     * <p/>
+     * <p>
      * The file type is determined by inspecting the leading bytes of the stream, and parsing of the file
      * is delegated to one of:
      * <ul>
@@ -132,7 +132,7 @@ public class ImageMetadataReader
 
     /**
      * Reads {@link Metadata} from a {@link File} object.
-     * <p/>
+     * <p>
      * The file type is determined by inspecting the leading bytes of the stream, and parsing of the file
      * is delegated to one of:
      * <ul>
@@ -183,12 +183,12 @@ public class ImageMetadataReader
     /**
      * An application entry point.  Takes the name of one or more files as arguments and prints the contents of all
      * metadata directories to <code>System.out</code>.
-     * <p/>
+     * <p>
      * If <code>-thumb</code> is passed, then any thumbnail data will be written to a file with name of the
      * input file having <code>.thumb.jpg</code> appended.
-     * <p/>
+     * <p>
      * If <code>-markdown</code> is passed, then output will be in markdown format.
-     * <p/>
+     * <p>
      * If <code>-hex</code> is passed, then the ID of each tag will be displayed in hexadecimal.
      *
      * @param args the command line arguments

--- a/Source/com/drew/imaging/jpeg/JpegSegmentData.java
+++ b/Source/com/drew/imaging/jpeg/JpegSegmentData.java
@@ -29,10 +29,10 @@ import java.util.*;
  * Holds a collection of JPEG data segments.  This need not necessarily be all segments
  * within the JPEG. For example, it may be convenient to store only the non-image
  * segments when analysing metadata.
- * <p/>
+ * <p>
  * Segments are keyed via their {@link JpegSegmentType}. Where multiple segments use the
  * same segment type, they will all be stored and available.
- * <p/>
+ * <p>
  * Each segment type may contain multiple entries. Conceptually the model is:
  * <code>Map&lt;JpegSegmentType, Collection&lt;byte[]&gt;&gt;</code>. This class provides
  * convenience methods around that structure.
@@ -106,7 +106,7 @@ public class JpegSegmentData
      *
      * @param segmentType identifies the required segment
      * @param occurrence  the zero-based index of the occurrence
-     * @return the segment data as a byte[], or null if no segment exists for the type & occurrence
+     * @return the segment data as a byte[], or null if no segment exists for the type &amp; occurrence
      */
     @Nullable
     public byte[] getSegment(@NotNull JpegSegmentType segmentType, int occurrence)
@@ -120,7 +120,7 @@ public class JpegSegmentData
      *
      * @param segmentType identifies the required segment
      * @param occurrence  the zero-based index of the occurrence
-     * @return the segment data as a byte[], or null if no segment exists for the type & occurrence
+     * @return the segment data as a byte[], or null if no segment exists for the type &amp; occurrence
      */
     @Nullable
     public byte[] getSegment(byte segmentType, int occurrence)

--- a/Source/com/drew/imaging/jpeg/JpegSegmentReader.java
+++ b/Source/com/drew/imaging/jpeg/JpegSegmentReader.java
@@ -33,7 +33,7 @@ import java.util.Set;
 
 /**
  * Performs read functions of JPEG files, returning specific file segments.
- * <p/>
+ * <p>
  * JPEG files are composed of a sequence of consecutive JPEG 'segments'. Each is identified by one of a set of byte
  * values, modelled in the {@link JpegSegmentType} enumeration. Use <code>readSegments</code> to read out the some
  * or all segments into a {@link JpegSegmentData} object, from which the raw JPEG segment byte arrays may be accessed.
@@ -54,7 +54,7 @@ public class JpegSegmentReader
 
     /**
      * Processes the provided JPEG data, and extracts the specified JPEG segments into a {@link JpegSegmentData} object.
-     * <p/>
+     * <p>
      * Will not return SOS (start of scan) or EOI (end of image) segments.
      *
      * @param file a {@link File} from which the JPEG data will be read.
@@ -77,7 +77,7 @@ public class JpegSegmentReader
 
     /**
      * Processes the provided JPEG data, and extracts the specified JPEG segments into a {@link JpegSegmentData} object.
-     * <p/>
+     * <p>
      * Will not return SOS (start of scan) or EOI (end of image) segments.
      *
      * @param reader a {@link SequentialReader} from which the JPEG data will be read. It must be positioned at the

--- a/Source/com/drew/imaging/png/PngChunkType.java
+++ b/Source/com/drew/imaging/png/PngChunkType.java
@@ -21,7 +21,7 @@ public class PngChunkType
     /**
      * Denotes a critical {@link PngChunk} that contains basic information about the PNG image.
      * This must be the first chunk in the data sequence, and may only occur once.
-     * <p/>
+     * <p>
      * The format is:
      * <ul>
      *     <li><b>pixel width</b> 4 bytes, unsigned and greater than zero</li>
@@ -39,7 +39,7 @@ public class PngChunkType
      * Denotes a critical {@link PngChunk} that contains palette entries.
      * This chunk should only appear for a {@link PngColorType} of <code>IndexedColor</code>,
      * and may only occur once in the PNG data sequence.
-     * <p/>
+     * <p>
      * The chunk contains between one and 256 entries, each of three bytes:
      * <ul>
      *     <li><b>red</b> 1 byte</li>
@@ -71,7 +71,7 @@ public class PngChunkType
     /**
      * Denotes an ancillary {@link PngChunk} that contains textual data, having first a keyword and then a value.
      * If multiple text data keywords are needed, then multiple chunks are included in the PNG data stream.
-     * <p/>
+     * <p>
      * The format is:
      * <ul>
      *     <li><b>keyword</b> 1-79 bytes</li>

--- a/Source/com/drew/imaging/tiff/TiffHandler.java
+++ b/Source/com/drew/imaging/tiff/TiffHandler.java
@@ -34,7 +34,7 @@ public interface TiffHandler
 {
     /**
      * Receives the 2-byte marker found in the TIFF header.
-     * <p/>
+     * <p>
      * Implementations are not obligated to use this information for any purpose, though it may be useful for
      * validation or perhaps differentiating the type of mapping to use for observed tags and IFDs.
      *

--- a/Source/com/drew/imaging/tiff/TiffReader.java
+++ b/Source/com/drew/imaging/tiff/TiffReader.java
@@ -82,7 +82,7 @@ public class TiffReader
 
     /**
      * Processes a TIFF IFD.
-     * <p/>
+     * 
      * IFD Header:
      * <ul>
      *     <li><b>2 bytes</b> number of tags</li>

--- a/Source/com/drew/lang/ByteArrayReader.java
+++ b/Source/com/drew/lang/ByteArrayReader.java
@@ -28,7 +28,7 @@ import java.io.IOException;
 /**
  * Provides methods to read specific values from a byte array, with a consistent, checked exception structure for
  * issues.
- * <p/>
+ * <p>
  * By default, the reader operates with Motorola byte order (big endianness).  This can be changed by calling
  * <code>setMotorolaByteOrder(boolean)</code>.
  * 

--- a/Source/com/drew/lang/GeoLocation.java
+++ b/Source/com/drew/lang/GeoLocation.java
@@ -28,9 +28,9 @@ import java.text.DecimalFormat;
 
 /**
  * Represents a latitude and longitude pair, giving a position on earth in spherical coordinates.
- * <p/>
+ * <p>
  * Values of latitude and longitude are given in degrees.
- * <p/>
+ * <p>
  * This type is immutable.
  */
 public final class GeoLocation

--- a/Source/com/drew/lang/RandomAccessReader.java
+++ b/Source/com/drew/lang/RandomAccessReader.java
@@ -28,10 +28,10 @@ import java.io.UnsupportedEncodingException;
 
 /**
  * Base class for random access data reading operations of common data types.
- * <p/>
+ * <p>
  * By default, the reader operates with Motorola byte order (big endianness).  This can be changed by calling
  * {@link com.drew.lang.RandomAccessReader#setMotorolaByteOrder(boolean)}.
- * <p/>
+ * <p>
  * Concrete implementations include:
  * <ul>
  *     <li>{@link ByteArrayReader}</li>
@@ -46,7 +46,7 @@ public abstract class RandomAccessReader
 
     /**
      * Gets the byte value at the specified byte <code>index</code>.
-     * <p/>
+     * <p>
      * Implementations should not perform any bounds checking in this method. That should be performed
      * in <code>validateIndex</code> and <code>isValidIndex</code>.
      *
@@ -74,7 +74,7 @@ public abstract class RandomAccessReader
     /**
      * Ensures that the buffered bytes extend to cover the specified index. If not, an attempt is made
      * to read to that point.
-     * <p/>
+     * <p>
      * If the stream ends before the point is reached, a {@link BufferBoundsException} is raised.
      *
      * @param index the index from which the required bytes start
@@ -87,10 +87,10 @@ public abstract class RandomAccessReader
 
     /**
      * Returns the length of the data source in bytes.
-     * <p/>
+     * <p>
      * This is a simple operation for implementations (such as {@link RandomAccessFileReader} and
      * {@link ByteArrayReader}) that have the entire data source available.
-     * <p/>
+     * <p>
      * Users of this method must be aware that sequentially accessed implementations such as
      * {@link RandomAccessStreamReader} will have to read and buffer the entire data source in
      * order to determine the length.
@@ -285,7 +285,7 @@ public abstract class RandomAccessReader
 
     /**
      * Gets a s15.16 fixed point float from the buffer.
-     * <p/>
+     * <p>
      * This particular fixed point encoding has one sign bit, 15 numerator bits and 16 denominator bits.
      *
      * @return the floating point value

--- a/Source/com/drew/lang/Rational.java
+++ b/Source/com/drew/lang/Rational.java
@@ -257,21 +257,21 @@ public class Rational extends java.lang.Number implements Serializable
      * the minimum number of checks required.</p>
      * <p>
      * However, generating the prime number series seems to be a hefty task.  Perhaps
-     * it's simpler to check if both d & n are divisible by all numbers from 2 ->
+     * it's simpler to check if both d &amp; n are divisible by all numbers from 2 {@literal ->}
      * (Math.min(denominator, numerator) / 2).  In doing this, one can check for 2
      * and 5 once, then ignore all even numbers, and all numbers ending in 0 or 5.
      * This leaves four numbers from every ten to check.</p>
      * <p>
      * Therefore, the max number of pairs of modulus divisions required will be:</p>
-     * <code><pre>
+     * <pre><code>
      *    4   Math.min(denominator, numerator) - 1
      *   -- * ------------------------------------ + 2
      *   10                    2
-     * <p/>
+     * 
      *   Math.min(denominator, numerator) - 1
      * = ------------------------------------ + 2
      *                  5
-     * </pre></code>
+     * </code></pre>
      *
      * @return a simplified instance, or if the Rational could not be simplified,
      *         returns itself (unchanged)

--- a/Source/com/drew/lang/SequentialReader.java
+++ b/Source/com/drew/lang/SequentialReader.java
@@ -232,7 +232,7 @@ public abstract class SequentialReader
 
     /**
      * Gets a s15.16 fixed point float from the buffer.
-     * <p/>
+     * <p>
      * This particular fixed point encoding has one sign bit, 15 numerator bits and 16 denominator bits.
      *
      * @return the floating point value

--- a/Source/com/drew/metadata/Age.java
+++ b/Source/com/drew/metadata/Age.java
@@ -26,7 +26,7 @@ import com.drew.lang.annotations.Nullable;
 
 /**
  * Represents an age in years, months, days, hours, minutes and seconds.
- * <p/>
+ * <p>
  * Used by certain Panasonic cameras which have face recognition features.
  *
  * @author Drew Noakes https://drewnoakes.com

--- a/Source/com/drew/metadata/Directory.java
+++ b/Source/com/drew/metadata/Directory.java
@@ -714,7 +714,7 @@ public abstract class Directory
 
     /**
      * Returns the specified tag's value as a java.util.Date.  If the value is unset or cannot be converted, <code>null</code> is returned.
-     * <p/>
+     * <p>
      * If the underlying value is a {@link String}, then attempts will be made to parse the string as though it is in
      * the current {@link TimeZone}.  If the {@link TimeZone} is known, call the overload that accepts one as an argument.
      */
@@ -726,7 +726,7 @@ public abstract class Directory
     
     /**
      * Returns the specified tag's value as a java.util.Date.  If the value is unset or cannot be converted, <code>null</code> is returned.
-     * <p/>
+     * <p>
      * If the underlying value is a {@link String}, then attempts will be made to parse the string as though it is in
      * the {@link TimeZone} represented by the {@code timeZone} parameter (if it is non-null).  Note that this parameter
      * is only considered if the underlying value is a string and parsing occurs, otherwise it has no effect.

--- a/Source/com/drew/metadata/Face.java
+++ b/Source/com/drew/metadata/Face.java
@@ -25,7 +25,7 @@ import com.drew.lang.annotations.Nullable;
 
 /**
  * Class to hold information about a detected or recognized face in a photo.
- * <p/>
+ * <p>
  * When a face is <em>detected</em>, the camera believes that a face is present at a given location in
  * the image, but is not sure whose face it is.  When a face is <em>recognised</em>, then the face is
  * both detected and identified as belonging to a known person.

--- a/Source/com/drew/metadata/Metadata.java
+++ b/Source/com/drew/metadata/Metadata.java
@@ -27,7 +27,7 @@ import java.util.*;
 
 /**
  * A top-level object that holds the metadata values extracted from an image.
- * <p/>
+ * <p>
  * Metadata objects may contain zero or more {@link Directory} objects.  Each directory may contain zero or more tags
  * with corresponding values.
  *

--- a/Source/com/drew/metadata/MetadataReader.java
+++ b/Source/com/drew/metadata/MetadataReader.java
@@ -25,7 +25,7 @@ import com.drew.lang.annotations.NotNull;
 
 /**
  * Defines an object capable of processing a particular type of metadata from a {@link RandomAccessReader}.
- * <p/>
+ * <p>
  * Instances of this interface must be thread-safe and reusable.
  *
  * @author Drew Noakes https://drewnoakes.com

--- a/Source/com/drew/metadata/TagDescriptor.java
+++ b/Source/com/drew/metadata/TagDescriptor.java
@@ -82,7 +82,7 @@ public class TagDescriptor<T extends Directory>
     /**
      * Takes a series of 4 bytes from the specified offset, and converts these to a
      * well-known version number, where possible.
-     * <p/>
+     * <p>
      * Two different formats are processed:
      * <ul>
      * <li>[30 32 31 30] -&gt; 2.10</li>

--- a/Source/com/drew/metadata/adobe/AdobeJpegDirectory.java
+++ b/Source/com/drew/metadata/adobe/AdobeJpegDirectory.java
@@ -35,7 +35,7 @@ public class AdobeJpegDirectory extends Directory {
     /**
      * The convention for TAG_APP14_FLAGS0 and TAG_APP14_FLAGS1 is that 0 bits are benign.
      * 1 bits in TAG_APP14_FLAGS0 pass information that is possibly useful but not essential for decoding.
-     * <p/>
+     * <p>
      * 0x8000 bit: Encoder used Blend=1 downsampling
      */
     public static final int TAG_APP14_FLAGS0 = 1;

--- a/Source/com/drew/metadata/exif/ExifSubIFDDirectory.java
+++ b/Source/com/drew/metadata/exif/ExifSubIFDDirectory.java
@@ -132,9 +132,9 @@ public class ExifSubIFDDirectory extends Directory
     public static final int TAG_SPECTRAL_SENSITIVITY = 0x8824;
     /**
      * Indicates the Opto-Electric Conversion Function (OECF) specified in ISO 14524.
-     * <p/>
+     * <p>
      * OECF is the relationship between the camera optical input and the image values.
-     * <p/>
+     * <p>
      * The values are:
      * <ul>
      *   <li>Two shorts, indicating respectively number of columns, and number of rows.</li>
@@ -264,7 +264,7 @@ public class ExifSubIFDDirectory extends Directory
      * This tag holds the Exif Makernote. Makernotes are free to be in any format, though they are often IFDs.
      * To determine the format, we consider the starting bytes of the makernote itself and sometimes the
      * camera model and make.
-     * <p/>
+     * <p>
      * The component count for this tag includes all of the bytes needed for the makernote.
      */
     public static final int TAG_MAKERNOTE = 0x927C;

--- a/Source/com/drew/metadata/exif/ExifThumbnailDirectory.java
+++ b/Source/com/drew/metadata/exif/ExifThumbnailDirectory.java
@@ -56,7 +56,7 @@ public class ExifThumbnailDirectory extends Directory
      * 6 = JPEG (old-style)
      * 7 = JPEG
      * 8 = Adobe Deflate
-     * 9 = JBIG B&W
+     * 9 = JBIG B&amp;W
      * 10 = JBIG Color
      * 32766 = Next
      * 32771 = CCIRLEW

--- a/Source/com/drew/metadata/exif/ExifTiffHandler.java
+++ b/Source/com/drew/metadata/exif/ExifTiffHandler.java
@@ -35,7 +35,7 @@ import java.util.Set;
 /**
  * Implementation of {@link com.drew.imaging.tiff.TiffHandler} used for handling TIFF tags according to the Exif
  * standard.
- * <p/>
+ * <p>
  * Includes support for camera manufacturer makernotes.
  *
  * @author Drew Noakes https://drewnoakes.com

--- a/Source/com/drew/metadata/exif/makernotes/CanonMakernoteDirectory.java
+++ b/Source/com/drew/metadata/exif/makernotes/CanonMakernoteDirectory.java
@@ -172,7 +172,7 @@ public class CanonMakernoteDirectory extends Directory
          * 3 = Fast Shutter
          * 4 = Slow Shutter
          * 5 = Night
-         * 6 = Black & White
+         * 6 = Black &amp; White
          * 7 = Sepia
          * 8 = Portrait
          * 9 = Sports

--- a/Source/com/drew/metadata/exif/makernotes/FujifilmMakernoteDescriptor.java
+++ b/Source/com/drew/metadata/exif/makernotes/FujifilmMakernoteDescriptor.java
@@ -29,7 +29,7 @@ import static com.drew.metadata.exif.makernotes.FujifilmMakernoteDirectory.*;
 
 /**
  * Provides human-readable string representations of tag values stored in a {@link FujifilmMakernoteDirectory}.
- * <p/>
+ * <p>
  * Fujifilm added their Makernote tag from the Year 2000's models (e.g.Finepix1400,
  * Finepix4700). It uses IFD format and start from ASCII character 'FUJIFILM', and next 4
  * bytes (value 0x000c) points the offset to first IFD entry.

--- a/Source/com/drew/metadata/exif/makernotes/KyoceraMakernoteDescriptor.java
+++ b/Source/com/drew/metadata/exif/makernotes/KyoceraMakernoteDescriptor.java
@@ -28,10 +28,10 @@ import static com.drew.metadata.exif.makernotes.KyoceraMakernoteDirectory.*;
 
 /**
  * Provides human-readable string representations of tag values stored in a {@link KyoceraMakernoteDirectory}.
- * <p/>
+ * <p>
  * Some information about this makernote taken from here:
  * http://www.ozhiker.com/electronics/pjmt/jpeg_info/kyocera_mn.html
- * <p/>
+ * <p>
  * Most manufacturer's Makernote counts the "offset to data" from the first byte
  * of TIFF header (same as the other IFD), but Kyocera (along with Fujifilm) counts
  * it from the first byte of Makernote itself.

--- a/Source/com/drew/metadata/exif/makernotes/LeicaMakernoteDescriptor.java
+++ b/Source/com/drew/metadata/exif/makernotes/LeicaMakernoteDescriptor.java
@@ -28,7 +28,7 @@ import static com.drew.metadata.exif.makernotes.LeicaMakernoteDirectory.*;
 
 /**
  * Provides human-readable string representations of tag values stored in a {@link LeicaMakernoteDirectory}.
- * <p/>
+ * <p>
  * Tag reference from: http://gvsoft.homedns.org/exif/makernote-leica-type1.html
  *
  * @author Drew Noakes https://drewnoakes.com

--- a/Source/com/drew/metadata/exif/makernotes/LeicaMakernoteDirectory.java
+++ b/Source/com/drew/metadata/exif/makernotes/LeicaMakernoteDirectory.java
@@ -27,7 +27,7 @@ import java.util.HashMap;
 
 /**
  * Describes tags specific to certain Leica cameras.
- * <p/>
+ * <p>
  * Tag reference from: http://gvsoft.homedns.org/exif/makernote-leica-type1.html
  *
  * @author Drew Noakes https://drewnoakes.com

--- a/Source/com/drew/metadata/exif/makernotes/NikonType1MakernoteDescriptor.java
+++ b/Source/com/drew/metadata/exif/makernotes/NikonType1MakernoteDescriptor.java
@@ -29,10 +29,10 @@ import static com.drew.metadata.exif.makernotes.NikonType1MakernoteDirectory.*;
 
 /**
  * Provides human-readable string representations of tag values stored in a {@link NikonType1MakernoteDirectory}.
- * <p/>
+ * <p>
  * Type-1 is for E-Series cameras prior to (not including) E990.  For example: E700, E800, E900,
  * E900S, E910, E950.
- * <p/>
+ * <p>
  * Makernote starts from ASCII string "Nikon". Data format is the same as IFD, but it starts from
  * offset 0x08. This is the same as Olympus except start string. Example of actual data
  * structure is shown below.

--- a/Source/com/drew/metadata/exif/makernotes/NikonType2MakernoteDirectory.java
+++ b/Source/com/drew/metadata/exif/makernotes/NikonType2MakernoteDirectory.java
@@ -28,16 +28,16 @@ import java.util.HashMap;
 /**
  * Describes tags specific to Nikon (type 2) cameras.  Type-2 applies to the E990 and D-series cameras such as the E990, D1,
  * D70 and D100.
- * <p/>
+ * <p>
  * Thanks to Fabrizio Giudici for publishing his reverse-engineering of the D100 makernote data.
  * http://www.timelesswanderings.net/equipment/D100/NEF.html
- * <p/>
+ * <p>
  * Note that the camera implements image protection (locking images) via the file's 'readonly' attribute.  Similarly
  * image hiding uses the 'hidden' attribute (observed on the D70).  Consequently, these values are not available here.
- * <p/>
+ * <p>
  * Additional sample images have been observed, and their tag values recorded in javadoc comments for each tag's field.
  * New tags have subsequently been added since Fabrizio's observations.
- * <p/>
+ * <p>
  * In earlier models (such as the E990 and D1), this directory begins at the first byte of the makernote IFD.  In
  * later models, the IFD was given the standard prefix to indicate the camera models (most other manufacturers also
  * provide this prefix to aid in software decoding).
@@ -63,7 +63,7 @@ public class NikonType2MakernoteDirectory extends Directory
     /**
      * The camera's color mode, as an uppercase string.  Examples include:
      * <ul>
-     * <li><code>B & W</code></li>
+     * <li><code>B &amp; W</code></li>
      * <li><code>COLOR</code></li>
      * <li><code>COOL</code></li>
      * <li><code>SEPIA</code></li>
@@ -226,20 +226,20 @@ public class NikonType2MakernoteDirectory extends Directory
      * The camera's ISO mode, as an uppercase string.
      *
      * <ul>
-     * <li><code>AUTO</code></code></li>
+     * <li><code>AUTO</code></li>
      * <li><code>MANUAL</code></li>
      * </ul>
      */
     public static final int TAG_ISO_MODE = 0x000F;
 
     /**
-     * Added during merge of Type2 & Type3.  May apply to earlier models, such as E990 and D1.
+     * Added during merge of Type2 &amp; Type3.  May apply to earlier models, such as E990 and D1.
      */
     public static final int TAG_DATA_DUMP = 0x0010;
 
     /**
      * Preview to another IFD (?)
-     * <p/>
+     * <p>
      * Details here: http://gvsoft.homedns.org/exif/makernote-nikon-2-tag0x0011.html
      * // TODO if this is another IFD, decode it
      */
@@ -400,7 +400,7 @@ public class NikonType2MakernoteDirectory extends Directory
      * <li><code>CONTRAST(+)</code></li>
      * <li><code>CONTRAST(-)</code></li>
      * <li><code>NORMAL</code></li>
-     * <li><code>B & W</code></li>
+     * <li><code>B &amp; W</code></li>
      * <li><code>BRIGHTNESS(+)</code></li>
      * <li><code>BRIGHTNESS(-)</code></li>
      * <li><code>SEPIA</code></li>
@@ -467,7 +467,7 @@ public class NikonType2MakernoteDirectory extends Directory
     public static final int TAG_LENS = 0x0084;
 
     /**
-     * Added during merge of Type2 & Type3.  May apply to earlier models, such as E990 and D1.
+     * Added during merge of Type2 &amp; Type3.  May apply to earlier models, such as E990 and D1.
      */
     public static final int TAG_MANUAL_FOCUS_DISTANCE = 0x0085;
 
@@ -497,7 +497,7 @@ public class NikonType2MakernoteDirectory extends Directory
 
     /**
      * The camera's shooting mode.
-     * <p/>
+     * <p>
      * A bit-array with:
      * <ul>
      * <li><code>0</code> Single Frame</li>
@@ -536,7 +536,7 @@ public class NikonType2MakernoteDirectory extends Directory
      * <li><code>MODE2</code> = Mode 2 (Adobe RGB)</li>
      * <li><code>MODE3</code> = Mode 2 (sRGB): Higher Saturation</li>
      * <li><code>MODE3a</code> = Mode 2 (sRGB): Higher Saturation</li>
-     * <li><code>B & W</code> = B & W</li>
+     * <li><code>B &amp; W</code> = B &amp; W</li>
      * </ul>
      */
     public static final int TAG_CAMERA_COLOR_MODE = 0x008D;
@@ -615,7 +615,7 @@ public class NikonType2MakernoteDirectory extends Directory
      * <li><code>0</code> Normal</li>
      * <li><code>-1</code></li>
      * <li><code>-2</code></li>
-     * <li><code>-3</code> (B&W)</li>
+     * <li><code>-3</code> (B&amp;W)</li>
      * </ul>
      */
     public static final int TAG_SATURATION = 0x0094;

--- a/Source/com/drew/metadata/exif/makernotes/OlympusMakernoteDirectory.java
+++ b/Source/com/drew/metadata/exif/makernotes/OlympusMakernoteDirectory.java
@@ -53,7 +53,7 @@ public class OlympusMakernoteDirectory extends Directory
     /**
      * Used by Konica / Minolta cameras
      * 0 = Natural Colour
-     * 1 = Black & White
+     * 1 = Black &amp; White
      * 2 = Vivid colour
      * 3 = Solarization
      * 4 = AdobeRGB
@@ -72,7 +72,7 @@ public class OlympusMakernoteDirectory extends Directory
 
     /**
      * Not 100% sure about this tag.
-     * <p/>
+     * <p>
      * Used by Konica / Minolta cameras.
      * 0 = Raw
      * 1 = Super Fine

--- a/Source/com/drew/metadata/exif/makernotes/PanasonicMakernoteDescriptor.java
+++ b/Source/com/drew/metadata/exif/makernotes/PanasonicMakernoteDescriptor.java
@@ -34,7 +34,7 @@ import static com.drew.metadata.exif.makernotes.PanasonicMakernoteDirectory.*;
 
 /**
  * Provides human-readable string representations of tag values stored in a {@link PanasonicMakernoteDirectory}.
- * <p/>
+ * <p>
  * Some information about this makernote taken from here:
  * <ul>
  * <li><a href="http://www.ozhiker.com/electronics/pjmt/jpeg_info/panasonic_mn.html">http://www.ozhiker.com/electronics/pjmt/jpeg_info/panasonic_mn.html</a></li>

--- a/Source/com/drew/metadata/exif/makernotes/PanasonicMakernoteDirectory.java
+++ b/Source/com/drew/metadata/exif/makernotes/PanasonicMakernoteDirectory.java
@@ -58,7 +58,7 @@ public class PanasonicMakernoteDirectory extends Directory
      * 4 = Incandescent    <br>
      * 5 = Manual          <br>
      * 8 = Flash           <br>
-     * 10 = Black & White  <br>
+     * 10 = Black &amp; White  <br>
      * 11 = Manual         <br>
      * 12 = Shade          <br>
      */
@@ -192,7 +192,7 @@ public class PanasonicMakernoteDirectory extends Directory
      * 1 = Off           <br>
      * 2 = Warm          <br>
      * 3 = Cool          <br>
-     * 4 = Black & White <br>
+     * 4 = Black &amp; White <br>
      * 5 = Sepia         <br>
      */
     public static final int TAG_COLOR_EFFECT = 0x0028;
@@ -233,8 +233,8 @@ public class PanasonicMakernoteDirectory extends Directory
      * 4 = +2                                                  <br>
      * 7 = Nature (Color Film)                                 <br>
      * 12 = Smooth (Color Film) or Pure (My Color)             <br>
-     * 17 = Dynamic (B&W Film)                                 <br>
-     * 22 = Smooth (B&W Film)                                  <br>
+     * 17 = Dynamic (B&amp;W Film)                                 <br>
+     * 22 = Smooth (B&amp;W Film)                                  <br>
      * 27 = Dynamic (Color Film)                               <br>
      * 32 = Vibrant (Color Film) or Expressive (My Color)      <br>
      * 33 = Elegant (My Color)                                 <br>
@@ -327,7 +327,7 @@ public class PanasonicMakernoteDirectory extends Directory
      * <br>
      * 1 = Normal                               <br>
      * 2 = Outdoor/Illuminations/Flower/HDR Art <br>
-     * 3 = Indoor/Architecture/Objects/HDR B&W  <br>
+     * 3 = Indoor/Architecture/Objects/HDR B&amp;W  <br>
      * 4 = Creative                             <br>
      * 5 = Auto                                 <br>
      * 7 = Expressive                           <br>

--- a/Source/com/drew/metadata/exif/makernotes/PentaxMakernoteDescriptor.java
+++ b/Source/com/drew/metadata/exif/makernotes/PentaxMakernoteDescriptor.java
@@ -28,7 +28,7 @@ import static com.drew.metadata.exif.makernotes.PentaxMakernoteDirectory.*;
 
 /**
  * Provides human-readable string representations of tag values stored in a {@link PentaxMakernoteDirectory}.
- * <p/>
+ * <p>
  * Some information about this makernote taken from here:
  * http://www.ozhiker.com/electronics/pjmt/jpeg_info/pentax_mn.html
  *

--- a/Source/com/drew/metadata/exif/makernotes/PentaxMakernoteDirectory.java
+++ b/Source/com/drew/metadata/exif/makernotes/PentaxMakernoteDirectory.java
@@ -107,7 +107,7 @@ public class PentaxMakernoteDirectory extends Directory
 
     /**
      * 1 = Normal
-     * 2 = Black & White
+     * 2 = Black &amp; White
      * 3 = Sepia
      */
     public static final int TAG_COLOUR = 0x0017;

--- a/Source/com/drew/metadata/exif/makernotes/RicohMakernoteDescriptor.java
+++ b/Source/com/drew/metadata/exif/makernotes/RicohMakernoteDescriptor.java
@@ -26,7 +26,7 @@ import com.drew.metadata.TagDescriptor;
 
 /**
  * Provides human-readable string representations of tag values stored in a {@link RicohMakernoteDescriptor}.
- * <p/>
+ * <p>
  * Some information about this makernote taken from here:
  * http://www.ozhiker.com/electronics/pjmt/jpeg_info/ricoh_mn.html
  *

--- a/Source/com/drew/metadata/iptc/IptcDescriptor.java
+++ b/Source/com/drew/metadata/iptc/IptcDescriptor.java
@@ -27,7 +27,7 @@ import com.drew.metadata.TagDescriptor;
 
 /**
  * Provides human-readable string representations of tag values stored in a {@link IptcDirectory}.
- * <p/>
+ * <p>
  * As the IPTC directory already stores values as strings, this class simply returns the tag's value.
  *
  * @author Drew Noakes https://drewnoakes.com

--- a/Source/com/drew/metadata/iptc/IptcReader.java
+++ b/Source/com/drew/metadata/iptc/IptcReader.java
@@ -34,7 +34,7 @@ import java.util.Date;
 
 /**
  * Decodes IPTC binary data, populating a {@link Metadata} object with tag values in an {@link IptcDirectory}.
- * <p/>
+ * <p>
  * http://www.iptc.org/std/IIM/4.1/specification/IIMV4.1.pdf
  *
  * @author Drew Noakes https://drewnoakes.com

--- a/Source/com/drew/metadata/jfif/JfifDescriptor.java
+++ b/Source/com/drew/metadata/jfif/JfifDescriptor.java
@@ -26,7 +26,7 @@ import com.drew.metadata.TagDescriptor;
 
 /**
  * Provides human-readable string versions of the tags stored in a JfifDirectory.
- * <p/>
+ * <p>
  * More info at: http://en.wikipedia.org/wiki/JPEG_File_Interchange_Format
  *
  * @author Yuri Binev, Drew Noakes

--- a/Source/com/drew/metadata/jfif/JfifReader.java
+++ b/Source/com/drew/metadata/jfif/JfifReader.java
@@ -33,7 +33,7 @@ import java.util.Arrays;
 
 /**
  * Reader for JFIF data, found in the APP0 JPEG segment.
- * <p/>
+ * <p>
  * More info at: http://en.wikipedia.org/wiki/JPEG_File_Interchange_Format
  *
  * @author Yuri Binev, Drew Noakes, Markus Meyer

--- a/Source/com/drew/metadata/jpeg/JpegDirectory.java
+++ b/Source/com/drew/metadata/jpeg/JpegDirectory.java
@@ -47,7 +47,7 @@ public class JpegDirectory extends Directory
      * component Id(1byte)(1 = Y, 2 = Cb, 3 = Cr, 4 = I, 5 = Q),
      * sampling factors (1byte) (bit 0-3 vertical., 4-7 horizontal.),
      * quantization table number (1 byte).
-     * <p/>
+     * <p>
      * This info is from http://www.funducode.com/freec/Fileformats/format3/format3b.htm
      */
     public static final int TAG_NUMBER_OF_COMPONENTS = 5;

--- a/Source/com/drew/metadata/xmp/XmpDirectory.java
+++ b/Source/com/drew/metadata/xmp/XmpDirectory.java
@@ -162,7 +162,7 @@ public class XmpDirectory extends Directory
 
     /**
      * Gets a map of all XMP properties in this directory, not just the known ones.
-     * <p/>
+     * <p>
      * This is required because XMP properties are represented as strings, whereas the rest of this library
      * uses integers for keys.
      */

--- a/Source/com/drew/metadata/xmp/XmpReader.java
+++ b/Source/com/drew/metadata/xmp/XmpReader.java
@@ -36,7 +36,7 @@ import java.util.Calendar;
 
 /**
  * Extracts XMP data from a JPEG header segment.
- * <p/>
+ * <p>
  * The extraction is done with Adobe's XmpCore-Library (XMP-Toolkit)
  * Copyright (c) 1999 - 2007, Adobe Systems Incorporated All rights reserved.
  *
@@ -110,7 +110,7 @@ public class XmpReader implements JpegSegmentMetadataReader
 
     /**
      * Performs the XMP data extraction, adding found values to the specified instance of {@link Metadata}.
-     * <p/>
+     * <p>
      * The extraction is done with Adobe's XMPCore library.
      */
     public void extract(@NotNull final byte[] xmpBytes, @NotNull Metadata metadata)
@@ -127,7 +127,7 @@ public class XmpReader implements JpegSegmentMetadataReader
 
     /**
      * Performs the XMP data extraction, adding found values to the specified instance of {@link Metadata}.
-     * <p/>
+     * <p>
      * The extraction is done with Adobe's XMPCore library.
      */
     public void extract(@NotNull final String xmpString, @NotNull Metadata metadata)


### PR DESCRIPTION
#47 
This patch allows running a maven build with JDK 8.

Note: I used {@literal} for -> I think we should use {@literal} instead of HTML escape sequences because {@literal} is more easier to read imo. Only for & i would prefer using the escape sequence because ``&amp;`` is easily readable.