### PR TITLE
Improved timestamp handling

### DIFF
--- a/Source/com/drew/imaging/png/PngMetadataReader.java
+++ b/Source/com/drew/imaging/png/PngMetadataReader.java
@@ -212,17 +212,20 @@ public class PngMetadataReader
         } else if (chunkType.equals(PngChunkType.tIME)) {
             SequentialByteArrayReader reader = new SequentialByteArrayReader(bytes);
             int year = reader.getUInt16();
-            int month = reader.getUInt8() - 1;
+            int month = reader.getUInt8();
             int day = reader.getUInt8();
             int hour = reader.getUInt8();
             int minute = reader.getUInt8();
             int second = reader.getUInt8();
-            Calendar calendar = Calendar.getInstance(TimeZone.getTimeZone("UTC"));
-            calendar.setTimeInMillis(0);
-            //noinspection MagicConstant
-            calendar.set(year, month, day, hour, minute, second);
             PngDirectory directory = new PngDirectory(PngChunkType.tIME);
-            directory.setDate(PngDirectory.TAG_LAST_MODIFICATION_TIME, calendar.getTime());
+            if (DateUtil.isValidDate(year, month - 1, day) && DateUtil.isValidTime(hour, minute, second)) {
+                String dateString = String.format("%04d:%02d:%02d %02d:%02d:%02d", year, month, day, hour, minute, second);
+                directory.setString(PngDirectory.TAG_LAST_MODIFICATION_TIME, dateString);
+            } else {
+                directory.addError(String.format(
+                    "PNG tIME data describes an invalid date/time: year=%d month=%d day=%d hour=%d minute=%d second=%d",
+                    year, month, day, hour, minute, second));
+            }
             metadata.addDirectory(directory);
         } else if (chunkType.equals(PngChunkType.pHYs)) {
             SequentialByteArrayReader reader = new SequentialByteArrayReader(bytes);

--- a/Source/com/drew/metadata/Directory.java
+++ b/Source/com/drew/metadata/Directory.java
@@ -768,9 +768,7 @@ public abstract class Directory
                     "yyyy-MM-dd HH:mm",
                     "yyyy.MM.dd HH:mm:ss",
                     "yyyy.MM.dd HH:mm",
-                    "yyyy-MM-dd'T'HH:mm:ssX",
                     "yyyy-MM-dd'T'HH:mm:ss",
-                    "yyyy-MM-dd'T'HH:mmX",
                     "yyyy-MM-dd'T'HH:mm",
                     "yyyy-MM-dd",
                     "yyyy-MM",
@@ -784,6 +782,14 @@ public abstract class Directory
                 dateString = subsecondMatcher.replaceAll("$1");
             }
 
