### PR TITLE
Added date parsing methods to IptcDirectory

### DIFF
--- a/Source/com/drew/metadata/iptc/IptcDescriptor.java
+++ b/Source/com/drew/metadata/iptc/IptcDescriptor.java
@@ -46,17 +46,57 @@ public class IptcDescriptor extends TagDescriptor<IptcDirectory>
     public String getDescription(int tagType)
     {
         switch (tagType) {
+            case TAG_DATE_CREATED:
+                return getDateCreatedDescription();
+            case TAG_DIGITAL_DATE_CREATED:
+                return getDigitalDateCreatedDescription();
+            case TAG_DATE_SENT:
+                return getDateSentDescription();
+            case TAG_EXPIRATION_DATE:
+                return getExpirationDateDescription();
+            case TAG_EXPIRATION_TIME:
+                return getExpirationTimeDescription();
             case TAG_FILE_FORMAT:
                 return getFileFormatDescription();
             case TAG_KEYWORDS:
                 return getKeywordsDescription();
+            case TAG_REFERENCE_DATE:
+                return getReferenceDateDescription();
+            case TAG_RELEASE_DATE:
+                return getReleaseDateDescription();
+            case TAG_RELEASE_TIME:
+                return getReleaseTimeDescription();
             case TAG_TIME_CREATED:
                 return getTimeCreatedDescription();
             case TAG_DIGITAL_TIME_CREATED:
                 return getDigitalTimeCreatedDescription();
+            case TAG_TIME_SENT:
+                return getTimeSentDescription();
             default:
                 return super.getDescription(tagType);
         }
+    }
+
+    @Nullable
+    public String getDateDescription(int tagType)
+    {
+        String s = _directory.getString(tagType);
+        if (s == null)
+            return null;
+        if (s.length() == 8)
+            return s.substring(0, 4) + ':' + s.substring(4, 6) + ':' + s.substring(6);
+        return s;
+    }
+
+    @Nullable
+    public String getTimeDescription(int tagType)
+    {
+        String s = _directory.getString(tagType);
+        if (s == null)
+            return null;
+        if (s.length() == 6 || s.length() == 11)
+            return s.substring(0, 2) + ':' + s.substring(2, 4) + ':' + s.substring(4);
+        return s;
     }
 
     @Nullable
@@ -151,7 +191,31 @@ public class IptcDescriptor extends TagDescriptor<IptcDirectory>
     @Nullable
     public String getDateCreatedDescription()
     {
-        return _directory.getString(TAG_DATE_CREATED);
+        return getDateDescription(TAG_DATE_CREATED);
+    }
+
+    @Nullable
+    public String getDigitalDateCreatedDescription()
+    {
+        return getDateDescription(TAG_DIGITAL_DATE_CREATED);
+    }
+
+    @Nullable
+    public String getDateSentDescription()
+    {
+        return getDateDescription(TAG_DATE_SENT);
+    }
+
+    @Nullable
+    public String getExpirationDateDescription()
+    {
+        return getDateDescription(TAG_EXPIRATION_DATE);
+    }
+
+    @Nullable
+    public String getExpirationTimeDescription()
+    {
+        return getTimeDescription(TAG_EXPIRATION_TIME);
     }
 
     @Nullable
@@ -200,15 +264,21 @@ public class IptcDescriptor extends TagDescriptor<IptcDirectory>
     }
 
     @Nullable
+    public String getReferenceDateDescription()
+    {
+        return getDateDescription(TAG_REFERENCE_DATE);
+    }
+
+    @Nullable
     public String getReleaseDateDescription()
     {
-        return _directory.getString(TAG_RELEASE_DATE);
+        return getDateDescription(TAG_RELEASE_DATE);
     }
 
     @Nullable
     public String getReleaseTimeDescription()
     {
-        return _directory.getString(TAG_RELEASE_TIME);
+        return getTimeDescription(TAG_RELEASE_TIME);
     }
 
     @Nullable
