### PR TITLE
Rename JfifDirectory.getImageWidth() and JfifDirectory.getImageHeight()

### DIFF
--- a/Source/com/drew/metadata/jfif/JfifDirectory.java
+++ b/Source/com/drew/metadata/jfif/JfifDirectory.java
@@ -83,12 +83,30 @@ public class JfifDirectory extends Directory
         return getInt(JfifDirectory.TAG_UNITS);
     }
 
+    /**
+     * @deprecated use {@link #getResY} instead.
+     */
+    @Deprecated
     public int getImageWidth() throws MetadataException
     {
         return getInt(JfifDirectory.TAG_RESY);
     }
 
+    public int getResY() throws MetadataException
+    {
+        return getInt(JfifDirectory.TAG_RESY);
+    }
+
+    /**
+     * @deprecated use {@link #getResX} instead.
+     */
+    @Deprecated
     public int getImageHeight() throws MetadataException
+    {
+        return getInt(JfifDirectory.TAG_RESX);
+    }
+
+    public int getResX() throws MetadataException
     {
         return getInt(JfifDirectory.TAG_RESX);
     }


### PR DESCRIPTION
Add getResY() and getResX(), and mark getImageWidth() and getImageHeight() as deprecated. This closes #143