### PR TITLE
Handle Tiff IFD0 ApplicationNotes tag (0x02bc) as XMP

### DIFF
--- a/Source/com/drew/metadata/exif/ExifDirectoryBase.java
+++ b/Source/com/drew/metadata/exif/ExifDirectoryBase.java
@@ -149,6 +149,8 @@ public abstract class ExifDirectoryBase extends Directory
     public static final int TAG_YCBCR_SUBSAMPLING                 = 0x0212;
     public static final int TAG_YCBCR_POSITIONING                 = 0x0213;
     public static final int TAG_REFERENCE_BLACK_WHITE             = 0x0214;
+    public static final int TAG_STRIP_ROW_COUNTS                  = 0x022f;
+    public static final int TAG_APPLICATION_NOTES                 = 0x02bc;
 
     public static final int TAG_RELATED_IMAGE_FILE_FORMAT         = 0x1000;
     public static final int TAG_RELATED_IMAGE_WIDTH               = 0x1001;
@@ -630,6 +632,8 @@ public abstract class ExifDirectoryBase extends Directory
         map.put(TAG_YCBCR_SUBSAMPLING, "YCbCr Sub-Sampling");
         map.put(TAG_YCBCR_POSITIONING, "YCbCr Positioning");
         map.put(TAG_REFERENCE_BLACK_WHITE, "Reference Black/White");
+        map.put(TAG_STRIP_ROW_COUNTS, "Strip Row Counts");
+        map.put(TAG_APPLICATION_NOTES, "Application Notes");
         map.put(TAG_RELATED_IMAGE_FILE_FORMAT, "Related Image File Format");
         map.put(TAG_RELATED_IMAGE_WIDTH, "Related Image Width");
         map.put(TAG_RELATED_IMAGE_HEIGHT, "Related Image Height");

--- a/Source/com/drew/metadata/exif/ExifTiffHandler.java
+++ b/Source/com/drew/metadata/exif/ExifTiffHandler.java
@@ -30,6 +30,7 @@ import com.drew.metadata.Metadata;
 import com.drew.metadata.exif.makernotes.*;
 import com.drew.metadata.iptc.IptcReader;
 import com.drew.metadata.tiff.DirectoryTiffHandler;
+import com.drew.metadata.xmp.XmpReader;
 
 import java.io.IOException;
 import java.util.Set;
@@ -118,6 +119,12 @@ public class ExifTiffHandler extends DirectoryTiffHandler
                 return true;
             }
             return false;
+        }
+
+        // Custom processing for embedded XMP data
+        if(tagId == ExifSubIFDDirectory.TAG_APPLICATION_NOTES && _currentDirectory instanceof ExifIFD0Directory) {
+            new XmpReader().extract(reader.getNullTerminatedString(tagOffset, byteCount), _metadata);
+            return true;
         }
 
         return false;


### PR DESCRIPTION
Ported from drewnoakes/metadata-extractor-dotnet#40 - addresses the other half of #151

IFD0 was missing the ApplicationNotes tag (0x02BC) which can apparently hold XMP data. This assumes it is always XMP in there, but I can't 100% confirm this.