### PR TITLE
Reset TimeInMillis for Calendar objects before setting the values

### DIFF
--- a/Source/com/drew/imaging/png/PngMetadataReader.java
+++ b/Source/com/drew/imaging/png/PngMetadataReader.java
@@ -218,6 +218,7 @@ public class PngMetadataReader
             int minute = reader.getUInt8();
             int second = reader.getUInt8();
             Calendar calendar = Calendar.getInstance(TimeZone.getTimeZone("UTC"));
+            calendar.setTimeInMillis(0);
             //noinspection MagicConstant
             calendar.set(year, month, day, hour, minute, second);
             PngDirectory directory = new PngDirectory(PngChunkType.tIME);

--- a/Source/com/drew/metadata/icc/IccReader.java
+++ b/Source/com/drew/metadata/icc/IccReader.java
@@ -186,6 +186,7 @@ public class IccReader implements JpegSegmentMetadataReader, MetadataReader
         {
 //          Date value = new Date(Date.UTC(y - 1900, m - 1, d, h, M, s));
             Calendar calendar = Calendar.getInstance(TimeZone.getTimeZone("UTC"));
+            calendar.setTimeInMillis(0);
             calendar.set(y, m - 1, d, h, M, s);
             directory.setDate(tagType, calendar.getTime());
         }

--- a/Tests/com/drew/imaging/png/PngMetadataReaderTest.java
+++ b/Tests/com/drew/imaging/png/PngMetadataReaderTest.java
@@ -98,7 +98,7 @@ public class PngMetadataReaderTest
             SimpleDateFormat formatter = new SimpleDateFormat("EE MMM DD HH:mm:ss z yyyy");
             formatter.setTimeZone(TimeZone.getTimeZone("GMT"));
             assertEquals("Tue Jan 01 04:08:30 GMT 2013", formatter.format(modTime));
-            assertEquals(1357013310000, modTime.getTime());
+            assertEquals(1357013310000L, modTime.getTime());
 
             assertEquals(PngChunkType.iTXt, dirs[5].getPngChunkType());
             @SuppressWarnings("unchecked")

--- a/Tests/com/drew/imaging/png/PngMetadataReaderTest.java
+++ b/Tests/com/drew/imaging/png/PngMetadataReaderTest.java
@@ -98,6 +98,7 @@ public class PngMetadataReaderTest
             SimpleDateFormat formatter = new SimpleDateFormat("EE MMM DD HH:mm:ss z yyyy");
             formatter.setTimeZone(TimeZone.getTimeZone("GMT"));
             assertEquals("Tue Jan 01 04:08:30 GMT 2013", formatter.format(modTime));
+            assertEquals(1357013310000, modTime.getTime());
 
             assertEquals(PngChunkType.iTXt, dirs[5].getPngChunkType());
             @SuppressWarnings("unchecked")


### PR DESCRIPTION
Reset TimeInMillis for Calender objects before setting the values, and added a test. This closes #145.