### PR TITLE
Change GifHeaderDirectory.TAG_TRANSPARENT_COLOR_INDEX to TAG_BACKGROUND_COLOR_INDEX

### DIFF
--- a/Source/com/drew/metadata/gif/GifHeaderDirectory.java
+++ b/Source/com/drew/metadata/gif/GifHeaderDirectory.java
@@ -37,7 +37,7 @@ public class GifHeaderDirectory extends Directory
     public static final int TAG_IS_COLOR_TABLE_SORTED = 5;
     public static final int TAG_BITS_PER_PIXEL = 6;
     public static final int TAG_HAS_GLOBAL_COLOR_TABLE = 7;
-    public static final int TAG_TRANSPARENT_COLOR_INDEX = 8;
+    public static final int TAG_BACKGROUND_COLOR_INDEX = 8;
     public static final int TAG_PIXEL_ASPECT_RATIO = 9;
 
     @NotNull
@@ -51,7 +51,7 @@ public class GifHeaderDirectory extends Directory
         _tagNameMap.put(TAG_IS_COLOR_TABLE_SORTED, "Is Color Table Sorted");
         _tagNameMap.put(TAG_BITS_PER_PIXEL, "Bits per Pixel");
         _tagNameMap.put(TAG_HAS_GLOBAL_COLOR_TABLE, "Has Global Color Table");
-        _tagNameMap.put(TAG_TRANSPARENT_COLOR_INDEX, "Transparent Color Index");
+        _tagNameMap.put(TAG_BACKGROUND_COLOR_INDEX, "Background Color Index");
         _tagNameMap.put(TAG_PIXEL_ASPECT_RATIO, "Pixel Aspect Ratio");
     }
 

--- a/Source/com/drew/metadata/gif/GifHeaderDirectory.java
+++ b/Source/com/drew/metadata/gif/GifHeaderDirectory.java
@@ -37,6 +37,11 @@ public class GifHeaderDirectory extends Directory
     public static final int TAG_IS_COLOR_TABLE_SORTED = 5;
     public static final int TAG_BITS_PER_PIXEL = 6;
     public static final int TAG_HAS_GLOBAL_COLOR_TABLE = 7;
+    /**
+     * @deprecated use {@link #TAG_BACKGROUND_COLOR_INDEX} instead.
+     */
+    @Deprecated
+    public static final int TAG_TRANSPARENT_COLOR_INDEX = 8;
     public static final int TAG_BACKGROUND_COLOR_INDEX = 8;
     public static final int TAG_PIXEL_ASPECT_RATIO = 9;
 

--- a/Source/com/drew/metadata/gif/GifReader.java
+++ b/Source/com/drew/metadata/gif/GifReader.java
@@ -95,7 +95,7 @@ public class GifReader
             boolean hasGlobalColorTable = (flags & 0xf) != 0;
             directory.setBoolean(GifHeaderDirectory.TAG_HAS_GLOBAL_COLOR_TABLE, hasGlobalColorTable);
 
-            directory.setInt(GifHeaderDirectory.TAG_TRANSPARENT_COLOR_INDEX, reader.getUInt8());
+            directory.setInt(GifHeaderDirectory.TAG_BACKGROUND_COLOR_INDEX, reader.getUInt8());
 
             int aspectRatioByte = reader.getUInt8();
             if (aspectRatioByte != 0) {

--- a/Tests/com/drew/metadata/gif/GifReaderTest.java
+++ b/Tests/com/drew/metadata/gif/GifReaderTest.java
@@ -63,7 +63,7 @@ public class GifReaderTest
         assertFalse(directory.getBoolean(GifHeaderDirectory.TAG_IS_COLOR_TABLE_SORTED));
         assertEquals(8, directory.getInt(GifHeaderDirectory.TAG_BITS_PER_PIXEL));
         assertTrue(directory.getBoolean(GifHeaderDirectory.TAG_HAS_GLOBAL_COLOR_TABLE));
-        assertEquals(0, directory.getInt(GifHeaderDirectory.TAG_TRANSPARENT_COLOR_INDEX));
+        assertEquals(0, directory.getInt(GifHeaderDirectory.TAG_BACKGROUND_COLOR_INDEX));
     }
 
     @Test
@@ -80,6 +80,6 @@ public class GifReaderTest
         assertFalse(directory.getBoolean(GifHeaderDirectory.TAG_IS_COLOR_TABLE_SORTED));
         assertEquals(5, directory.getInt(GifHeaderDirectory.TAG_BITS_PER_PIXEL));
         assertTrue(directory.getBoolean(GifHeaderDirectory.TAG_HAS_GLOBAL_COLOR_TABLE));
-        assertEquals(8, directory.getInt(GifHeaderDirectory.TAG_TRANSPARENT_COLOR_INDEX));
+        assertEquals(8, directory.getInt(GifHeaderDirectory.TAG_BACKGROUND_COLOR_INDEX));
     }
 }


### PR DESCRIPTION
GifHeaderDirectory class has TAG_TRANSPARENT_COLOR_INDEX tag, but its value is read from the Background Color Index field in the GIF header. The tag name should be TAG_BACKGROUND_COLOR_INDEX. This closes #141.