+            // if the date string has time zone information, it supersedes the timeZone parameter
+            Pattern timeZonePattern = Pattern.compile("(Z|[+-]\\d\\d:\\d\\d)$");
+            Matcher timeZoneMatcher = timeZonePattern.matcher(dateString);
+            if (timeZoneMatcher.find()) {
+                timeZone = TimeZone.getTimeZone("GMT" + timeZoneMatcher.group().replaceAll("Z", ""));
+                dateString = timeZoneMatcher.replaceAll("");
+            }
+
             for (String datePattern : datePatterns) {
                 try {
                     DateFormat parser = new SimpleDateFormat(datePattern);
@@ -792,7 +798,6 @@ public abstract class Directory
                     else
                         parser.setTimeZone(TimeZone.getTimeZone("GMT")); // don't interpret zone time
 
-                    // if the date string has time zone information, it supersedes the time zone set above
                     date = parser.parse(dateString);
                     break;
                 } catch (ParseException ex) {

--- a/Source/com/drew/metadata/icc/IccReader.java
+++ b/Source/com/drew/metadata/icc/IccReader.java
@@ -31,9 +31,7 @@ import com.drew.metadata.Metadata;
 import com.drew.metadata.MetadataReader;
 
 import java.io.IOException;
-import java.util.Calendar;
 import java.util.Collections;
-import java.util.TimeZone;
 
 /**
  * Reads an ICC profile.
@@ -184,11 +182,8 @@ public class IccReader implements JpegSegmentMetadataReader, MetadataReader
 
         if (DateUtil.isValidDate(y, m - 1, d) && DateUtil.isValidTime(h, M, s))
         {
-//          Date value = new Date(Date.UTC(y - 1900, m - 1, d, h, M, s));
-            Calendar calendar = Calendar.getInstance(TimeZone.getTimeZone("UTC"));
-            calendar.setTimeInMillis(0);
-            calendar.set(y, m - 1, d, h, M, s);
-            directory.setDate(tagType, calendar.getTime());
+            String dateString = String.format("%04d:%02d:%02d %02d:%02d:%02d", y, m, d, h, M, s);
+            directory.setString(tagType, dateString);
         }
         else
         {

--- a/Source/com/drew/metadata/xmp/XmpReader.java
+++ b/Source/com/drew/metadata/xmp/XmpReader.java
@@ -31,7 +31,6 @@ import com.drew.lang.Rational;
 import com.drew.lang.annotations.NotNull;
 import com.drew.metadata.Metadata;
 
-import java.util.Calendar;
 import java.util.Collections;
 
 /**
@@ -49,7 +48,7 @@ public class XmpReader implements JpegSegmentMetadataReader
     private static final int FMT_RATIONAL = 2;
     private static final int FMT_INT = 3;
     private static final int FMT_DOUBLE = 4;
-	private static final int FMT_STRING_ARRAY = 5;
+	  private static final int FMT_STRING_ARRAY = 5;
     /**
      * XMP tag namespace.
      * TODO the older "xap", "xapBJ", "xapMM" or "xapRights" namespace prefixes should be translated to the newer "xmp", "xmpBJ", "xmpMM" and "xmpRights" prefixes for use in family 1 group names
@@ -165,8 +164,8 @@ public class XmpReader implements JpegSegmentMetadataReader
         processXmpTag(xmpMeta, directory, XmpDirectory.TAG_FOCAL_LENGTH, FMT_RATIONAL);
         processXmpTag(xmpMeta, directory, XmpDirectory.TAG_SHUTTER_SPEED, FMT_RATIONAL);
 
-        processXmpDateTag(xmpMeta, directory, XmpDirectory.TAG_DATETIME_ORIGINAL);
-        processXmpDateTag(xmpMeta, directory, XmpDirectory.TAG_DATETIME_DIGITIZED);
+        processXmpTag(xmpMeta, directory, XmpDirectory.TAG_DATETIME_ORIGINAL, FMT_STRING);
+        processXmpTag(xmpMeta, directory, XmpDirectory.TAG_DATETIME_DIGITIZED, FMT_STRING);
 
         processXmpTag(xmpMeta, directory, XmpDirectory.TAG_RATING, FMT_DOUBLE);
         processXmpTag(xmpMeta, directory, XmpDirectory.TAG_LABEL, FMT_STRING);
@@ -260,19 +259,6 @@ public class XmpReader implements JpegSegmentMetadataReader
                 break;
             default:
                 directory.addError(String.format("Unknown format code %d for tag %d", formatCode, tagType));
-        }
-    }
-
-    @SuppressWarnings({"SameParameterValue"})
-    private static void processXmpDateTag(@NotNull XMPMeta meta, @NotNull XmpDirectory directory, int tagType)
-            throws XMPException
-    {
-        String schemaNS = XmpDirectory._tagSchemaMap.get(tagType);
-        String propName = XmpDirectory._tagPropNameMap.get(tagType);
-        Calendar cal = meta.getPropertyCalendar(schemaNS, propName);
-
-        if (cal != null) {
-            directory.setDate(tagType, cal.getTime());
         }
     }
 }

--- a/Tests/com/drew/imaging/png/PngMetadataReaderTest.java
+++ b/Tests/com/drew/imaging/png/PngMetadataReaderTest.java
@@ -93,6 +93,7 @@ public class PngMetadataReaderTest
             assertEquals(2835, dirs[3].getInt(PngDirectory.TAG_PIXELS_PER_UNIT_Y));
 
             assertEquals(PngChunkType.tIME, dirs[4].getPngChunkType());
+            assertEquals("2013:01:01 04:08:30", dirs[4].getString(PngDirectory.TAG_LAST_MODIFICATION_TIME));
 
             java.util.Date modTime = dirs[4].getDate(PngDirectory.TAG_LAST_MODIFICATION_TIME);
             SimpleDateFormat formatter = new SimpleDateFormat("EE MMM DD HH:mm:ss z yyyy");

--- a/Tests/com/drew/metadata/DirectoryTest.java
+++ b/Tests/com/drew/metadata/DirectoryTest.java
@@ -26,6 +26,7 @@ import com.drew.metadata.exif.ExifSubIFDDirectory;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.util.Calendar;
 import java.util.GregorianCalendar;
 import java.util.TimeZone;
 
@@ -110,10 +111,28 @@ public class DirectoryTest
         String date2 = "2002:01:30 23:59";
         String date3 = "2002-01-30 23:59:59";
         String date4 = "2002-01-30 23:59";
+        String date5 = "2002-01-30T23:59:59.099-08:00";
+        String date6 = "2002-01-30T23:59:59.099";
+        String date7 = "2002-01-30T23:59:59-08:00";
+        String date8 = "2002-01-30T23:59:59";
+        String date9 = "2002-01-30T23:59-08:00";
+        String date10 = "2002-01-30T23:59";
+        String date11 = "2002-01-30";
+        String date12 = "2002-01";
+        String date13 = "2002";
         _directory.setString(1, date1);
         _directory.setString(2, date2);
         _directory.setString(3, date3);
         _directory.setString(4, date4);
+        _directory.setString(5, date5);
+        _directory.setString(6, date6);
+        _directory.setString(7, date7);
+        _directory.setString(8, date8);
+        _directory.setString(9, date9);
+        _directory.setString(10, date10);
+        _directory.setString(11, date11);
+        _directory.setString(12, date12);
+        _directory.setString(13, date13);
         assertEquals(date1, _directory.getString(1));
 
             // Don't use default timezone
@@ -137,6 +156,34 @@ public class DirectoryTest
 
         gc.set(2002, GregorianCalendar.JANUARY, 30, 23, 59, 0);
         assertEquals(gc.getTime(), _directory.getDate(4, pst));
+
+        gc.set(2002, GregorianCalendar.JANUARY, 30, 23, 59, 59);
+        gc.set(Calendar.MILLISECOND, 99);
+        assertEquals(gc.getTime(), _directory.getDate(5, null));
+        assertEquals(gc.getTime(), _directory.getDate(5, gmt));
+        assertEquals(gc.getTime(), _directory.getDate(6, pst));
+
+        gc.set(Calendar.MILLISECOND, 0);
+        assertEquals(gc.getTime(), _directory.getDate(7, null));
+        assertEquals(gc.getTime(), _directory.getDate(7, gmt));
+        assertEquals(gc.getTime(), _directory.getDate(8, pst));
+
+        gc.set(2002, GregorianCalendar.JANUARY, 30, 23, 59, 0);
+        assertEquals(gc.getTime(), _directory.getDate(9, null));
+        assertEquals(gc.getTime(), _directory.getDate(9, gmt));
+        assertEquals(gc.getTime(), _directory.getDate(10, pst));
+
+        gc = new GregorianCalendar(gmt);
+        gc.setTimeInMillis(0);
+
+        gc.set(2002, GregorianCalendar.JANUARY, 30, 0, 0, 0);
+        assertEquals(gc.getTime(), _directory.getDate(11, null));
+
+        gc.set(2002, GregorianCalendar.JANUARY, 1, 0, 0, 0);
+        assertEquals(gc.getTime(), _directory.getDate(12, null));
+
+        gc.set(2002, GregorianCalendar.JANUARY, 1, 0, 0, 0);
+        assertEquals(gc.getTime(), _directory.getDate(13, null));
     }
 
     @Test

--- a/Tests/com/drew/metadata/icc/IccReaderTest.java
+++ b/Tests/com/drew/metadata/icc/IccReaderTest.java
@@ -30,6 +30,7 @@ import org.junit.Test;
 
 import java.util.Arrays;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
@@ -66,5 +67,20 @@ public class IccReaderTest
 
         assertNotNull(directory);
         assertTrue(directory.hasErrors());
+    }
+
+    @Test
+    public void testExtract_ProfileDateTime() throws Exception
+    {
+        byte[] app2Bytes = FileUtil.readBytes("Tests/Data/withExifAndIptc.jpg.app2");
+
+        Metadata metadata = new Metadata();
+        new IccReader().readJpegSegments(Arrays.asList(app2Bytes), metadata, JpegSegmentType.APP2);
+
+        IccDirectory directory = metadata.getFirstDirectoryOfType(IccDirectory.class);
+
+        assertNotNull(directory);
+        assertEquals("1998:02:09 06:49:00", directory.getString(IccDirectory.TAG_PROFILE_DATETIME));
+        assertEquals(887006940000L, directory.getDate(IccDirectory.TAG_PROFILE_DATETIME).getTime());
     }
 }

--- a/Tests/com/drew/metadata/xmp/XmpReaderTest.java
+++ b/Tests/com/drew/metadata/xmp/XmpReaderTest.java
@@ -196,6 +196,7 @@ public class XmpReaderTest
         Calendar calendar = new GregorianCalendar(2010, 12-1, 12, 11, 41, 35);
         calendar.setTimeZone(TimeZone.getTimeZone("GMT"));
         assertEquals(calendar.getTime(), actual);
+        assertEquals(1292154095000L, actual.getTime());
     }
 
     @Test
@@ -211,6 +212,7 @@ public class XmpReaderTest
         Calendar calendar = new GregorianCalendar(2010, 12-1, 12, 11, 41, 35);
         calendar.setTimeZone(TimeZone.getTimeZone("GMT"));
         assertEquals(calendar.getTime(), actual);
+        assertEquals(1292154095000L, actual.getTime());
     }
 
     @Test


### PR DESCRIPTION
* The values for the following tags are now stored as date strings instead of Date objects
  * `IccDirectory.TAG_PROFILE_DATETIME`
  * `PngDirectory.TAG_LAST_MODIFICATION_TIME`
  * `XmpDirectory.TAG_DATETIME_ORIGINAL`
  * `XmpDirectory.TAG_DATETIME_DIGITIZED`
* Modified the `Directory.getDate()` method so that it can parse a date string in the ISO 8601 format for the XMP tags
* Added many date parsing tests

This resolves a part of #147.