@@ -232,23 +302,19 @@ public class IptcDescriptor extends TagDescriptor<IptcDirectory>
     @Nullable
     public String getTimeCreatedDescription()
     {
-        String s = _directory.getString(TAG_TIME_CREATED);
-        if (s == null)
-            return null;
-        if (s.length() == 6 || s.length() == 11)
-            return s.substring(0, 2) + ':' + s.substring(2, 4) + ':' + s.substring(4);
-        return s;
+        return getTimeDescription(TAG_TIME_CREATED);
     }
 
     @Nullable
     public String getDigitalTimeCreatedDescription()
     {
-        String s = _directory.getString(TAG_DIGITAL_TIME_CREATED);
-        if (s == null)
-            return null;
-        if (s.length() == 6 || s.length() == 11)
-            return s.substring(0, 2) + ':' + s.substring(2, 4) + ':' + s.substring(4);
-        return s;
+        return getTimeDescription(TAG_DIGITAL_TIME_CREATED);
+    }
+
+    @Nullable
+    public String getTimeSentDescription()
+    {
+        return getTimeDescription(TAG_TIME_SENT);
     }
 
     @Nullable

--- a/Source/com/drew/metadata/iptc/IptcDirectory.java
+++ b/Source/com/drew/metadata/iptc/IptcDirectory.java
@@ -24,7 +24,11 @@ import com.drew.lang.annotations.NotNull;
 import com.drew.lang.annotations.Nullable;
 import com.drew.metadata.Directory;
 
+import java.text.DateFormat;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
 import java.util.Arrays;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 
@@ -230,9 +234,84 @@ public class IptcDirectory extends Directory
     @Nullable
     public List<String> getKeywords()
     {
-        final String[] array = getStringArray(IptcDirectory.TAG_KEYWORDS);
+        final String[] array = getStringArray(TAG_KEYWORDS);
         if (array==null)
             return null;
         return Arrays.asList(array);
+    }
+
+    /**
+     * Parses the Date Sent tag and the Time Sent tag to obtain a single Date object representing the
+     * date and time when the service sent this image.
+     * @return A Date object representing when the service sent this image, if possible, otherwise null
+     */
+    @Nullable
+    public Date getDateSent()
+    {
+        return getDate(TAG_DATE_SENT, TAG_TIME_SENT);
+    }
+
+    /**
+     * Parses the Release Date tag and the Release Time tag to obtain a single Date object representing the
+     * date and time when this image was released.
+     * @return A Date object representing when this image was released, if possible, otherwise null
+     */
+    @Nullable
+    public Date getReleaseDate()
+    {
+        return getDate(TAG_RELEASE_DATE, TAG_RELEASE_TIME);
+    }
+
+    /**
+     * Parses the Expiration Date tag and the Expiration Time tag to obtain a single Date object representing
+     * that this image should not used after this date and time.
+     * @return A Date object representing when this image was released, if possible, otherwise null
+     */
+    @Nullable
+    public Date getExpirationDate()
+    {
+        return getDate(TAG_EXPIRATION_DATE, TAG_EXPIRATION_TIME);
+    }
+
+    /**
+     * Parses the Date Created tag and the Time Created tag to obtain a single Date object representing the
+     * date and time when this image was captured.
+     * @return A Date object representing when this image was captured, if possible, otherwise null
+     */
+    @Nullable
+    public Date getDateCreated()
+    {
+        return getDate(TAG_DATE_CREATED, TAG_TIME_CREATED);
+    }
+
+    /**
+     * Parses the Digital Date Created tag and the Digital Time Created tag to obtain a single Date object
+     * representing the date and time when the digital representation of this image was created.
+     * @return A Date object representing when the digital representation of this image was created,
+     * if possible, otherwise null
+     */
+    @Nullable
+    public Date getDigitalDateCreated()
+    {
+        return getDate(TAG_DIGITAL_DATE_CREATED, TAG_DIGITAL_TIME_CREATED);
+    }
+
+    @Nullable
+    private Date getDate(int dateTagType, int timeTagType)
+    {
+        String date = getString(dateTagType);
+        String time = getString(timeTagType);
+
+        if (date == null)
+            return null;
+        if (time == null)
+            return null;
+
+        try {
+            DateFormat parser = new SimpleDateFormat("yyyyMMddHHmmssZ");
+            return parser.parse(date + time);
+        } catch (ParseException e) {
+            return null;
+        }
     }
 }

