### PR TITLE
Added the getGpsDate() method

### DIFF
--- a/Source/com/drew/metadata/exif/GpsDescriptor.java
+++ b/Source/com/drew/metadata/exif/GpsDescriptor.java
@@ -109,7 +109,7 @@ public class GpsDescriptor extends TagDescriptor<GpsDirectory>
     {
         // time in hour, min, sec
         Rational[] timeComponents = _directory.getRationalArray(TAG_TIME_STAMP);
-        DecimalFormat df = new DecimalFormat("00.00");
+        DecimalFormat df = new DecimalFormat("00.000");
         return timeComponents == null
             ? null
             : String.format("%02d:%02d:%s UTC",

--- a/Source/com/drew/metadata/exif/GpsDirectory.java
+++ b/Source/com/drew/metadata/exif/GpsDirectory.java
@@ -25,6 +25,10 @@ import com.drew.lang.Rational;
 import com.drew.lang.annotations.NotNull;
 import com.drew.lang.annotations.Nullable;
 
+import java.text.DateFormat;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Date;
 import java.util.HashMap;
 
 /**
@@ -163,10 +167,10 @@ public class GpsDirectory extends ExifDirectoryBase
     @Nullable
     public GeoLocation getGeoLocation()
     {
-        Rational[] latitudes = getRationalArray(GpsDirectory.TAG_LATITUDE);
-        Rational[] longitudes = getRationalArray(GpsDirectory.TAG_LONGITUDE);
-        String latitudeRef = getString(GpsDirectory.TAG_LATITUDE_REF);
-        String longitudeRef = getString(GpsDirectory.TAG_LONGITUDE_REF);
+        Rational[] latitudes = getRationalArray(TAG_LATITUDE);
+        Rational[] longitudes = getRationalArray(TAG_LONGITUDE);
+        String latitudeRef = getString(TAG_LATITUDE_REF);
+        String longitudeRef = getString(TAG_LONGITUDE_REF);
 
         // Make sure we have the required values
         if (latitudes == null || latitudes.length != 3)
@@ -184,5 +188,33 @@ public class GpsDirectory extends ExifDirectoryBase
             return null;
 
         return new GeoLocation(lat, lon);
+    }
+
+    /**
+     * Parses the date stamp tag and the time stamp tag to obtain a single Date object representing the
+     * date and time when this image was captured.
+     *
+     * @return A Date object representing when this image was captured, if possible, otherwise null
+     */
+    @Nullable
+    public Date getGpsDate()
+    {
+        String date = getString(TAG_DATE_STAMP);
+        Rational[] timeComponents = getRationalArray(TAG_TIME_STAMP);
+
+        // Make sure we have the required values
+        if (date == null)
+            return null;
+        if (timeComponents == null || timeComponents.length != 3)
+            return null;
+
+        String dateTime = String.format("%s %02d:%02d:%02.3f UTC",
+            date, timeComponents[0].intValue(), timeComponents[1].intValue(), timeComponents[2].doubleValue());
+        try {
+            DateFormat parser = new SimpleDateFormat("yyyy:MM:dd HH:mm:ss.S z");
+            return parser.parse(dateTime);
+        } catch (ParseException e) {
+            return null;
+        }
     }
 }

--- a/Tests/com/drew/metadata/exif/ExifDirectoryTest.java
+++ b/Tests/com/drew/metadata/exif/ExifDirectoryTest.java
@@ -22,6 +22,7 @@ package com.drew.metadata.exif;
 
 import com.drew.imaging.jpeg.JpegProcessingException;
 import com.drew.imaging.jpeg.JpegSegmentReader;
+import com.drew.lang.GeoLocation;
 import com.drew.lang.SequentialByteArrayReader;
 import com.drew.metadata.Directory;
 import com.drew.metadata.Metadata;
@@ -46,14 +47,17 @@ public class ExifDirectoryTest
         Directory subIFDDirectory = new ExifSubIFDDirectory();
         Directory ifd0Directory = new ExifIFD0Directory();
         Directory thumbDirectory = new ExifThumbnailDirectory();
+        Directory gpsDirectory = new GpsDirectory();
 
         assertFalse(subIFDDirectory.hasErrors());
         assertFalse(ifd0Directory.hasErrors());
         assertFalse(thumbDirectory.hasErrors());
+        assertFalse(gpsDirectory.hasErrors());
 
         assertEquals("Exif IFD0", ifd0Directory.getName());
         assertEquals("Exif SubIFD", subIFDDirectory.getName());
         assertEquals("Exif Thumbnail", thumbDirectory.getName());
+        assertEquals("GPS", gpsDirectory.getName());
     }
 
     @Test
@@ -114,5 +118,29 @@ public class ExifDirectoryTest
         ExifIFD0Directory exifIFD0Directory = metadata.getFirstDirectoryOfType(ExifIFD0Directory.class);
         assertNotNull(exifIFD0Directory);
         assertEquals(216, exifIFD0Directory.getInt(ExifIFD0Directory.TAG_X_RESOLUTION));
+    }
+
+    @Test
+    public void testGeoLocation() throws IOException, MetadataException
+    {
+        Metadata metadata = ExifReaderTest.processBytes("Tests/Data/withExifAndIptc.jpg.app1.0");
+
+        GpsDirectory gpsDirectory = metadata.getFirstDirectoryOfType(GpsDirectory.class);
+        assertNotNull(gpsDirectory);
+        GeoLocation geoLocation = gpsDirectory.getGeoLocation();
+        assertEquals(54.989666666666665, geoLocation.getLatitude(), 0.001);
+        assertEquals(-1.9141666666666666, geoLocation.getLongitude(), 0.001);
+    }
+
+    @Test
+    public void testGpsDate() throws IOException, MetadataException
+    {
+        Metadata metadata = ExifReaderTest.processBytes("Tests/Data/withPanasonicFaces.jpg.app1");
+
+        GpsDirectory gpsDirectory = metadata.getFirstDirectoryOfType(GpsDirectory.class);
+        assertNotNull(gpsDirectory);
+        assertEquals("2010:06:24", gpsDirectory.getString(GpsDirectory.TAG_DATE_STAMP));
+        assertEquals("10/1 17/1 21/1", gpsDirectory.getString(GpsDirectory.TAG_TIME_STAMP));
+        assertEquals(1277374641000L, gpsDirectory.getGpsDate().getTime());
     }
 }


### PR DESCRIPTION
* Added `GpsDirectory.getGpsDate()` that parses the date stamp tag and the time stamp tag and returns a single `Date` object
* Modified the `GpsDescriptor.getGpsTimeStampDescription()` to return up to third decimal place
* Added tests that parse geo location data and gps date/time data

This resolves a part of #147.