### PR TITLE
Make formatting of F-Number locale-indenpendent

### DIFF
--- a/Source/com/drew/metadata/TagDescriptor.java
+++ b/Source/com/drew/metadata/TagDescriptor.java
@@ -29,10 +29,12 @@ import java.io.UnsupportedEncodingException;
 import java.lang.reflect.Array;
 import java.math.RoundingMode;
 import java.text.DecimalFormat;
+import java.text.DecimalFormatSymbols;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
+import java.util.Locale;
 
 /**
  * Base class for all tag descriptor classes.  Implementations are responsible for
@@ -285,7 +287,8 @@ public class TagDescriptor<T extends Directory>
     @Nullable
     protected static String getFStopDescription(double fStop)
     {
-        DecimalFormat format = new DecimalFormat("0.0");
+        DecimalFormatSymbols symbols = DecimalFormatSymbols.getInstance(Locale.ROOT);
+        DecimalFormat format = new DecimalFormat("0.0", symbols);
         format.setRoundingMode(RoundingMode.HALF_UP);
         return "f/" + format.format(fStop);
     }
@@ -293,7 +296,8 @@ public class TagDescriptor<T extends Directory>
     @Nullable
     protected static String getFocalLengthDescription(double mm)
     {
-        DecimalFormat format = new DecimalFormat("0.#");
+        DecimalFormatSymbols symbols = DecimalFormatSymbols.getInstance(Locale.ROOT);
+        DecimalFormat format = new DecimalFormat("0.#", symbols);
         format.setRoundingMode(RoundingMode.HALF_UP);
         return format.format(mm) + " mm";
     }

--- a/Tests/com/drew/imaging/jpeg/JpegMetadataReaderTest.java
+++ b/Tests/com/drew/imaging/jpeg/JpegMetadataReaderTest.java
@@ -65,7 +65,7 @@ public class JpegMetadataReaderTest
         Locale previousLocale = Locale.getDefault();
 
         // Setting this locale would cause an f-number with a comma:
-        Locale.setDefault(Locale.forLanguageTag("nl-NL"));
+        Locale.setDefault(new Locale("nl", "NL"));
 
         try {
             Metadata metadata = JpegMetadataReader.readMetadata(new File("Tests/Data/withExif.jpg"));

--- a/Tests/com/drew/imaging/jpeg/JpegMetadataReaderTest.java
+++ b/Tests/com/drew/imaging/jpeg/JpegMetadataReaderTest.java
@@ -22,12 +22,14 @@ package com.drew.imaging.jpeg;
 
 import com.drew.metadata.Directory;
 import com.drew.metadata.Metadata;
+import com.drew.metadata.exif.ExifDirectoryBase;
 import com.drew.metadata.exif.ExifSubIFDDirectory;
 import com.drew.metadata.xmp.XmpDirectory;
 import org.junit.Test;
 
 import java.io.File;
 import java.io.FileInputStream;
+import java.util.Locale;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -55,6 +57,24 @@ public class JpegMetadataReaderTest
         Metadata metadata = JpegMetadataReader.readMetadata(new File("Tests/Data/withXmp.jpg"));
         Directory directory = metadata.getFirstDirectoryOfType(XmpDirectory.class);
         assertNotNull(directory);
+    }
+
+    @Test
+    public void testFStopFormatting() throws Exception
+    {
+        Locale previousLocale = Locale.getDefault();
+
+        // Settings this locale would cause an f-number with a comma:
+        Locale.setDefault(Locale.forLanguageTag("nl-NL"));
+
+        try {
+            Metadata metadata = JpegMetadataReader.readMetadata(new File("Tests/Data/withExif.jpg"));
+            final ExifSubIFDDirectory subIFDDirectory = metadata.getFirstDirectoryOfType(ExifSubIFDDirectory.class);
+            assertEquals("f/4.0", subIFDDirectory.getDescription(ExifDirectoryBase.TAG_FNUMBER));
+        } finally {
+            // Reset the locale:
+            Locale.setDefault(previousLocale);
+        }
     }
 
     private void validate(Metadata metadata)

--- a/Tests/com/drew/imaging/jpeg/JpegMetadataReaderTest.java
+++ b/Tests/com/drew/imaging/jpeg/JpegMetadataReaderTest.java
@@ -64,7 +64,7 @@ public class JpegMetadataReaderTest
     {
         Locale previousLocale = Locale.getDefault();
 
-        // Settings this locale would cause an f-number with a comma:
+        // Setting this locale would cause an f-number with a comma:
         Locale.setDefault(Locale.forLanguageTag("nl-NL"));
 
         try {


### PR DESCRIPTION
Formatting the F-Number is not locale independent. For example, if one would set a Dutch locale (`nl-NL`), the F-numbers would be formatted as `f/2,8` (not the comma), and not as `f/2.8` (a period).

This tiny change fixes the issue. Also see the added test.