--- a/Source/com/drew/metadata/iptc/IptcReader.java
+++ b/Source/com/drew/metadata/iptc/IptcReader.java
@@ -22,7 +22,6 @@ package com.drew.metadata.iptc;
 
 import com.drew.imaging.jpeg.JpegSegmentMetadataReader;
 import com.drew.imaging.jpeg.JpegSegmentType;
-import com.drew.lang.DateUtil;
 import com.drew.lang.SequentialByteArrayReader;
 import com.drew.lang.SequentialReader;
 import com.drew.lang.annotations.NotNull;
@@ -31,7 +30,6 @@ import com.drew.metadata.Metadata;
 
 import java.io.IOException;
 import java.util.Collections;
-import java.util.Date;
 
 /**
  * Decodes IPTC binary data, populating a {@link Metadata} object with tag values in an {@link IptcDirectory}.
@@ -184,31 +182,6 @@ public class IptcReader implements JpegSegmentMetadataReader
                 directory.setInt(tagIdentifier, reader.getUInt8());
                 reader.skip(tagByteCount - 1);
                 return;
-            case IptcDirectory.TAG_RELEASE_DATE:
-            case IptcDirectory.TAG_DATE_CREATED:
-            case IptcDirectory.TAG_DIGITAL_DATE_CREATED:
-                // Date object
-                if (tagByteCount >= 8) {
-                    string = reader.getString(tagByteCount);
-                    assert(string.length() >= 8);
-                    try {
-                        int year = Integer.parseInt(string.substring(0, 4));
-                        int month = Integer.parseInt(string.substring(4, 6)) - 1;
-                        int day = Integer.parseInt(string.substring(6, 8));
-                        if (DateUtil.isValidDate(year, month, day)) {
-                            Date date = new java.util.GregorianCalendar(year, month, day).getTime();
-                            directory.setDate(tagIdentifier, date);
-                            return;
-                        }
-                    } catch (NumberFormatException e) {
-                        // fall through and we'll process the 'string' value below
-                    }
-                } else {
-                    reader.skip(tagByteCount);
-                }
-            case IptcDirectory.TAG_RELEASE_TIME:
-            case IptcDirectory.TAG_TIME_CREATED:
-                // time...
             default:
                 // fall through
         }

--- a/Tests/com/drew/metadata/iptc/IptcDirectoryTest.java
+++ b/Tests/com/drew/metadata/iptc/IptcDirectoryTest.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2002-2015 Drew Noakes
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ * More information about this project is available at:
+ *
+ *    https://drewnoakes.com/code/exif/
+ *    https://github.com/drewnoakes/metadata-extractor
+ */
+
+package com.drew.metadata.iptc;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Calendar;
+import java.util.Date;
+import java.util.GregorianCalendar;
+import java.util.TimeZone;
+
+import static org.junit.Assert.assertEquals;
+
+public class IptcDirectoryTest {
+
+  private IptcDirectory _directory;
+
+  @Before
+  public void setUp()
+  {
+    _directory = new IptcDirectory();
+  }
+
+  @Test
+  public void testGetDateSent()
+  {
+    _directory.setString(IptcDirectory.TAG_DATE_SENT, "20101212");
+    _directory.setString(IptcDirectory.TAG_TIME_SENT, "124135+0100");
+    final Date actual = _directory.getDateSent();
+
+    Calendar calendar = new GregorianCalendar(2010, 12-1, 12, 12, 41, 35);
+    calendar.setTimeZone(TimeZone.getTimeZone("GMT+1"));
+    assertEquals(calendar.getTime(), actual);
+    assertEquals(1292154095000L, actual.getTime());
+  }
+
+  @Test
+  public void testGetReleaseDate()
+  {
+    _directory.setString(IptcDirectory.TAG_RELEASE_DATE, "20101212");
+    _directory.setString(IptcDirectory.TAG_RELEASE_TIME, "124135+0100");
+    final Date actual = _directory.getReleaseDate();
+
+    Calendar calendar = new GregorianCalendar(2010, 12-1, 12, 12, 41, 35);
+    calendar.setTimeZone(TimeZone.getTimeZone("GMT+1"));
+    assertEquals(calendar.getTime(), actual);
+    assertEquals(1292154095000L, actual.getTime());
+  }
+
+  @Test
+  public void testGetExpirationDate()
+  {
+    _directory.setString(IptcDirectory.TAG_EXPIRATION_DATE, "20101212");
+    _directory.setString(IptcDirectory.TAG_EXPIRATION_TIME, "124135+0100");
+    final Date actual = _directory.getExpirationDate();
+
+    Calendar calendar = new GregorianCalendar(2010, 12-1, 12, 12, 41, 35);
+    calendar.setTimeZone(TimeZone.getTimeZone("GMT+1"));
+    assertEquals(calendar.getTime(), actual);
+    assertEquals(1292154095000L, actual.getTime());
+  }
+
+  @Test
+  public void testGetDateCreated()
+  {
+    _directory.setString(IptcDirectory.TAG_DATE_CREATED, "20101212");
+    _directory.setString(IptcDirectory.TAG_TIME_CREATED, "124135+0100");
+    final Date actual = _directory.getDateCreated();
+
+    Calendar calendar = new GregorianCalendar(2010, 12-1, 12, 12, 41, 35);
+    calendar.setTimeZone(TimeZone.getTimeZone("GMT+1"));
+    assertEquals(calendar.getTime(), actual);
+    assertEquals(1292154095000L, actual.getTime());
+  }
+
+  @Test
+  public void testGetDigitalDateCreated()
+  {
+    _directory.setString(IptcDirectory.TAG_DIGITAL_DATE_CREATED, "20101212");
+    _directory.setString(IptcDirectory.TAG_DIGITAL_TIME_CREATED, "124135+0100");
+    final Date actual = _directory.getDigitalDateCreated();
+
+    Calendar calendar = new GregorianCalendar(2010, 12-1, 12, 12, 41, 35);
+    calendar.setTimeZone(TimeZone.getTimeZone("GMT+1"));
+    assertEquals(calendar.getTime(), actual);
+    assertEquals(1292154095000L, actual.getTime());
+  }
+}

--- a/Tests/com/drew/metadata/iptc/IptcReaderTest.java
+++ b/Tests/com/drew/metadata/iptc/IptcReaderTest.java
@@ -90,7 +90,7 @@ public class IptcReaderTest
         assertEquals("City", directory.getObject(tags[9].getTagType()));
 
         assertEquals(IptcDirectory.TAG_DATE_CREATED, tags[10].getTagType());
-        assertEquals(new java.util.GregorianCalendar(2000, 0, 1).getTime(), directory.getObject(tags[10].getTagType()));
+        assertEquals("20000101", directory.getObject(tags[10].getTagType()));
 
         assertEquals(IptcDirectory.TAG_OBJECT_NAME, tags[11].getTagType());
         assertEquals("ObjectName", directory.getObject(tags[11].getTagType()));


### PR DESCRIPTION
* Added the `getXxxDate()` methods that parse the date tag and the time tag and return a single `Date` object
* Added the `getXxxDateDescription()` and `getXxxTimeDescription()` methods that return a descriptive string representation of the date and time
* Removed the date parsing code from `IptcReader`, and all the values for the date and time tags are now stored as strings instead of `Date` objects
* Added several date parsing tests

This resolves a part of #147.