### PR TITLE
Fix Tag.hasTagName() to return a boolean

### DIFF
--- a/Source/com/drew/metadata/Tag.java
+++ b/Source/com/drew/metadata/Tag.java
@@ -86,9 +86,9 @@ public class Tag
      * @return whether this tag has a name
      */
     @NotNull
-    public String hasTagName()
+    public boolean hasTagName()
     {
-        return _directory.getTagName(_tagType);
+        return _directory.hasTagName(_tagType);
     }
 
     /**


### PR DESCRIPTION
I believe `Tag.hasTagName()` was always meant to return a boolean, but currently returns a String (essentially identical to `getTagName()`).

Apologies for not noticing prior to 2.7.1 release, but it's not a big deal and the functionality can still be accessed via the `Directory`.