### PR TITLE
IPTC metadata: Fix an off-by-one error.

### DIFF
--- a/Source/com/drew/metadata/iptc/IptcReader.java
+++ b/Source/com/drew/metadata/iptc/IptcReader.java
@@ -114,8 +114,8 @@ public class IptcReader implements JpegSegmentMetadataReader
                 return;
             }
 
-            // we need at least five bytes left to read a tag
-            if (offset + 5 >= length) {
+            // we need at least four bytes left to read a tag
+            if (offset + 4 >= length) {
                 directory.addError("Too few bytes remain for a valid IPTC tag");
                 return;
             }


### PR DESCRIPTION
Fixes an issue where a single-byte value at the end of an IPTC directory
would not be sufficient to consider the number of remaining bytes
sufficient, causing the extraction to be halted prematurely.