### PR TITLE
Olympus base Makernotes, CameraSettings, Equipment, and RawDev closer…

### DIFF
--- a/Source/com/drew/imaging/FileTypeDetector.java
+++ b/Source/com/drew/imaging/FileTypeDetector.java
@@ -60,6 +60,7 @@ public class FileTypeDetector
         _root.addPath(FileType.Cr2, "II".getBytes(), new byte[]{0x2a, 0x00, 0x10, 0x00, 0x00, 0x00, 0x43, 0x52});
         _root.addPath(FileType.Nef, "MM".getBytes(), new byte[]{0x00, 0x2a, 0x00, 0x00, 0x00, (byte)0x80, 0x00});
         _root.addPath(FileType.Orf, "IIRO".getBytes(), new byte[]{(byte)0x08, 0x00});
+        _root.addPath(FileType.Orf, "MMOR".getBytes(), new byte[]{(byte)0x00, 0x00});
         _root.addPath(FileType.Orf, "IIRS".getBytes(), new byte[]{(byte)0x08, 0x00});
         _root.addPath(FileType.Raf, "FUJIFILMCCD-RAW".getBytes());
         _root.addPath(FileType.Rw2, "II".getBytes(), new byte[]{0x55, 0x00});

--- a/Source/com/drew/metadata/TagDescriptor.java
+++ b/Source/com/drew/metadata/TagDescriptor.java
@@ -345,4 +345,67 @@ public class TagDescriptor<T extends Directory>
 
         return sb.toString();
     }
+
+    @Nullable
+    public String getOrientationDescription(int tag)
+    {
+        return getIndexedDescription(tag, 1,
+            "Top, left side (Horizontal / normal)",
+            "Top, right side (Mirror horizontal)",
+            "Bottom, right side (Rotate 180)",
+            "Bottom, left side (Mirror vertical)",
+            "Left side, top (Mirror horizontal and rotate 270 CW)",
+            "Right side, top (Rotate 90 CW)",
+            "Right side, bottom (Mirror horizontal and rotate 90 CW)",
+            "Left side, bottom (Rotate 270 CW)");
+    }
+
+    @Nullable
+    public String getShutterSpeedDescription(int tag)
+    {
+        // I believe this method to now be stable, but am leaving some alternative snippets of
+        // code in here, to assist anyone who's looking into this (given that I don't have a public CVS).
+
+//        float apexValue = _directory.getFloat(ExifSubIFDDirectory.TAG_SHUTTER_SPEED);
+//        int apexPower = (int)Math.pow(2.0, apexValue);
+//        return "1/" + apexPower + " sec";
+        // TODO test this method
+        // thanks to Mark Edwards for spotting and patching a bug in the calculation of this
+        // description (spotted bug using a Canon EOS 300D)
+        // thanks also to Gli Blr for spotting this bug
+        Float apexValue = _directory.getFloatObject(tag);
+        if (apexValue == null)
+            return null;
+        if (apexValue <= 1) {
+            float apexPower = (float)(1 / (Math.exp(apexValue * Math.log(2))));
+            long apexPower10 = Math.round((double)apexPower * 10.0);
+            float fApexPower = (float)apexPower10 / 10.0f;
+            DecimalFormat format = new DecimalFormat("0.##");
+            format.setRoundingMode(RoundingMode.HALF_UP);
+            return format.format(fApexPower) + " sec";
+        } else {
+            int apexPower = (int)((Math.exp(apexValue * Math.log(2))));
+            return "1/" + apexPower + " sec";
+        }
+
+/*
+        // This alternative implementation offered by Bill Richards
+        // TODO determine which is the correct / more-correct implementation
+        double apexValue = _directory.getDouble(ExifSubIFDDirectory.TAG_SHUTTER_SPEED);
+        double apexPower = Math.pow(2.0, apexValue);
+
+        StringBuffer sb = new StringBuffer();
+        if (apexPower > 1)
+            apexPower = Math.floor(apexPower);
+
+        if (apexPower < 1) {
+            sb.append((int)Math.round(1/apexPower));
+        } else {
+            sb.append("1/");
+            sb.append((int)apexPower);
+        }
+        sb.append(" sec");
+        return sb.toString();
+*/
+    }
 }

--- a/Source/com/drew/metadata/exif/ExifDescriptorBase.java
+++ b/Source/com/drew/metadata/exif/ExifDescriptorBase.java
@@ -279,15 +279,7 @@ public abstract class ExifDescriptorBase<T extends Directory> extends TagDescrip
     @Nullable
     public String getOrientationDescription()
     {
-        return getIndexedDescription(TAG_ORIENTATION, 1,
-            "Top, left side (Horizontal / normal)",
-            "Top, right side (Mirror horizontal)",
-            "Bottom, right side (Rotate 180)",
-            "Bottom, left side (Mirror vertical)",
-            "Left side, top (Mirror horizontal and rotate 270 CW)",
-            "Right side, top (Rotate 90 CW)",
-            "Right side, bottom (Mirror horizontal and rotate 90 CW)",
-            "Left side, bottom (Rotate 270 CW)");
+        return super.getOrientationDescription(TAG_ORIENTATION);
     }
 
     @Nullable
@@ -1002,50 +994,7 @@ public abstract class ExifDescriptorBase<T extends Directory> extends TagDescrip
     @Nullable
     public String getShutterSpeedDescription()
     {
-        // I believe this method to now be stable, but am leaving some alternative snippets of
-        // code in here, to assist anyone who's looking into this (given that I don't have a public CVS).
-
-//        float apexValue = _directory.getFloat(ExifSubIFDDirectory.TAG_SHUTTER_SPEED);
-//        int apexPower = (int)Math.pow(2.0, apexValue);
-//        return "1/" + apexPower + " sec";
-        // TODO test this method
-        // thanks to Mark Edwards for spotting and patching a bug in the calculation of this
-        // description (spotted bug using a Canon EOS 300D)
-        // thanks also to Gli Blr for spotting this bug
-        Float apexValue = _directory.getFloatObject(TAG_SHUTTER_SPEED);
-        if (apexValue == null)
-            return null;
-        if (apexValue <= 1) {
-            float apexPower = (float)(1 / (Math.exp(apexValue * Math.log(2))));
-            long apexPower10 = Math.round((double)apexPower * 10.0);
-            float fApexPower = (float)apexPower10 / 10.0f;
-            DecimalFormat format = new DecimalFormat("0.##");
-            format.setRoundingMode(RoundingMode.HALF_UP);
-            return format.format(fApexPower) + " sec";
-        } else {
-            int apexPower = (int)((Math.exp(apexValue * Math.log(2))));
-            return "1/" + apexPower + " sec";
-        }
-
-/*
-        // This alternative implementation offered by Bill Richards
-        // TODO determine which is the correct / more-correct implementation
-        double apexValue = _directory.getDouble(ExifSubIFDDirectory.TAG_SHUTTER_SPEED);
-        double apexPower = Math.pow(2.0, apexValue);
-
-        StringBuffer sb = new StringBuffer();
-        if (apexPower > 1)
-            apexPower = Math.floor(apexPower);
-
-        if (apexPower < 1) {
-            sb.append((int)Math.round(1/apexPower));
-        } else {
-            sb.append("1/");
-            sb.append((int)apexPower);
-        }
-        sb.append(" sec");
-        return sb.toString();
-*/
+        return super.getShutterSpeedDescription(TAG_SHUTTER_SPEED);
     }
 
     @Nullable

--- a/Source/com/drew/metadata/exif/ExifTiffHandler.java
+++ b/Source/com/drew/metadata/exif/ExifTiffHandler.java
@@ -121,6 +121,9 @@ public class ExifTiffHandler extends DirectoryTiffHandler
                 case OlympusMakernoteDirectory.TAG_RAW_INFO:
                     pushDirectory(OlympusRawInfoMakernoteDirectory.class);
                     return true;
+                case OlympusMakernoteDirectory.TAG_MAIN_INFO:
+                    pushDirectory(OlympusMakernoteDirectory.class);
+                    return true;
             }
         }
 
@@ -230,6 +233,10 @@ public class ExifTiffHandler extends DirectoryTiffHandler
                     return true;
                 case OlympusMakernoteDirectory.TAG_RAW_INFO:
                     pushDirectory(OlympusRawInfoMakernoteDirectory.class);
+                    TiffReader.processIfd(this, reader, processedIfdOffsets, tagOffset, tiffHeaderOffset);
+                    return true;
+                case OlympusMakernoteDirectory.TAG_MAIN_INFO:
+                    pushDirectory(OlympusMakernoteDirectory.class);
                     TiffReader.processIfd(this, reader, processedIfdOffsets, tagOffset, tiffHeaderOffset);
                     return true;
             }

--- a/Source/com/drew/metadata/exif/ExifTiffHandler.java
+++ b/Source/com/drew/metadata/exif/ExifTiffHandler.java
@@ -115,6 +115,9 @@ public class ExifTiffHandler extends DirectoryTiffHandler
                 case OlympusMakernoteDirectory.TAG_IMAGE_PROCESSING:
                     pushDirectory(OlympusImageProcessingMakernoteDirectory.class);
                     return true;
+                case OlympusMakernoteDirectory.TAG_FOCUS_INFO:
+                    pushDirectory(OlympusFocusInfoMakernoteDirectory.class);
+                    return true;
             }
         }
 
@@ -216,6 +219,10 @@ public class ExifTiffHandler extends DirectoryTiffHandler
                     return true;
                 case OlympusMakernoteDirectory.TAG_IMAGE_PROCESSING:
                     pushDirectory(OlympusImageProcessingMakernoteDirectory.class);
+                    TiffReader.processIfd(this, reader, processedIfdOffsets, tagOffset, tiffHeaderOffset);
+                    return true;
+                case OlympusMakernoteDirectory.TAG_FOCUS_INFO:
+                    pushDirectory(OlympusFocusInfoMakernoteDirectory.class);
                     TiffReader.processIfd(this, reader, processedIfdOffsets, tagOffset, tiffHeaderOffset);
                     return true;
             }

--- a/Source/com/drew/metadata/exif/ExifTiffHandler.java
+++ b/Source/com/drew/metadata/exif/ExifTiffHandler.java
@@ -109,6 +109,9 @@ public class ExifTiffHandler extends DirectoryTiffHandler
                 case OlympusMakernoteDirectory.TAG_RAW_DEVELOPMENT:
                     pushDirectory(OlympusRawDevelopmentMakernoteDirectory.class);
                     return true;
+                case OlympusMakernoteDirectory.TAG_RAW_DEVELOPMENT_2:
+                    pushDirectory(OlympusRawDevelopment2MakernoteDirectory.class);
+                    return true;
             }
         }
 
@@ -202,6 +205,10 @@ public class ExifTiffHandler extends DirectoryTiffHandler
                     return true;
                 case OlympusMakernoteDirectory.TAG_RAW_DEVELOPMENT:
                     pushDirectory(OlympusRawDevelopmentMakernoteDirectory.class);
+                    TiffReader.processIfd(this, reader, processedIfdOffsets, tagOffset, tiffHeaderOffset);
+                    return true;
+                case OlympusMakernoteDirectory.TAG_RAW_DEVELOPMENT_2:
+                    pushDirectory(OlympusRawDevelopment2MakernoteDirectory.class);
                     TiffReader.processIfd(this, reader, processedIfdOffsets, tagOffset, tiffHeaderOffset);
                     return true;
             }

--- a/Source/com/drew/metadata/exif/ExifTiffHandler.java
+++ b/Source/com/drew/metadata/exif/ExifTiffHandler.java
@@ -112,6 +112,9 @@ public class ExifTiffHandler extends DirectoryTiffHandler
                 case OlympusMakernoteDirectory.TAG_RAW_DEVELOPMENT_2:
                     pushDirectory(OlympusRawDevelopment2MakernoteDirectory.class);
                     return true;
+                case OlympusMakernoteDirectory.TAG_IMAGE_PROCESSING:
+                    pushDirectory(OlympusImageProcessingMakernoteDirectory.class);
+                    return true;
             }
         }
 
@@ -209,6 +212,10 @@ public class ExifTiffHandler extends DirectoryTiffHandler
                     return true;
                 case OlympusMakernoteDirectory.TAG_RAW_DEVELOPMENT_2:
                     pushDirectory(OlympusRawDevelopment2MakernoteDirectory.class);
+                    TiffReader.processIfd(this, reader, processedIfdOffsets, tagOffset, tiffHeaderOffset);
+                    return true;
+                case OlympusMakernoteDirectory.TAG_IMAGE_PROCESSING:
+                    pushDirectory(OlympusImageProcessingMakernoteDirectory.class);
                     TiffReader.processIfd(this, reader, processedIfdOffsets, tagOffset, tiffHeaderOffset);
                     return true;
             }

--- a/Source/com/drew/metadata/exif/ExifTiffHandler.java
+++ b/Source/com/drew/metadata/exif/ExifTiffHandler.java
@@ -118,6 +118,9 @@ public class ExifTiffHandler extends DirectoryTiffHandler
                 case OlympusMakernoteDirectory.TAG_FOCUS_INFO:
                     pushDirectory(OlympusFocusInfoMakernoteDirectory.class);
                     return true;
+                case OlympusMakernoteDirectory.TAG_RAW_INFO:
+                    pushDirectory(OlympusRawInfoMakernoteDirectory.class);
+                    return true;
             }
         }
 
@@ -223,6 +226,10 @@ public class ExifTiffHandler extends DirectoryTiffHandler
                     return true;
                 case OlympusMakernoteDirectory.TAG_FOCUS_INFO:
                     pushDirectory(OlympusFocusInfoMakernoteDirectory.class);
+                    TiffReader.processIfd(this, reader, processedIfdOffsets, tagOffset, tiffHeaderOffset);
+                    return true;
+                case OlympusMakernoteDirectory.TAG_RAW_INFO:
+                    pushDirectory(OlympusRawInfoMakernoteDirectory.class);
                     TiffReader.processIfd(this, reader, processedIfdOffsets, tagOffset, tiffHeaderOffset);
                     return true;
             }

--- a/Source/com/drew/metadata/exif/makernotes/OlympusCameraSettingsMakernoteDirectory.java
+++ b/Source/com/drew/metadata/exif/makernotes/OlympusCameraSettingsMakernoteDirectory.java
@@ -89,6 +89,7 @@ public class OlympusCameraSettingsMakernoteDirectory extends Directory
     public static final int TagPictureModeEffect = 0x52d;
     public static final int TagToneLevel = 0x52e;
     public static final int TagArtFilterEffect = 0x52f;
+    public static final int TagColorCreatorEffect = 0x532;
 
     public static final int TagDriveMode = 0x600;
     public static final int TagPanoramaMode = 0x601;
@@ -162,6 +163,7 @@ public class OlympusCameraSettingsMakernoteDirectory extends Directory
         _tagNameMap.put(TagPictureModeEffect, "Picture Mode Effect");
         _tagNameMap.put(TagToneLevel, "Tone Level");
         _tagNameMap.put(TagArtFilterEffect, "Art Filter Effect");
+        _tagNameMap.put(TagColorCreatorEffect, "Color Creator Effect");
 
         _tagNameMap.put(TagDriveMode, "Drive Mode");
         _tagNameMap.put(TagPanoramaMode, "Panorama Mode");

--- a/Source/com/drew/metadata/exif/makernotes/OlympusEquipmentMakernoteDescriptor.java
+++ b/Source/com/drew/metadata/exif/makernotes/OlympusEquipmentMakernoteDescriptor.java
@@ -54,6 +54,8 @@ public class OlympusEquipmentMakernoteDescriptor extends TagDescriptor<OlympusEq
         switch (tagType) {
             case TAG_EQUIPMENT_VERSION:
                 return getEquipmentVersionDescription();
+            case TAG_CAMERA_TYPE_2:
+                return getCameraType2Description();
             case TAG_FOCAL_PLANE_DIAGONAL:
                 return getFocalPlaneDiagonalDescription();
             case TAG_BODY_FIRMWARE_VERSION:
@@ -85,6 +87,19 @@ public class OlympusEquipmentMakernoteDescriptor extends TagDescriptor<OlympusEq
     public String getEquipmentVersionDescription()
     {
         return getVersionBytesDescription(TAG_EQUIPMENT_VERSION, 4);
+    }
+
+    @Nullable
+    public String getCameraType2Description()
+    {
+        String cameratype = _directory.getString(TAG_CAMERA_TYPE_2);
+        if(cameratype == null)
+            return null;
+
+        if(OlympusMakernoteDirectory.OlympusCameraTypes.containsKey(cameratype))
+            return OlympusMakernoteDirectory.OlympusCameraTypes.get(cameratype);
+
+        return cameratype;
     }
 
     @Nullable

--- a/Source/com/drew/metadata/exif/makernotes/OlympusFocusInfoMakernoteDescriptor.java
+++ b/Source/com/drew/metadata/exif/makernotes/OlympusFocusInfoMakernoteDescriptor.java
@@ -1,0 +1,217 @@
+/*
+ * Copyright 2002-2015 Drew Noakes
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ * More information about this project is available at:
+ *
+ *    https://drewnoakes.com/code/exif/
+ *    https://github.com/drewnoakes/metadata-extractor
+ */
+package com.drew.metadata.exif.makernotes;
+
+import com.drew.lang.Rational;
+import com.drew.lang.annotations.NotNull;
+import com.drew.lang.annotations.Nullable;
+import com.drew.metadata.TagDescriptor;
+
+import static com.drew.metadata.exif.makernotes.OlympusFocusInfoMakernoteDirectory.*;
+
+/**
+ * Provides human-readable String representations of tag values stored in a {@link OlympusFocusInfoMakernoteDirectory}.
+ * <p>
+ * Some Description functions converted from Exiftool version 10.10 created by Phil Harvey
+ * http://www.sno.phy.queensu.ca/~phil/exiftool/
+ * lib\Image\ExifTool\Olympus.pm
+ *
+ * @author Kevin Mott https://github.com/kwhopper
+ * @author Drew Noakes https://drewnoakes.com
+ */
+@SuppressWarnings("WeakerAccess")
+public class OlympusFocusInfoMakernoteDescriptor extends TagDescriptor<OlympusFocusInfoMakernoteDirectory>
+{
+    public OlympusFocusInfoMakernoteDescriptor(@NotNull OlympusFocusInfoMakernoteDirectory directory)
+    {
+        super(directory);
+    }
+
+    @Override
+    @Nullable
+    public String getDescription(int tagType)
+    {
+        switch (tagType) {
+            case TagFocusInfoVersion:
+                return getFocusInfoVersionDescription();
+            case TagAutoFocus:
+                return getAutoFocusDescription();
+            case TagFocusDistance:
+                return getFocusDistanceDescription();
+            case TagAfPoint:
+                return getAfPointDescription();
+            case TagExternalFlash:
+                return getExternalFlashDescription();
+            case TagExternalFlashBounce:
+                return getExternalFlashBounceDescription();
+            case TagExternalFlashZoom:
+                return getExternalFlashZoomDescription();
+            case TagManualFlash:
+                return getManualFlashDescription();
+            case TagMacroLed:
+                return getMacroLedDescription();
+            case TagSensorTemperature:
+                return getSensorTemperatureDescription();
+            case TagImageStabilization:
+                return getImageStabilizationDescription();
+            default:
+                return super.getDescription(tagType);
+        }
+    }
+
+    @Nullable
+    public String getFocusInfoVersionDescription()
+    {
+        return getVersionBytesDescription(TagFocusInfoVersion, 4);
+    }
+
+    @Nullable
+    public String getAutoFocusDescription()
+    {
+        return getIndexedDescription(TagAutoFocus,
+            "Off", "On");
+    }
+
+    @Nullable
+    public String getFocusDistanceDescription()
+    {
+        Rational value = _directory.getRational(TagFocusDistance);
+        if (value == null)
+            return "inf";
+        if (value.getNumerator() == 0xFFFFFFFF)
+            return "inf";
+
+        return value.getNumerator() / 1000.0 + " m";
+    }
+
+    @Nullable
+    public String getAfPointDescription()
+    {
+        Integer value = _directory.getInteger(TagAfPoint);
+        if (value == null)
+            return null;
+
+        return value.toString();
+    }
+
+    @Nullable
+    public String getExternalFlashDescription()
+    {
+        int[] values = _directory.getIntArray(TagExternalFlash);
+        if (values == null || values.length < 2)
+            return null;
+
+        String join = String.format("%d %d", (short)values[0], (short)values[1]);
+
+        if(join.equals("0 0"))
+            return "Off";
+        else if(join.equals("1 0"))
+            return "On";
+        else
+            return "Unknown (" + join + ")";
+    }
+
+    @Nullable
+    public String getExternalFlashBounceDescription()
+    {
+        return getIndexedDescription(TagExternalFlashBounce,
+                "Bounce or Off", "Direct");
+    }
+
+    @Nullable
+    public String getExternalFlashZoomDescription()
+    {
+        int[] values = _directory.getIntArray(TagExternalFlashZoom);
+        if (values == null)
+        {
+            // check if it's only one value long also
+            Integer value = _directory.getInteger(TagExternalFlashZoom);
+            if(value == null)
+                return null;
+
+            values = new int[1];
+            values[0] = value;
+        }
+
+        if (values.length == 0)
+            return null;
+
+        String join = String.format("%d", (short)values[0]);
+        if(values.length > 1)
+            join += " " + String.format("%d", (short)values[1]);
+
+        if(join.equals("0"))
+            return "Off";
+        else if(join.equals("1"))
+            return "On";
+        else if(join.equals("0 0"))
+            return "Off";
+        else if(join.equals("1 0"))
+            return "On";
+        else
+            return "Unknown (" + join + ")";
+
+    }
+
+    @Nullable
+    public String getManualFlashDescription()
+    {
+        int[] values = _directory.getIntArray(TagManualFlash);
+        if (values == null)
+            return null;
+
+        if ((short)values[0] == 0)
+            return "Off";
+
+        if ((short)values[1] == 1)
+            return "Full";
+        return "On " + 1.0 / (short)values[1] + " strength)";
+    }
+
+    @Nullable
+    public String getMacroLedDescription()
+    {
+        return getIndexedDescription(TagMacroLed,
+                "Off", "On");
+    }
+
+    /// <remarks>
+    /// <para>TODO: Complete when Camera Model is available.</para>
+    /// <para>There are differences in how to interpret this tag that can only be reconciled by knowing the model.</para>
+    /// </remarks>
+    @Nullable
+    public String getSensorTemperatureDescription()
+    {
+        return _directory.getString(TagSensorTemperature);
+    }
+
+    @Nullable
+    public String getImageStabilizationDescription()
+    {
+        byte[] values = _directory.getByteArray(TagImageStabilization);
+        if (values == null)
+            return null;
+
+        if((values[0] | values[1] | values[2] | values[3]) == 0x0)
+            return "Off";
+        return "On, " + ((values[43] & 1) > 0 ? "Mode 1" : "Mode 2");
+    }
+}

--- a/Source/com/drew/metadata/exif/makernotes/OlympusFocusInfoMakernoteDirectory.java
+++ b/Source/com/drew/metadata/exif/makernotes/OlympusFocusInfoMakernoteDirectory.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2002-2015 Drew Noakes
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ * More information about this project is available at:
+ *
+ *    https://drewnoakes.com/code/exif/
+ *    https://github.com/drewnoakes/metadata-extractor
+ */
+package com.drew.metadata.exif.makernotes;
+
+import com.drew.lang.annotations.NotNull;
+import com.drew.metadata.Directory;
+
+import java.util.HashMap;
+
+/**
+ * The Olympus focus info makernote is used by many manufacturers (Epson, Konica, Minolta and Agfa...), and as such contains some tags
+ * that appear specific to those manufacturers.
+ *
+ * @author Kevin Mott https://github.com/kwhopper
+ * @author Drew Noakes https://drewnoakes.com
+ */
+@SuppressWarnings("WeakerAccess")
+public class OlympusFocusInfoMakernoteDirectory extends Directory
+{
+    public static final int TagFocusInfoVersion = 0x0000;
+    public static final int TagAutoFocus = 0x0209;
+    public static final int TagSceneDetect = 0x0210;
+    public static final int TagSceneArea = 0x0211;
+    public static final int TagSceneDetectData = 0x0212;
+
+    public static final int TagZoomStepCount = 0x0300;
+    public static final int TagFocusStepCount = 0x0301;
+    public static final int TagFocusStepInfinity = 0x0303;
+    public static final int TagFocusStepNear = 0x0304;
+    public static final int TagFocusDistance = 0x0305;
+    public static final int TagAfPoint = 0x0308;
+    // 0x031a Continuous AF parameters?
+    public static final int TagAfInfo = 0x0328;    // ifd
+
+    public static final int TagExternalFlash = 0x1201;
+    public static final int TagExternalFlashGuideNumber = 0x1203;
+    public static final int TagExternalFlashBounce = 0x1204;
+    public static final int TagExternalFlashZoom = 0x1205;
+    public static final int TagInternalFlash = 0x1208;
+    public static final int TagManualFlash = 0x1209;
+    public static final int TagMacroLed = 0x120A;
+
+    public static final int TagSensorTemperature = 0x1500;
+
+    public static final int TagImageStabilization = 0x1600;
+
+    @NotNull
+    protected static final HashMap<Integer, String> _tagNameMap = new HashMap<Integer, String>();
+
+    static {
+        _tagNameMap.put(TagFocusInfoVersion, "Focus Info Version");
+        _tagNameMap.put(TagAutoFocus, "Auto Focus");
+        _tagNameMap.put(TagSceneDetect, "Scene Detect");
+        _tagNameMap.put(TagSceneArea, "Scene Area");
+        _tagNameMap.put(TagSceneDetectData, "Scene Detect Data");
+        _tagNameMap.put(TagZoomStepCount, "Zoom Step Count");
+        _tagNameMap.put(TagFocusStepCount, "Focus Step Count");
+        _tagNameMap.put(TagFocusStepInfinity, "Focus Step Infinity");
+        _tagNameMap.put(TagFocusStepNear, "Focus Step Near");
+        _tagNameMap.put(TagFocusDistance, "Focus Distance");
+        _tagNameMap.put(TagAfPoint, "AF Point");
+        _tagNameMap.put(TagAfInfo, "AF Info");
+        _tagNameMap.put(TagExternalFlash, "External Flash");
+        _tagNameMap.put(TagExternalFlashGuideNumber, "External Flash Guide Number");
+        _tagNameMap.put(TagExternalFlashBounce, "External Flash Bounce");
+        _tagNameMap.put(TagExternalFlashZoom, "External Flash Zoom");
+        _tagNameMap.put(TagInternalFlash, "Internal Flash");
+        _tagNameMap.put(TagManualFlash, "Manual Flash");
+        _tagNameMap.put(TagMacroLed, "Macro LED");
+        _tagNameMap.put(TagSensorTemperature, "Sensor Temperature");
+        _tagNameMap.put(TagImageStabilization, "Image Stabilization");
+    }
+
+    public OlympusFocusInfoMakernoteDirectory()
+    {
+        this.setDescriptor(new OlympusFocusInfoMakernoteDescriptor(this));
+    }
+
+    @Override
+    @NotNull
+    public String getName()
+    {
+        return "Olympus Focus Info";
+    }
+
+    @Override
+    @NotNull
+    protected HashMap<Integer, String> getTagNameMap()
+    {
+        return _tagNameMap;
+    }
+}

--- a/Source/com/drew/metadata/exif/makernotes/OlympusImageProcessingMakernoteDescriptor.java
+++ b/Source/com/drew/metadata/exif/makernotes/OlympusImageProcessingMakernoteDescriptor.java
@@ -1,0 +1,240 @@
+/*
+ * Copyright 2002-2015 Drew Noakes
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ * More information about this project is available at:
+ *
+ *    https://drewnoakes.com/code/exif/
+ *    https://github.com/drewnoakes/metadata-extractor
+ */
+package com.drew.metadata.exif.makernotes;
+
+import com.drew.lang.annotations.NotNull;
+import com.drew.lang.annotations.Nullable;
+import com.drew.metadata.TagDescriptor;
+
+import static com.drew.metadata.exif.makernotes.OlympusImageProcessingMakernoteDirectory.*;
+
+/**
+ * Provides human-readable String representations of tag values stored in a {@link OlympusImageProcessingMakernoteDirectory}.
+ * <p>
+ * Some Description functions converted from Exiftool version 10.33 created by Phil Harvey
+ * http://www.sno.phy.queensu.ca/~phil/exiftool/
+ * lib\Image\ExifTool\Olympus.pm
+ *
+ * @author Kevin Mott https://github.com/kwhopper
+ * @author Drew Noakes https://drewnoakes.com
+ */
+@SuppressWarnings("WeakerAccess")
+public class OlympusImageProcessingMakernoteDescriptor extends TagDescriptor<OlympusImageProcessingMakernoteDirectory>
+{
+    public OlympusImageProcessingMakernoteDescriptor(@NotNull OlympusImageProcessingMakernoteDirectory directory)
+    {
+        super(directory);
+    }
+
+    @Override
+    @Nullable
+    public String getDescription(int tagType)
+    {
+        switch (tagType) {
+            case TagImageProcessingVersion:
+                return getImageProcessingVersionDescription();
+            case TagColorMatrix:
+                return getColorMatrixDescription();
+            case TagNoiseReduction2:
+                return getNoiseReduction2Description();
+            case TagDistortionCorrection2:
+                return getDistortionCorrection2Description();
+            case TagShadingCompensation2:
+                return getShadingCompensation2Description();
+            case TagMultipleExposureMode:
+                return getMultipleExposureModeDescription();
+            case TagAspectRatio:
+                return getAspectRatioDescription();
+            case TagKeystoneCompensation:
+                return getKeystoneCompensationDescription();
+            case TagKeystoneDirection:
+                return getKeystoneDirectionDescription();
+            default:
+                return super.getDescription(tagType);
+        }
+    }
+
+    @Nullable
+    public String getImageProcessingVersionDescription()
+    {
+        return getVersionBytesDescription(TagImageProcessingVersion, 4);
+    }
+
+    @Nullable
+    public String getColorMatrixDescription()
+    {
+        int[] obj = _directory.getIntArray(TagColorMatrix);
+        if (obj == null)
+            return null;
+
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < obj.length; i++) {
+            if (i != 0)
+                sb.append(" ");
+            sb.append((short)obj[i]);
+        }
+        return sb.toString();
+    }
+
+    @Nullable
+    public String getNoiseReduction2Description()
+    {
+        Integer value = _directory.getInteger(TagNoiseReduction2);
+        if (value == null)
+            return null;
+
+        if (value == 0)
+            return "(none)";
+
+        StringBuilder sb = new StringBuilder();
+        short v = value.shortValue();
+
+        if (( v       & 1) != 0) sb.append("Noise Reduction, ");
+        if (((v >> 1) & 1) != 0) sb.append("Noise Filter, ");
+        if (((v >> 2) & 1) != 0) sb.append("Noise Filter (ISO Boost), ");
+
+        return sb.substring(0, sb.length() - 2);
+    }
+
+    @Nullable
+    public String getDistortionCorrection2Description()
+    {
+        return getIndexedDescription(TagDistortionCorrection2, "Off", "On");
+    }
+
+    @Nullable
+    public String getShadingCompensation2Description()
+    {
+        return getIndexedDescription(TagShadingCompensation2, "Off", "On");
+    }
+
+    @Nullable
+    public String getMultipleExposureModeDescription()
+    {
+        int[] values = _directory.getIntArray(TagMultipleExposureMode);
+        if (values == null)
+        {
+            // check if it's only one value long also
+            Integer value = _directory.getInteger(TagMultipleExposureMode);
+            if(value == null)
+                return null;
+
+            values = new int[1];
+            values[0] = value;
+        }
+
+        if (values.length == 0)
+            return null;
+
+        StringBuilder sb = new StringBuilder();
+
+        switch ((short)values[0])
+        {
+            case 0:
+                sb.append("Off");
+                break;
+            case 2:
+                sb.append("On (2 frames)");
+                break;
+            case 3:
+                sb.append("On (3 frames)");
+                break;
+            default:
+                sb.append("Unknown (").append((short)values[0]).append(")");
+                break;
+        }
+
+        if (values.length > 1)
+            sb.append("; ").append((short)values[1]);
+
+        return sb.toString();
+    }
+
+    @Nullable
+    public String getAspectRatioDescription()
+    {
+        byte[] values = _directory.getByteArray(TagAspectRatio);
+        if (values == null || values.length < 2)
+            return null;
+
+        String join = String.format("%d %d", values[0], values[1]);
+
+        String ret;
+        if(join.equals("1 1"))
+            ret = "4:3";
+        else if(join.equals("1 4"))
+            ret = "1:1";
+        else if(join.equals("2 1"))
+            ret = "3:2 (RAW)";
+        else if(join.equals("2 2"))
+            ret = "3:2";
+        else if(join.equals("3 1"))
+            ret = "16:9 (RAW)";
+        else if(join.equals("3 3"))
+            ret = "16:9";
+        else if(join.equals("4 1"))
+            ret = "1:1 (RAW)";
+        else if(join.equals("4 4"))
+            ret = "6:6";
+        else if(join.equals("5 5"))
+            ret = "5:4";
+        else if(join.equals("6 6"))
+            ret = "7:6";
+        else if(join.equals("7 7"))
+            ret = "6:5";
+        else if(join.equals("8 8"))
+            ret = "7:5";
+        else if(join.equals("9 1"))
+            ret = "3:4 (RAW)";
+        else if(join.equals("9 9"))
+            ret = "3:4";
+        else
+            ret = "Unknown (" + join + ")";
+
+        return ret;
+    }
+
+    @Nullable
+    public String getKeystoneCompensationDescription()
+    {
+        byte[] values = _directory.getByteArray(TagKeystoneCompensation);
+        if (values == null || values.length < 2)
+            return null;
+
+        String join = String.format("%d %d", values[0], values[1]);
+
+        String ret;
+        if(join.equals("0 0"))
+            ret = "Off";
+        else if(join.equals("0 1"))
+            ret = "On";
+        else
+            ret = "Unknown (" + join + ")";
+
+        return ret;
+    }
+
+    @Nullable
+    public String getKeystoneDirectionDescription()
+    {
+        return getIndexedDescription(TagKeystoneDirection, "Vertical", "Horizontal");
+    }
+}

--- a/Source/com/drew/metadata/exif/makernotes/OlympusImageProcessingMakernoteDirectory.java
+++ b/Source/com/drew/metadata/exif/makernotes/OlympusImageProcessingMakernoteDirectory.java
@@ -1,0 +1,212 @@
+/*
+ * Copyright 2002-2015 Drew Noakes
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ * More information about this project is available at:
+ *
+ *    https://drewnoakes.com/code/exif/
+ *    https://github.com/drewnoakes/metadata-extractor
+ */
+package com.drew.metadata.exif.makernotes;
+
+import com.drew.lang.annotations.NotNull;
+import com.drew.metadata.Directory;
+
+import java.util.HashMap;
+
+/**
+ * The Olympus image processing makernote is used by many manufacturers (Epson, Konica, Minolta and Agfa...), and as such contains some tags
+ * that appear specific to those manufacturers.
+ *
+ * @author Kevin Mott https://github.com/kwhopper
+ * @author Drew Noakes https://drewnoakes.com
+ */
+@SuppressWarnings("WeakerAccess")
+public class OlympusImageProcessingMakernoteDirectory extends Directory
+{
+    public static final int TagImageProcessingVersion = 0x0000;
+    public static final int TagWbRbLevels = 0x0100;
+    // 0x0101 - in-camera AutoWB unless it is all 0's or all 256's (ref IB)
+    public static final int TagWbRbLevels3000K = 0x0102;
+    public static final int TagWbRbLevels3300K = 0x0103;
+    public static final int TagWbRbLevels3600K = 0x0104;
+    public static final int TagWbRbLevels3900K = 0x0105;
+    public static final int TagWbRbLevels4000K = 0x0106;
+    public static final int TagWbRbLevels4300K = 0x0107;
+    public static final int TagWbRbLevels4500K = 0x0108;
+    public static final int TagWbRbLevels4800K = 0x0109;
+    public static final int TagWbRbLevels5300K = 0x010a;
+    public static final int TagWbRbLevels6000K = 0x010b;
+    public static final int TagWbRbLevels6600K = 0x010c;
+    public static final int TagWbRbLevels7500K = 0x010d;
+    public static final int TagWbRbLevelsCwB1 = 0x010e;
+    public static final int TagWbRbLevelsCwB2 = 0x010f;
+    public static final int TagWbRbLevelsCwB3 = 0x0110;
+    public static final int TagWbRbLevelsCwB4 = 0x0111;
+    public static final int TagWbGLevel3000K = 0x0113;
+    public static final int TagWbGLevel3300K = 0x0114;
+    public static final int TagWbGLevel3600K = 0x0115;
+    public static final int TagWbGLevel3900K = 0x0116;
+    public static final int TagWbGLevel4000K = 0x0117;
+    public static final int TagWbGLevel4300K = 0x0118;
+    public static final int TagWbGLevel4500K = 0x0119;
+    public static final int TagWbGLevel4800K = 0x011a;
+    public static final int TagWbGLevel5300K = 0x011b;
+    public static final int TagWbGLevel6000K = 0x011c;
+    public static final int TagWbGLevel6600K = 0x011d;
+    public static final int TagWbGLevel7500K = 0x011e;
+    public static final int TagWbGLevel = 0x011f;
+    // 0x0121 = WB preset for flash (about 6000K) (ref IB)
+    // 0x0125 = WB preset for underwater (ref IB)
+
+    public static final int TagColorMatrix = 0x0200;
+    // color matrices (ref 11):
+    // 0x0201-0x020d are sRGB color matrices
+    // 0x020e-0x021a are Adobe RGB color matrices
+    // 0x021b-0x0227 are ProPhoto RGB color matrices
+    // 0x0228 and 0x0229 are ColorMatrix for E-330
+    // 0x0250-0x0252 are sRGB color matrices
+    // 0x0253-0x0255 are Adobe RGB color matrices
+    // 0x0256-0x0258 are ProPhoto RGB color matrices
+
+    public static final int TagEnhancer = 0x0300;
+    public static final int TagEnhancerValues = 0x0301;
+    public static final int TagCoringFilter = 0x0310;
+    public static final int TagCoringValues = 0x0311;
+    public static final int TagBlackLevel2 = 0x0600;
+    public static final int TagGainBase = 0x0610;
+    public static final int TagValidBits = 0x0611;
+    public static final int TagCropLeft = 0x0612;
+    public static final int TagCropTop = 0x0613;
+    public static final int TagCropWidth = 0x0614;
+    public static final int TagCropHeight = 0x0615;
+    public static final int TagUnknownBlock1 = 0x0635;
+    public static final int TagUnknownBlock2 = 0x0636;
+
+    // 0x0800 LensDistortionParams, float[9] (ref 11)
+    // 0x0801 LensShadingParams, int16u[16] (ref 11)
+    public static final int TagSensorCalibration = 0x0805;
+
+    public static final int TagNoiseReduction2 = 0x1010;
+    public static final int TagDistortionCorrection2 = 0x1011;
+    public static final int TagShadingCompensation2 = 0x1012;
+    public static final int TagMultipleExposureMode = 0x101c;
+    public static final int TagUnknownBlock3 = 0x1103;
+    public static final int TagUnknownBlock4 = 0x1104;
+    public static final int TagAspectRatio = 0x1112;
+    public static final int TagAspectFrame = 0x1113;
+    public static final int TagFacesDetected = 0x1200;
+    public static final int TagFaceDetectArea = 0x1201;
+    public static final int TagMaxFaces = 0x1202;
+    public static final int TagFaceDetectFrameSize = 0x1203;
+    public static final int TagFaceDetectFrameCrop = 0x1207;
+    public static final int TagCameraTemperature = 0x1306;
+
+    public static final int TagKeystoneCompensation = 0x1900;
+    public static final int TagKeystoneDirection = 0x1901;
+    // 0x1905 - focal length (PH, E-M1)
+    public static final int TagKeystoneValue = 0x1906;
+
+    @NotNull
+    protected static final HashMap<Integer, String> _tagNameMap = new HashMap<Integer, String>();
+
+    static {
+        _tagNameMap.put(TagImageProcessingVersion, "Image Processing Version");
+        _tagNameMap.put(TagWbRbLevels, "WB RB Levels");
+        _tagNameMap.put(TagWbRbLevels3000K, "WB RB Levels 3000K");
+        _tagNameMap.put(TagWbRbLevels3300K, "WB RB Levels 3300K");
+        _tagNameMap.put(TagWbRbLevels3600K, "WB RB Levels 3600K");
+        _tagNameMap.put(TagWbRbLevels3900K, "WB RB Levels 3900K");
+        _tagNameMap.put(TagWbRbLevels4000K, "WB RB Levels 4000K");
+        _tagNameMap.put(TagWbRbLevels4300K, "WB RB Levels 4300K");
+        _tagNameMap.put(TagWbRbLevels4500K, "WB RB Levels 4500K");
+        _tagNameMap.put(TagWbRbLevels4800K, "WB RB Levels 4800K");
+        _tagNameMap.put(TagWbRbLevels5300K, "WB RB Levels 5300K");
+        _tagNameMap.put(TagWbRbLevels6000K, "WB RB Levels 6000K");
+        _tagNameMap.put(TagWbRbLevels6600K, "WB RB Levels 6600K");
+        _tagNameMap.put(TagWbRbLevels7500K, "WB RB Levels 7500K");
+        _tagNameMap.put(TagWbRbLevelsCwB1, "WB RB Levels CWB1");
+        _tagNameMap.put(TagWbRbLevelsCwB2, "WB RB Levels CWB2");
+        _tagNameMap.put(TagWbRbLevelsCwB3, "WB RB Levels CWB3");
+        _tagNameMap.put(TagWbRbLevelsCwB4, "WB RB Levels CWB4");
+        _tagNameMap.put(TagWbGLevel3000K, "WB G Level 3000K");
+        _tagNameMap.put(TagWbGLevel3300K, "WB G Level 3300K");
+        _tagNameMap.put(TagWbGLevel3600K, "WB G Level 3600K");
+        _tagNameMap.put(TagWbGLevel3900K, "WB G Level 3900K");
+        _tagNameMap.put(TagWbGLevel4000K, "WB G Level 4000K");
+        _tagNameMap.put(TagWbGLevel4300K, "WB G Level 4300K");
+        _tagNameMap.put(TagWbGLevel4500K, "WB G Level 4500K");
+        _tagNameMap.put(TagWbGLevel4800K, "WB G Level 4800K");
+        _tagNameMap.put(TagWbGLevel5300K, "WB G Level 5300K");
+        _tagNameMap.put(TagWbGLevel6000K, "WB G Level 6000K");
+        _tagNameMap.put(TagWbGLevel6600K, "WB G Level 6600K");
+        _tagNameMap.put(TagWbGLevel7500K, "WB G Level 7500K");
+        _tagNameMap.put(TagWbGLevel, "WB G Level");
+
+        _tagNameMap.put(TagColorMatrix, "Color Matrix");
+
+        _tagNameMap.put(TagEnhancer, "Enhancer");
+        _tagNameMap.put(TagEnhancerValues, "Enhancer Values");
+        _tagNameMap.put(TagCoringFilter, "Coring Filter");
+        _tagNameMap.put(TagCoringValues, "Coring Values");
+        _tagNameMap.put(TagBlackLevel2, "Black Level 2");
+        _tagNameMap.put(TagGainBase, "Gain Base");
+        _tagNameMap.put(TagValidBits, "Valid Bits");
+        _tagNameMap.put(TagCropLeft, "Crop Left");
+        _tagNameMap.put(TagCropTop, "Crop Top");
+        _tagNameMap.put(TagCropWidth, "Crop Width");
+        _tagNameMap.put(TagCropHeight, "Crop Height");
+        _tagNameMap.put(TagUnknownBlock1, "Unknown Block 1");
+        _tagNameMap.put(TagUnknownBlock2, "Unknown Block 2");
+
+        _tagNameMap.put(TagSensorCalibration, "Sensor Calibration");
+
+        _tagNameMap.put(TagNoiseReduction2, "Noise Reduction 2");
+        _tagNameMap.put(TagDistortionCorrection2, "Distortion Correction 2");
+        _tagNameMap.put(TagShadingCompensation2, "Shading Compensation 2");
+        _tagNameMap.put(TagMultipleExposureMode, "Multiple Exposure Mode");
+        _tagNameMap.put(TagUnknownBlock3, "Unknown Block 3");
+        _tagNameMap.put(TagUnknownBlock4, "Unknown Block 4");
+        _tagNameMap.put(TagAspectRatio, "Aspect Ratio");
+        _tagNameMap.put(TagAspectFrame, "Aspect Frame");
+        _tagNameMap.put(TagFacesDetected, "Faces Detected");
+        _tagNameMap.put(TagFaceDetectArea, "Face Detect Area");
+        _tagNameMap.put(TagMaxFaces, "Max Faces");
+        _tagNameMap.put(TagFaceDetectFrameSize, "Face Detect Frame Size");
+        _tagNameMap.put(TagFaceDetectFrameCrop, "Face Detect Frame Crop");
+        _tagNameMap.put(TagCameraTemperature , "Camera Temperature");
+        _tagNameMap.put(TagKeystoneCompensation, "Keystone Compensation");
+        _tagNameMap.put(TagKeystoneDirection, "Keystone Direction");
+        _tagNameMap.put(TagKeystoneValue, "Keystone Value");
+    }
+
+    public OlympusImageProcessingMakernoteDirectory()
+    {
+        this.setDescriptor(new OlympusImageProcessingMakernoteDescriptor(this));
+    }
+
+    @Override
+    @NotNull
+    public String getName()
+    {
+        return "Olympus Image Processing";
+    }
+
+    @Override
+    @NotNull
+    protected HashMap<Integer, String> getTagNameMap()
+    {
+        return _tagNameMap;
+    }
+}

--- a/Source/com/drew/metadata/exif/makernotes/OlympusMakernoteDescriptor.java
+++ b/Source/com/drew/metadata/exif/makernotes/OlympusMakernoteDescriptor.java
@@ -20,7 +20,10 @@
  */
 package com.drew.metadata.exif.makernotes;
 
+import com.drew.imaging.PhotographicConversions;
+import com.drew.lang.Rational;
 import com.drew.lang.DateUtil;
+import com.drew.lang.StringUtil;
 import com.drew.lang.annotations.NotNull;
 import com.drew.lang.annotations.Nullable;
 import com.drew.metadata.TagDescriptor;
@@ -29,6 +32,7 @@ import java.math.RoundingMode;
 import java.text.DecimalFormat;
 
 import static com.drew.metadata.exif.makernotes.OlympusMakernoteDirectory.*;
+import java.lang.reflect.Array;
 
 /**
  * Provides human-readable string representations of tag values stored in a {@link OlympusMakernoteDirectory}.
@@ -66,10 +70,22 @@ public class OlympusMakernoteDescriptor extends TagDescriptor<OlympusMakernoteDi
                 return getMacroModeDescription();
             case TAG_BW_MODE:
                 return getBWModeDescription();
-            case TAG_DIGI_ZOOM_RATIO:
-                return getDigiZoomRatioDescription();
+            case TAG_DIGITAL_ZOOM:
+                return getDigitalZoomDescription();
+            case TAG_FOCAL_PLANE_DIAGONAL:
+                return getFocalPlaneDiagonalDescription();
+            case TAG_CAMERA_TYPE:
+                return getCameraTypeDescription();
             case TAG_CAMERA_ID:
                 return getCameraIdDescription();
+            case TAG_ONE_TOUCH_WB:
+                return getOneTouchWbDescription();
+            case TAG_SHUTTER_SPEED_VALUE:
+                return getShutterSpeedDescription();
+            case TAG_ISO_VALUE:
+                return getIsoValueDescription();
+            case TAG_APERTURE_VALUE:
+                return getApertureValueDescription();
             case TAG_FLASH_MODE:
                 return getFlashModeDescription();
             case TAG_FOCUS_RANGE:
@@ -78,6 +94,18 @@ public class OlympusMakernoteDescriptor extends TagDescriptor<OlympusMakernoteDi
                 return getFocusModeDescription();
             case TAG_SHARPNESS:
                 return getSharpnessDescription();
+            case TAG_COLOUR_MATRIX:
+                return getColorMatrixDescription();
+            case TAG_WB_MODE:
+                return getWbModeDescription();
+            case TAG_RED_BALANCE:
+                return getRedBalanceDescription();
+            case TAG_BLUE_BALANCE:
+                return getBlueBalanceDescription();
+            case TAG_CONTRAST:
+                return getContrastDescription();
+            case TAG_PREVIEW_IMAGE_VALID:
+                return getPreviewImageValidDescription();
 
             case CameraSettings.TAG_EXPOSURE_MODE:
                 return getExposureModeDescription();
@@ -102,7 +130,7 @@ public class OlympusMakernoteDescriptor extends TagDescriptor<OlympusMakernoteDi
             case CameraSettings.TAG_MACRO_MODE:
                 return getMacroModeCameraSettingDescription();
             case CameraSettings.TAG_DIGITAL_ZOOM:
-                return getDigitalZoomDescription();
+                return getDigitalZoomCameraSettingDescription();
             case CameraSettings.TAG_EXPOSURE_COMPENSATION:
                 return getExposureCompensationDescription();
             case CameraSettings.TAG_BRACKET_STEP:
@@ -138,7 +166,7 @@ public class OlympusMakernoteDescriptor extends TagDescriptor<OlympusMakernoteDi
             case CameraSettings.TAG_SATURATION:
                 return getSaturationDescription();
             case CameraSettings.TAG_CONTRAST:
-                return getContrastDescription();
+                return getContrastCameraSettingDescription();
             case CameraSettings.TAG_SHARPNESS:
                 return getSharpnessCameraSettingDescription();
             case CameraSettings.TAG_SUBJECT_PROGRAM:
@@ -305,7 +333,7 @@ public class OlympusMakernoteDescriptor extends TagDescriptor<OlympusMakernoteDi
     }
 
     @Nullable
-    public String getDigitalZoomDescription()
+    public String getDigitalZoomCameraSettingDescription()
     {
         return getIndexedDescription(CameraSettings.TAG_DIGITAL_ZOOM, "Off", "Electronic magnification", "Digital zoom 2x");
     }
@@ -468,7 +496,7 @@ public class OlympusMakernoteDescriptor extends TagDescriptor<OlympusMakernoteDi
     }
 
     @Nullable
-    public String getContrastDescription()
+    public String getContrastCameraSettingDescription()
     {
         Long value = _directory.getLongObject(CameraSettings.TAG_CONTRAST);
         return value == null ? null : Long.toString(value-3);
@@ -647,6 +675,94 @@ public class OlympusMakernoteDescriptor extends TagDescriptor<OlympusMakernoteDi
     }
 
     @Nullable
+    public String getColorMatrixDescription()
+    {
+        int[] obj = _directory.getIntArray(TAG_COLOUR_MATRIX);
+        if (obj == null)
+            return null;
+
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < obj.length; i++) {
+            sb.append((short)obj[i]);
+            if (i < obj.length - 1)
+                sb.append(" ");
+        }
+        return sb.length() == 0 ? null : sb.toString();
+    }
+
+    @Nullable
+    public String getWbModeDescription()
+    {
+        Object obj = _directory.getObject(TAG_WB_MODE);
+        if (obj == null || !(obj instanceof short[]))
+            return null;
+
+        short[] objshort = (short[])obj;
+        String val = String.format("%d %d", objshort[0], objshort[1]);
+
+        if(val.equals("1 0"))
+            return "Auto";
+        else if(val.equals("1 2"))
+            return "Auto (2)";
+        else if(val.equals("1 4"))
+            return "Auto (4)";
+        else if(val.equals("2 2"))
+            return "3000 Kelvin";
+        else if(val.equals("2 3"))
+            return "3700 Kelvin";
+        else if(val.equals("2 4"))
+            return "4000 Kelvin";
+        else if(val.equals("2 5"))
+            return "4500 Kelvin";
+        else if(val.equals("2 6"))
+            return "5500 Kelvin";
+        else if(val.equals("2 7"))
+            return "6500 Kelvin";
+        else if(val.equals("2 8"))
+            return "7500 Kelvin";
+        else if(val.equals("3 0"))
+            return "One-touch";
+        else
+            return "Unknown " + val;
+    }
+
+    @Nullable
+    public String getRedBalanceDescription()
+    {
+        int[] values = _directory.getIntArray(TAG_RED_BALANCE);
+        if (values == null)
+            return null;
+
+        Short uintvalue = (short)values[0];
+
+        return uintvalue == null ? null : String.valueOf((float)uintvalue/256d);
+    }
+
+    @Nullable
+    public String getBlueBalanceDescription()
+    {
+        int[] values = _directory.getIntArray(TAG_BLUE_BALANCE);
+        if (values == null)
+            return null;
+
+        Short uintvalue = (short)values[0];
+
+        return uintvalue == null ? null : String.valueOf((float)uintvalue/256d);
+    }
+
+    @Nullable
+    public String getContrastDescription()
+    {
+        return getIndexedDescription(TAG_CONTRAST, "High", "Normal", "Low");
+    }
+
+    @Nullable
+    public String getPreviewImageValidDescription()
+    {
+        return getIndexedDescription(TAG_PREVIEW_IMAGE_VALID, "No", "Yes");
+    }
+
+    @Nullable
     public String getFocusModeDescription()
     {
         return getIndexedDescription(TAG_FOCUS_MODE, "Auto", "Manual");
@@ -665,9 +781,36 @@ public class OlympusMakernoteDescriptor extends TagDescriptor<OlympusMakernoteDi
     }
 
     @Nullable
-    public String getDigiZoomRatioDescription()
+    public String getDigitalZoomDescription()
     {
-        return getIndexedDescription(TAG_DIGI_ZOOM_RATIO, "Normal", null, "Digital 2x Zoom");
+        Rational value = _directory.getRational(TAG_DIGITAL_ZOOM);
+        if (value == null)
+            return null;
+        return value.toSimpleString(false);
+    }
+
+    @Nullable
+    public String getFocalPlaneDiagonalDescription()
+    {
+        Rational value = _directory.getRational(TAG_FOCAL_PLANE_DIAGONAL);
+        if (value == null)
+            return null;
+
+        DecimalFormat format = new DecimalFormat("0.###");
+        return format.format(value.doubleValue()) + " mm";
+    }
+
+    @Nullable
+    public String getCameraTypeDescription()
+    {
+        String cameratype = _directory.getString(TAG_CAMERA_TYPE);
+        if(cameratype == null)
+            return null;
+
+        if(OlympusMakernoteDirectory.OlympusCameraTypes.containsKey(cameratype))
+            return OlympusMakernoteDirectory.OlympusCameraTypes.get(cameratype);
+
+        return cameratype;
     }
 
     @Nullable
@@ -677,6 +820,38 @@ public class OlympusMakernoteDescriptor extends TagDescriptor<OlympusMakernoteDi
         if (bytes == null)
             return null;
         return new String(bytes);
+    }
+
+    @Nullable
+    public String getOneTouchWbDescription()
+    {
+        return getIndexedDescription(TAG_ONE_TOUCH_WB, "Off", "On", "On (Preset)");
+    }
+
+    @Nullable
+    public String getShutterSpeedDescription()
+    {
+        return super.getShutterSpeedDescription(TAG_SHUTTER_SPEED_VALUE);
+    }
+
+    @Nullable
+    public String getIsoValueDescription()
+    {
+        Rational value = _directory.getRational(TAG_ISO_VALUE);
+        if (value == null)
+            return null;
+
+        return String.valueOf(Math.round(Math.pow(2, value.doubleValue() - 5) * 100));
+    }
+
+    @Nullable
+    public String getApertureValueDescription()
+    {
+        Double aperture = _directory.getDoubleObject(TAG_APERTURE_VALUE);
+        if (aperture == null)
+            return null;
+        double fStop = PhotographicConversions.apertureToFStop(aperture);
+        return getFStopDescription(fStop);
     }
 
     @Nullable
@@ -694,7 +869,56 @@ public class OlympusMakernoteDescriptor extends TagDescriptor<OlympusMakernoteDi
     @Nullable
     public String getJpegQualityDescription()
     {
-        return getIndexedDescription(TAG_JPEG_QUALITY,
+        String cameratype = _directory.getString(TAG_CAMERA_TYPE);
+
+        if(cameratype != null)
+        {
+            Integer value = _directory.getInteger(TAG_JPEG_QUALITY);
+            if(value == null)
+                return null;
+
+            if((cameratype.startsWith("SX") && !cameratype.startsWith("SX151"))
+                || cameratype.startsWith("D4322"))
+            {
+                switch (value)
+                {
+                    case 0:
+                        return "Standard Quality (Low)";
+                    case 1:
+                        return "High Quality (Normal)";
+                    case 2:
+                        return "Super High Quality (Fine)";
+                    case 6:
+                        return "RAW";
+                    default:
+                        return "Unknown (" + value.toString() + ")";
+                }
+            }
+            else
+            {
+                switch (value)
+                {
+                    case 0:
+                        return "Standard Quality (Low)";
+                    case 1:
+                        return "High Quality (Normal)";
+                    case 2:
+                        return "Super High Quality (Fine)";
+                    case 4:
+                        return "RAW";
+                    case 5:
+                        return "Medium-Fine";
+                    case 6:
+                        return "Small-Fine";
+                    case 33:
+                        return "Uncompressed";
+                    default:
+                        return "Unknown (" + value.toString() + ")";
+                }
+            }
+        }
+        else
+            return getIndexedDescription(TAG_JPEG_QUALITY,
             1,
             "Standard Quality",
             "High Quality",

--- a/Source/com/drew/metadata/exif/makernotes/OlympusMakernoteDirectory.java
+++ b/Source/com/drew/metadata/exif/makernotes/OlympusMakernoteDirectory.java
@@ -117,10 +117,10 @@ public class OlympusMakernoteDirectory extends Directory
     public static final int TAG_BW_MODE = 0x0203;
 
     /** Zoom Factor (0 or 1 = normal) */
-    public static final int TAG_DIGI_ZOOM_RATIO = 0x0204;
+    public static final int TAG_DIGITAL_ZOOM = 0x0204;
     public static final int TAG_FOCAL_PLANE_DIAGONAL = 0x0205;
     public static final int TAG_LENS_DISTORTION_PARAMETERS = 0x0206;
-    public static final int TAG_FIRMWARE_VERSION = 0x0207;
+    public static final int TAG_CAMERA_TYPE = 0x0207;
     public static final int TAG_PICT_INFO = 0x0208;
     public static final int TAG_CAMERA_ID = 0x0209;
 
@@ -146,7 +146,8 @@ public class OlympusMakernoteDirectory extends Directory
     public static final int TAG_WHITE_BALANCE_BRACKET = 0x0303;
     public static final int TAG_WHITE_BALANCE_BIAS = 0x0304;
     public static final int TAG_SCENE_MODE = 0x0403;
-    public static final int TAG_FIRMWARE = 0x0404;
+    public static final int TAG_SERIAL_NUMBER_1 = 0x0404;
+    public static final int TAG_FIRMWARE = 0x0405;
 
     /**
      * See the PIM specification here:
@@ -176,25 +177,27 @@ public class OlympusMakernoteDirectory extends Directory
     public static final int TAG_FLASH_CHARGE_LEVEL = 0x1010;
     public static final int TAG_COLOUR_MATRIX = 0x1011;
     public static final int TAG_BLACK_LEVEL = 0x1012;
-//    public static final int TAG_ = 0x1013;
-//    public static final int TAG_ = 0x1014;
-    public static final int TAG_WHITE_BALANCE = 0x1015;
+    public static final int TAG_COLOR_TEMPERATURE_BG = 0x1013;
+    public static final int TAG_COLOR_TEMPERATURE_RG = 0x1014;
+    public static final int TAG_WB_MODE = 0x1015;
 //    public static final int TAG_ = 0x1016;
-    public static final int TAG_RED_BIAS = 0x1017;
-    public static final int TAG_BLUE_BIAS = 0x1018;
+    public static final int TAG_RED_BALANCE = 0x1017;
+    public static final int TAG_BLUE_BALANCE = 0x1018;
     public static final int TAG_COLOR_MATRIX_NUMBER = 0x1019;
-    public static final int TAG_SERIAL_NUMBER = 0x101A;
-//    public static final int TAG_ = 0x101B;
-//    public static final int TAG_ = 0x101C;
-//    public static final int TAG_ = 0x101D;
-//    public static final int TAG_ = 0x101E;
-//    public static final int TAG_ = 0x101F;
-//    public static final int TAG_ = 0x1020;
-//    public static final int TAG_ = 0x1021;
-//    public static final int TAG_ = 0x1022;
+    public static final int TAG_SERIAL_NUMBER_2 = 0x101A;
+
+    public static final int TAG_EXTERNAL_FLASH_AE1_0 = 0x101B;
+    public static final int TAG_EXTERNAL_FLASH_AE2_0 = 0x101C;
+    public static final int TAG_INTERNAL_FLASH_AE1_0 = 0x101D;
+    public static final int TAG_INTERNAL_FLASH_AE2_0 = 0x101E;
+    public static final int TAG_EXTERNAL_FLASH_AE1 = 0x101F;
+    public static final int TAG_EXTERNAL_FLASH_AE2 = 0x1020;
+    public static final int TAG_INTERNAL_FLASH_AE1 = 0x1021;
+    public static final int TAG_INTERNAL_FLASH_AE2 = 0x1022;
+
     public static final int TAG_FLASH_BIAS = 0x1023;
-//    public static final int TAG_ = 0x1024;
-//    public static final int TAG_ = 0x1025;
+    public static final int TAG_INTERNAL_FLASH_TABLE = 0x1024;
+    public static final int TAG_EXTERNAL_FLASH_G_VALUE = 0x1025;
     public static final int TAG_EXTERNAL_FLASH_BOUNCE = 0x1026;
     public static final int TAG_EXTERNAL_FLASH_ZOOM = 0x1027;
     public static final int TAG_EXTERNAL_FLASH_MODE = 0x1028;
@@ -203,21 +206,24 @@ public class OlympusMakernoteDirectory extends Directory
     public static final int TAG_COLOUR_CONTROL = 0x102B;
     public static final int TAG_VALID_BITS = 0x102C;
     public static final int TAG_CORING_FILTER = 0x102D;
-    public static final int TAG_FINAL_WIDTH = 0x102E;
-    public static final int TAG_FINAL_HEIGHT = 0x102F;
-//    public static final int TAG_ = 0x1030;
-//    public static final int TAG_ = 0x1031;
+    public static final int TAG_OLYMPUS_IMAGE_WIDTH = 0x102E;
+    public static final int TAG_OLYMPUS_IMAGE_HEIGHT = 0x102F;
+    public static final int TAG_SCENE_DETECT = 0x1030;
+    public static final int TAG_SCENE_AREA = 0x1031;
 //    public static final int TAG_ = 0x1032;
-//    public static final int TAG_ = 0x1033;
+    public static final int TAG_SCENE_DETECT_DATA = 0x1033;
     public static final int TAG_COMPRESSION_RATIO = 0x1034;
-    public static final int TAG_THUMBNAIL = 0x1035;
-    public static final int TAG_THUMBNAIL_OFFSET = 0x1036;
-    public static final int TAG_THUMBNAIL_LENGTH = 0x1037;
-//    public static final int TAG_ = 0x1038;
+    public static final int TAG_PREVIEW_IMAGE_VALID = 0x1035;
+    public static final int TAG_PREVIEW_IMAGE_START = 0x1036;
+    public static final int TAG_PREVIEW_IMAGE_LENGTH = 0x1037;
+    public static final int TAG_AF_RESULT = 0x1038;
     public static final int TAG_CCD_SCAN_MODE = 0x1039;
     public static final int TAG_NOISE_REDUCTION = 0x103A;
     public static final int TAG_INFINITY_LENS_STEP = 0x103B;
     public static final int TAG_NEAR_LENS_STEP = 0x103C;
+    public static final int TAG_LIGHT_VALUE_CENTER = 0x103D;
+    public static final int TAG_LIGHT_VALUE_PERIPHERY = 0x103E;
+    public static final int TAG_FIELD_COUNT = 0x103F;
     public static final int TAG_EQUIPMENT = 0x2010;
     public static final int TAG_CAMERA_SETTINGS = 0x2020;
     public static final int TAG_RAW_DEVELOPMENT = 0x2030;
@@ -225,6 +231,7 @@ public class OlympusMakernoteDirectory extends Directory
     public static final int TAG_IMAGE_PROCESSING = 0x2040;
     public static final int TAG_FOCUS_INFO = 0x2050;
     public static final int TAG_RAW_INFO = 0x3000;
+    public static final int TAG_MAIN_INFO = 0x4000;
 
     public final static class CameraSettings
     {
@@ -302,10 +309,10 @@ public class OlympusMakernoteDirectory extends Directory
         _tagNameMap.put(TAG_JPEG_QUALITY, "JPEG Quality");
         _tagNameMap.put(TAG_MACRO_MODE, "Macro");
         _tagNameMap.put(TAG_BW_MODE, "BW Mode");
-        _tagNameMap.put(TAG_DIGI_ZOOM_RATIO, "DigiZoom Ratio");
+        _tagNameMap.put(TAG_DIGITAL_ZOOM, "Digital Zoom");
         _tagNameMap.put(TAG_FOCAL_PLANE_DIAGONAL, "Focal Plane Diagonal");
         _tagNameMap.put(TAG_LENS_DISTORTION_PARAMETERS, "Lens Distortion Parameters");
-        _tagNameMap.put(TAG_FIRMWARE_VERSION, "Firmware Version");
+        _tagNameMap.put(TAG_CAMERA_TYPE, "Camera Type");
         _tagNameMap.put(TAG_PICT_INFO, "Pict Info");
         _tagNameMap.put(TAG_CAMERA_ID, "Camera Id");
         _tagNameMap.put(TAG_IMAGE_WIDTH, "Image Width");
@@ -341,12 +348,24 @@ public class OlympusMakernoteDirectory extends Directory
         _tagNameMap.put(TAG_FLASH_CHARGE_LEVEL, "Flash Charge Level");
         _tagNameMap.put(TAG_COLOUR_MATRIX, "Colour Matrix");
         _tagNameMap.put(TAG_BLACK_LEVEL, "Black Level");
-        _tagNameMap.put(TAG_WHITE_BALANCE, "White Balance");
-        _tagNameMap.put(TAG_RED_BIAS, "Red Bias");
-        _tagNameMap.put(TAG_BLUE_BIAS, "Blue Bias");
+        _tagNameMap.put(TAG_COLOR_TEMPERATURE_BG, "Color Temperature BG");
+        _tagNameMap.put(TAG_COLOR_TEMPERATURE_RG, "Color Temperature RG");
+        _tagNameMap.put(TAG_WB_MODE, "White Balance Mode");
+        _tagNameMap.put(TAG_RED_BALANCE, "Red Balance");
+        _tagNameMap.put(TAG_BLUE_BALANCE, "Blue Balance");
         _tagNameMap.put(TAG_COLOR_MATRIX_NUMBER, "Color Matrix Number");
-        _tagNameMap.put(TAG_SERIAL_NUMBER, "Serial Number");
+        _tagNameMap.put(TAG_SERIAL_NUMBER_2, "Serial Number");
+        _tagNameMap.put(TAG_EXTERNAL_FLASH_AE1_0, "External Flash AE1 0");
+        _tagNameMap.put(TAG_EXTERNAL_FLASH_AE2_0, "External Flash AE2 0");
+        _tagNameMap.put(TAG_INTERNAL_FLASH_AE1_0, "Internal Flash AE1 0");
+        _tagNameMap.put(TAG_INTERNAL_FLASH_AE2_0, "Internal Flash AE2 0");
+        _tagNameMap.put(TAG_EXTERNAL_FLASH_AE1, "External Flash AE1");
+        _tagNameMap.put(TAG_EXTERNAL_FLASH_AE2, "External Flash AE2");
+        _tagNameMap.put(TAG_INTERNAL_FLASH_AE1, "Internal Flash AE1");
+        _tagNameMap.put(TAG_INTERNAL_FLASH_AE2, "Internal Flash AE2");
         _tagNameMap.put(TAG_FLASH_BIAS, "Flash Bias");
+        _tagNameMap.put(TAG_INTERNAL_FLASH_TABLE, "Internal Flash Table");
+        _tagNameMap.put(TAG_EXTERNAL_FLASH_G_VALUE, "External Flash G Value");
         _tagNameMap.put(TAG_EXTERNAL_FLASH_BOUNCE, "External Flash Bounce");
         _tagNameMap.put(TAG_EXTERNAL_FLASH_ZOOM, "External Flash Zoom");
         _tagNameMap.put(TAG_EXTERNAL_FLASH_MODE, "External Flash Mode");
@@ -355,16 +374,23 @@ public class OlympusMakernoteDirectory extends Directory
         _tagNameMap.put(TAG_COLOUR_CONTROL, "Colour Control");
         _tagNameMap.put(TAG_VALID_BITS, "Valid Bits");
         _tagNameMap.put(TAG_CORING_FILTER, "Coring Filter");
-        _tagNameMap.put(TAG_FINAL_WIDTH, "Final Width");
-        _tagNameMap.put(TAG_FINAL_HEIGHT, "Final Height");
+        _tagNameMap.put(TAG_OLYMPUS_IMAGE_WIDTH, "Olympus Image Width");
+        _tagNameMap.put(TAG_OLYMPUS_IMAGE_HEIGHT, "Olympus Image Height");
+        _tagNameMap.put(TAG_SCENE_DETECT, "Scene Detect");
+        _tagNameMap.put(TAG_SCENE_AREA, "Scene Area");
+        _tagNameMap.put(TAG_SCENE_DETECT_DATA, "Scene Detect Data");
         _tagNameMap.put(TAG_COMPRESSION_RATIO, "Compression Ratio");
-        _tagNameMap.put(TAG_THUMBNAIL, "Thumbnail");
-        _tagNameMap.put(TAG_THUMBNAIL_OFFSET, "Thumbnail Offset");
-        _tagNameMap.put(TAG_THUMBNAIL_LENGTH, "Thumbnail Length");
+        _tagNameMap.put(TAG_PREVIEW_IMAGE_VALID, "Preview Image Valid");
+        _tagNameMap.put(TAG_PREVIEW_IMAGE_START, "Preview Image Start");
+        _tagNameMap.put(TAG_PREVIEW_IMAGE_LENGTH, "Preview Image Length");
+        _tagNameMap.put(TAG_AF_RESULT, "AF Result");
         _tagNameMap.put(TAG_CCD_SCAN_MODE, "CCD Scan Mode");
         _tagNameMap.put(TAG_NOISE_REDUCTION, "Noise Reduction");
         _tagNameMap.put(TAG_INFINITY_LENS_STEP, "Infinity Lens Step");
         _tagNameMap.put(TAG_NEAR_LENS_STEP, "Near Lens Step");
+        _tagNameMap.put(TAG_LIGHT_VALUE_CENTER, "Light Value Center");
+        _tagNameMap.put(TAG_LIGHT_VALUE_PERIPHERY, "Light Value Periphery");
+        _tagNameMap.put(TAG_FIELD_COUNT, "Field Count");
         _tagNameMap.put(TAG_EQUIPMENT, "Equipment");
         _tagNameMap.put(TAG_CAMERA_SETTINGS, "Camera Settings");
         _tagNameMap.put(TAG_RAW_DEVELOPMENT, "Raw Development");
@@ -372,6 +398,7 @@ public class OlympusMakernoteDirectory extends Directory
         _tagNameMap.put(TAG_IMAGE_PROCESSING, "Image Processing");
         _tagNameMap.put(TAG_FOCUS_INFO, "Focus Info");
         _tagNameMap.put(TAG_RAW_INFO, "Raw Info");
+        _tagNameMap.put(TAG_MAIN_INFO, "Main Info");
 
         _tagNameMap.put(CameraSettings.TAG_EXPOSURE_MODE, "Exposure Mode");
         _tagNameMap.put(CameraSettings.TAG_FLASH_MODE, "Flash Mode");
@@ -475,5 +502,335 @@ public class OlympusMakernoteDirectory extends Directory
     protected HashMap<Integer, String> getTagNameMap()
     {
         return _tagNameMap;
+    }
+
+    // <summary>
+    // These values are currently decoded only for Olympus models.  Models with
+    // Olympus-style maker notes from other brands such as Acer, BenQ, Hitachi, HP,
+    // Premier, Konica-Minolta, Maginon, Ricoh, Rollei, SeaLife, Sony, Supra,
+    // Vivitar are not listed.
+    // </summary>
+    // <remarks>
+    // Converted from Exiftool version 10.33 created by Phil Harvey
+    // http://www.sno.phy.queensu.ca/~phil/exiftool/
+    // lib\Image\ExifTool\Olympus.pm
+    // </remarks>
+    public static final HashMap<String, String> OlympusCameraTypes = new HashMap<String, String>();
+
+    static {
+        OlympusCameraTypes.put("D4028", "X-2,C-50Z");
+        OlympusCameraTypes.put("D4029", "E-20,E-20N,E-20P");
+        OlympusCameraTypes.put("D4034", "C720UZ");
+        OlympusCameraTypes.put("D4040", "E-1");
+        OlympusCameraTypes.put("D4041", "E-300");
+        OlympusCameraTypes.put("D4083", "C2Z,D520Z,C220Z");
+        OlympusCameraTypes.put("D4106", "u20D,S400D,u400D");
+        OlympusCameraTypes.put("D4120", "X-1");
+        OlympusCameraTypes.put("D4122", "u10D,S300D,u300D");
+        OlympusCameraTypes.put("D4125", "AZ-1");
+        OlympusCameraTypes.put("D4141", "C150,D390");
+        OlympusCameraTypes.put("D4193", "C-5000Z");
+        OlympusCameraTypes.put("D4194", "X-3,C-60Z");
+        OlympusCameraTypes.put("D4199", "u30D,S410D,u410D");
+        OlympusCameraTypes.put("D4205", "X450,D535Z,C370Z");
+        OlympusCameraTypes.put("D4210", "C160,D395");
+        OlympusCameraTypes.put("D4211", "C725UZ");
+        OlympusCameraTypes.put("D4213", "FerrariMODEL2003");
+        OlympusCameraTypes.put("D4216", "u15D");
+        OlympusCameraTypes.put("D4217", "u25D");
+        OlympusCameraTypes.put("D4220", "u-miniD,Stylus V");
+        OlympusCameraTypes.put("D4221", "u40D,S500,uD500");
+        OlympusCameraTypes.put("D4231", "FerrariMODEL2004");
+        OlympusCameraTypes.put("D4240", "X500,D590Z,C470Z");
+        OlympusCameraTypes.put("D4244", "uD800,S800");
+        OlympusCameraTypes.put("D4256", "u720SW,S720SW");
+        OlympusCameraTypes.put("D4261", "X600,D630,FE5500");
+        OlympusCameraTypes.put("D4262", "uD600,S600");
+        OlympusCameraTypes.put("D4301", "u810/S810"); // (yes, "/".  Olympus is not consistent in the notation)
+        OlympusCameraTypes.put("D4302", "u710,S710");
+        OlympusCameraTypes.put("D4303", "u700,S700");
+        OlympusCameraTypes.put("D4304", "FE100,X710");
+        OlympusCameraTypes.put("D4305", "FE110,X705");
+        OlympusCameraTypes.put("D4310", "FE-130,X-720");
+        OlympusCameraTypes.put("D4311", "FE-140,X-725");
+        OlympusCameraTypes.put("D4312", "FE150,X730");
+        OlympusCameraTypes.put("D4313", "FE160,X735");
+        OlympusCameraTypes.put("D4314", "u740,S740");
+        OlympusCameraTypes.put("D4315", "u750,S750");
+        OlympusCameraTypes.put("D4316", "u730/S730");
+        OlympusCameraTypes.put("D4317", "FE115,X715");
+        OlympusCameraTypes.put("D4321", "SP550UZ");
+        OlympusCameraTypes.put("D4322", "SP510UZ");
+        OlympusCameraTypes.put("D4324", "FE170,X760");
+        OlympusCameraTypes.put("D4326", "FE200");
+        OlympusCameraTypes.put("D4327", "FE190/X750"); // (also SX876)
+        OlympusCameraTypes.put("D4328", "u760,S760");
+        OlympusCameraTypes.put("D4330", "FE180/X745"); // (also SX875)
+        OlympusCameraTypes.put("D4331", "u1000/S1000");
+        OlympusCameraTypes.put("D4332", "u770SW,S770SW");
+        OlympusCameraTypes.put("D4333", "FE240/X795");
+        OlympusCameraTypes.put("D4334", "FE210,X775");
+        OlympusCameraTypes.put("D4336", "FE230/X790");
+        OlympusCameraTypes.put("D4337", "FE220,X785");
+        OlympusCameraTypes.put("D4338", "u725SW,S725SW");
+        OlympusCameraTypes.put("D4339", "FE250/X800");
+        OlympusCameraTypes.put("D4341", "u780,S780");
+        OlympusCameraTypes.put("D4343", "u790SW,S790SW");
+        OlympusCameraTypes.put("D4344", "u1020,S1020");
+        OlympusCameraTypes.put("D4346", "FE15,X10");
+        OlympusCameraTypes.put("D4348", "FE280,X820,C520");
+        OlympusCameraTypes.put("D4349", "FE300,X830");
+        OlympusCameraTypes.put("D4350", "u820,S820");
+        OlympusCameraTypes.put("D4351", "u1200,S1200");
+        OlympusCameraTypes.put("D4352", "FE270,X815,C510");
+        OlympusCameraTypes.put("D4353", "u795SW,S795SW");
+        OlympusCameraTypes.put("D4354", "u1030SW,S1030SW");
+        OlympusCameraTypes.put("D4355", "SP560UZ");
+        OlympusCameraTypes.put("D4356", "u1010,S1010");
+        OlympusCameraTypes.put("D4357", "u830,S830");
+        OlympusCameraTypes.put("D4359", "u840,S840");
+        OlympusCameraTypes.put("D4360", "FE350WIDE,X865");
+        OlympusCameraTypes.put("D4361", "u850SW,S850SW");
+        OlympusCameraTypes.put("D4362", "FE340,X855,C560");
+        OlympusCameraTypes.put("D4363", "FE320,X835,C540");
+        OlympusCameraTypes.put("D4364", "SP570UZ");
+        OlympusCameraTypes.put("D4366", "FE330,X845,C550");
+        OlympusCameraTypes.put("D4368", "FE310,X840,C530");
+        OlympusCameraTypes.put("D4370", "u1050SW,S1050SW");
+        OlympusCameraTypes.put("D4371", "u1060,S1060");
+        OlympusCameraTypes.put("D4372", "FE370,X880,C575");
+        OlympusCameraTypes.put("D4374", "SP565UZ");
+        OlympusCameraTypes.put("D4377", "u1040,S1040");
+        OlympusCameraTypes.put("D4378", "FE360,X875,C570");
+        OlympusCameraTypes.put("D4379", "FE20,X15,C25");
+        OlympusCameraTypes.put("D4380", "uT6000,ST6000");
+        OlympusCameraTypes.put("D4381", "uT8000,ST8000");
+        OlympusCameraTypes.put("D4382", "u9000,S9000");
+        OlympusCameraTypes.put("D4384", "SP590UZ");
+        OlympusCameraTypes.put("D4385", "FE3010,X895");
+        OlympusCameraTypes.put("D4386", "FE3000,X890");
+        OlympusCameraTypes.put("D4387", "FE35,X30");
+        OlympusCameraTypes.put("D4388", "u550WP,S550WP");
+        OlympusCameraTypes.put("D4390", "FE5000,X905");
+        OlympusCameraTypes.put("D4391", "u5000");
+        OlympusCameraTypes.put("D4392", "u7000,S7000");
+        OlympusCameraTypes.put("D4396", "FE5010,X915");
+        OlympusCameraTypes.put("D4397", "FE25,X20");
+        OlympusCameraTypes.put("D4398", "FE45,X40");
+        OlympusCameraTypes.put("D4401", "XZ-1");
+        OlympusCameraTypes.put("D4402", "uT6010,ST6010");
+        OlympusCameraTypes.put("D4406", "u7010,S7010 / u7020,S7020");
+        OlympusCameraTypes.put("D4407", "FE4010,X930");
+        OlympusCameraTypes.put("D4408", "X560WP");
+        OlympusCameraTypes.put("D4409", "FE26,X21");
+        OlympusCameraTypes.put("D4410", "FE4000,X920,X925");
+        OlympusCameraTypes.put("D4411", "FE46,X41,X42");
+        OlympusCameraTypes.put("D4412", "FE5020,X935");
+        OlympusCameraTypes.put("D4413", "uTough-3000");
+        OlympusCameraTypes.put("D4414", "StylusTough-6020");
+        OlympusCameraTypes.put("D4415", "StylusTough-8010");
+        OlympusCameraTypes.put("D4417", "u5010,S5010");
+        OlympusCameraTypes.put("D4418", "u7040,S7040");
+        OlympusCameraTypes.put("D4419", "u9010,S9010");
+        OlympusCameraTypes.put("D4423", "FE4040");
+        OlympusCameraTypes.put("D4424", "FE47,X43");
+        OlympusCameraTypes.put("D4426", "FE4030,X950");
+        OlympusCameraTypes.put("D4428", "FE5030,X965,X960");
+        OlympusCameraTypes.put("D4430", "u7030,S7030");
+        OlympusCameraTypes.put("D4432", "SP600UZ");
+        OlympusCameraTypes.put("D4434", "SP800UZ");
+        OlympusCameraTypes.put("D4439", "FE4020,X940");
+        OlympusCameraTypes.put("D4442", "FE5035");
+        OlympusCameraTypes.put("D4448", "FE4050,X970");
+        OlympusCameraTypes.put("D4450", "FE5050,X985");
+        OlympusCameraTypes.put("D4454", "u-7050");
+        OlympusCameraTypes.put("D4464", "T10,X27");
+        OlympusCameraTypes.put("D4470", "FE5040,X980");
+        OlympusCameraTypes.put("D4472", "TG-310");
+        OlympusCameraTypes.put("D4474", "TG-610");
+        OlympusCameraTypes.put("D4476", "TG-810");
+        OlympusCameraTypes.put("D4478", "VG145,VG140,D715");
+        OlympusCameraTypes.put("D4479", "VG130,D710");
+        OlympusCameraTypes.put("D4480", "VG120,D705");
+        OlympusCameraTypes.put("D4482", "VR310,D720");
+        OlympusCameraTypes.put("D4484", "VR320,D725");
+        OlympusCameraTypes.put("D4486", "VR330,D730");
+        OlympusCameraTypes.put("D4488", "VG110,D700");
+        OlympusCameraTypes.put("D4490", "SP-610UZ");
+        OlympusCameraTypes.put("D4492", "SZ-10");
+        OlympusCameraTypes.put("D4494", "SZ-20");
+        OlympusCameraTypes.put("D4496", "SZ-30MR");
+        OlympusCameraTypes.put("D4498", "SP-810UZ");
+        OlympusCameraTypes.put("D4500", "SZ-11");
+        OlympusCameraTypes.put("D4504", "TG-615");
+        OlympusCameraTypes.put("D4508", "TG-620");
+        OlympusCameraTypes.put("D4510", "TG-820");
+        OlympusCameraTypes.put("D4512", "TG-1");
+        OlympusCameraTypes.put("D4516", "SH-21");
+        OlympusCameraTypes.put("D4519", "SZ-14");
+        OlympusCameraTypes.put("D4520", "SZ-31MR");
+        OlympusCameraTypes.put("D4521", "SH-25MR");
+        OlympusCameraTypes.put("D4523", "SP-720UZ");
+        OlympusCameraTypes.put("D4529", "VG170");
+        OlympusCameraTypes.put("D4531", "XZ-2");
+        OlympusCameraTypes.put("D4535", "SP-620UZ");
+        OlympusCameraTypes.put("D4536", "TG-320");
+        OlympusCameraTypes.put("D4537", "VR340,D750");
+        OlympusCameraTypes.put("D4538", "VG160,X990,D745");
+        OlympusCameraTypes.put("D4541", "SZ-12");
+        OlympusCameraTypes.put("D4545", "VH410");
+        OlympusCameraTypes.put("D4546", "XZ-10"); //IB
+        OlympusCameraTypes.put("D4547", "TG-2");
+        OlympusCameraTypes.put("D4548", "TG-830");
+        OlympusCameraTypes.put("D4549", "TG-630");
+        OlympusCameraTypes.put("D4550", "SH-50");
+        OlympusCameraTypes.put("D4553", "SZ-16,DZ-105");
+        OlympusCameraTypes.put("D4562", "SP-820UZ");
+        OlympusCameraTypes.put("D4566", "SZ-15");
+        OlympusCameraTypes.put("D4572", "STYLUS1");
+        OlympusCameraTypes.put("D4574", "TG-3");
+        OlympusCameraTypes.put("D4575", "TG-850");
+        OlympusCameraTypes.put("D4579", "SP-100EE");
+        OlympusCameraTypes.put("D4580", "SH-60");
+        OlympusCameraTypes.put("D4581", "SH-1");
+        OlympusCameraTypes.put("D4582", "TG-835");
+        OlympusCameraTypes.put("D4585", "SH-2 / SH-3");
+        OlympusCameraTypes.put("D4586", "TG-4");
+        OlympusCameraTypes.put("D4587", "TG-860");
+        OlympusCameraTypes.put("D4591", "TG-870");
+        OlympusCameraTypes.put("D4809", "C2500L");
+        OlympusCameraTypes.put("D4842", "E-10");
+        OlympusCameraTypes.put("D4856", "C-1");
+        OlympusCameraTypes.put("D4857", "C-1Z,D-150Z");
+        OlympusCameraTypes.put("DCHC", "D500L");
+        OlympusCameraTypes.put("DCHT", "D600L / D620L");
+        OlympusCameraTypes.put("K0055", "AIR-A01");
+        OlympusCameraTypes.put("S0003", "E-330");
+        OlympusCameraTypes.put("S0004", "E-500");
+        OlympusCameraTypes.put("S0009", "E-400");
+        OlympusCameraTypes.put("S0010", "E-510");
+        OlympusCameraTypes.put("S0011", "E-3");
+        OlympusCameraTypes.put("S0013", "E-410");
+        OlympusCameraTypes.put("S0016", "E-420");
+        OlympusCameraTypes.put("S0017", "E-30");
+        OlympusCameraTypes.put("S0018", "E-520");
+        OlympusCameraTypes.put("S0019", "E-P1");
+        OlympusCameraTypes.put("S0023", "E-620");
+        OlympusCameraTypes.put("S0026", "E-P2");
+        OlympusCameraTypes.put("S0027", "E-PL1");
+        OlympusCameraTypes.put("S0029", "E-450");
+        OlympusCameraTypes.put("S0030", "E-600");
+        OlympusCameraTypes.put("S0032", "E-P3");
+        OlympusCameraTypes.put("S0033", "E-5");
+        OlympusCameraTypes.put("S0034", "E-PL2");
+        OlympusCameraTypes.put("S0036", "E-M5");
+        OlympusCameraTypes.put("S0038", "E-PL3");
+        OlympusCameraTypes.put("S0039", "E-PM1");
+        OlympusCameraTypes.put("S0040", "E-PL1s");
+        OlympusCameraTypes.put("S0042", "E-PL5");
+        OlympusCameraTypes.put("S0043", "E-PM2");
+        OlympusCameraTypes.put("S0044", "E-P5");
+        OlympusCameraTypes.put("S0045", "E-PL6");
+        OlympusCameraTypes.put("S0046", "E-PL7"); //IB
+        OlympusCameraTypes.put("S0047", "E-M1");
+        OlympusCameraTypes.put("S0051", "E-M10");
+        OlympusCameraTypes.put("S0052", "E-M5MarkII"); //IB
+        OlympusCameraTypes.put("S0059", "E-M10MarkII");
+        OlympusCameraTypes.put("S0061", "PEN-F"); //forum7005
+        OlympusCameraTypes.put("S0065", "E-PL8");
+        OlympusCameraTypes.put("S0067", "E-M1MarkII");
+        OlympusCameraTypes.put("SR45", "D220");
+        OlympusCameraTypes.put("SR55", "D320L");
+        OlympusCameraTypes.put("SR83", "D340L");
+        OlympusCameraTypes.put("SR85", "C830L,D340R");
+        OlympusCameraTypes.put("SR852", "C860L,D360L");
+        OlympusCameraTypes.put("SR872", "C900Z,D400Z");
+        OlympusCameraTypes.put("SR874", "C960Z,D460Z");
+        OlympusCameraTypes.put("SR951", "C2000Z");
+        OlympusCameraTypes.put("SR952", "C21");
+        OlympusCameraTypes.put("SR953", "C21T.commu");
+        OlympusCameraTypes.put("SR954", "C2020Z");
+        OlympusCameraTypes.put("SR955", "C990Z,D490Z");
+        OlympusCameraTypes.put("SR956", "C211Z");
+        OlympusCameraTypes.put("SR959", "C990ZS,D490Z");
+        OlympusCameraTypes.put("SR95A", "C2100UZ");
+        OlympusCameraTypes.put("SR971", "C100,D370");
+        OlympusCameraTypes.put("SR973", "C2,D230");
+        OlympusCameraTypes.put("SX151", "E100RS");
+        OlympusCameraTypes.put("SX351", "C3000Z / C3030Z");
+        OlympusCameraTypes.put("SX354", "C3040Z");
+        OlympusCameraTypes.put("SX355", "C2040Z");
+        OlympusCameraTypes.put("SX357", "C700UZ");
+        OlympusCameraTypes.put("SX358", "C200Z,D510Z");
+        OlympusCameraTypes.put("SX374", "C3100Z,C3020Z");
+        OlympusCameraTypes.put("SX552", "C4040Z");
+        OlympusCameraTypes.put("SX553", "C40Z,D40Z");
+        OlympusCameraTypes.put("SX556", "C730UZ");
+        OlympusCameraTypes.put("SX558", "C5050Z");
+        OlympusCameraTypes.put("SX571", "C120,D380");
+        OlympusCameraTypes.put("SX574", "C300Z,D550Z");
+        OlympusCameraTypes.put("SX575", "C4100Z,C4000Z");
+        OlympusCameraTypes.put("SX751", "X200,D560Z,C350Z");
+        OlympusCameraTypes.put("SX752", "X300,D565Z,C450Z");
+        OlympusCameraTypes.put("SX753", "C750UZ");
+        OlympusCameraTypes.put("SX754", "C740UZ");
+        OlympusCameraTypes.put("SX755", "C755UZ");
+        OlympusCameraTypes.put("SX756", "C5060WZ");
+        OlympusCameraTypes.put("SX757", "C8080WZ");
+        OlympusCameraTypes.put("SX758", "X350,D575Z,C360Z");
+        OlympusCameraTypes.put("SX759", "X400,D580Z,C460Z");
+        OlympusCameraTypes.put("SX75A", "AZ-2ZOOM");
+        OlympusCameraTypes.put("SX75B", "D595Z,C500Z");
+        OlympusCameraTypes.put("SX75C", "X550,D545Z,C480Z");
+        OlympusCameraTypes.put("SX75D", "IR-300");
+        OlympusCameraTypes.put("SX75F", "C55Z,C5500Z");
+        OlympusCameraTypes.put("SX75G", "C170,D425");
+        OlympusCameraTypes.put("SX75J", "C180,D435");
+        OlympusCameraTypes.put("SX771", "C760UZ");
+        OlympusCameraTypes.put("SX772", "C770UZ");
+        OlympusCameraTypes.put("SX773", "C745UZ");
+        OlympusCameraTypes.put("SX774", "X250,D560Z,C350Z");
+        OlympusCameraTypes.put("SX775", "X100,D540Z,C310Z");
+        OlympusCameraTypes.put("SX776", "C460ZdelSol");
+        OlympusCameraTypes.put("SX777", "C765UZ");
+        OlympusCameraTypes.put("SX77A", "D555Z,C315Z");
+        OlympusCameraTypes.put("SX851", "C7070WZ");
+        OlympusCameraTypes.put("SX852", "C70Z,C7000Z");
+        OlympusCameraTypes.put("SX853", "SP500UZ");
+        OlympusCameraTypes.put("SX854", "SP310");
+        OlympusCameraTypes.put("SX855", "SP350");
+        OlympusCameraTypes.put("SX873", "SP320");
+        OlympusCameraTypes.put("SX875", "FE180/X745"); // (also D4330)
+        OlympusCameraTypes.put("SX876", "FE190/X750"); // (also D4327)
+
+        //   other brands
+        //    4MP9Q3", "Camera 4MP-9Q3'
+        //    4MP9T2", "BenQ DC C420 / Camera 4MP-9T2'
+        //    5MP9Q3", "Camera 5MP-9Q3" },
+        //    5MP9X9", "Camera 5MP-9X9" },
+        //   '5MP-9T'=> 'Camera 5MP-9T3" },
+        //   '5MP-9Y'=> 'Camera 5MP-9Y2" },
+        //   '6MP-9U'=> 'Camera 6MP-9U9" },
+        //    7MP9Q3", "Camera 7MP-9Q3" },
+        //   '8MP-9U'=> 'Camera 8MP-9U4" },
+        //    CE5330", "Acer CE-5330" },
+        //   'CP-853'=> 'Acer CP-8531" },
+        //    CS5531", "Acer CS5531" },
+        //    DC500 ", "SeaLife DC500" },
+        //    DC7370", "Camera 7MP-9GA" },
+        //    DC7371", "Camera 7MP-9GM" },
+        //    DC7371", "Hitachi HDC-751E" },
+        //    DC7375", "Hitachi HDC-763E / Rollei RCP-7330X / Ricoh Caplio RR770 / Vivitar ViviCam 7330" },
+        //   'DC E63'=> 'BenQ DC E63+" },
+        //   'DC P86'=> 'BenQ DC P860" },
+        //    DS5340", "Maginon Performic S5 / Premier 5MP-9M7" },
+        //    DS5341", "BenQ E53+ / Supra TCM X50 / Maginon X50 / Premier 5MP-9P8" },
+        //    DS5346", "Premier 5MP-9Q2" },
+        //    E500  ", "Konica Minolta DiMAGE E500" },
+        //    MAGINO", "Maginon X60" },
+        //    Mz60  ", "HP Photosmart Mz60" },
+        //    Q3DIGI", "Camera 5MP-9Q3" },
+        //    SLIMLI", "Supra Slimline X6" },
+        //    V8300s", "Vivitar V8300s" },
     }
 }

--- a/Source/com/drew/metadata/exif/makernotes/OlympusRawDevelopment2MakernoteDescriptor.java
+++ b/Source/com/drew/metadata/exif/makernotes/OlympusRawDevelopment2MakernoteDescriptor.java
@@ -1,0 +1,231 @@
+/*
+ * Copyright 2002-2015 Drew Noakes
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ * More information about this project is available at:
+ *
+ *    https://drewnoakes.com/code/exif/
+ *    https://github.com/drewnoakes/metadata-extractor
+ */
+package com.drew.metadata.exif.makernotes;
+
+import com.drew.lang.annotations.NotNull;
+import com.drew.lang.annotations.Nullable;
+import com.drew.metadata.TagDescriptor;
+
+import java.text.DecimalFormat;
+import java.util.HashMap;
+
+import static com.drew.metadata.exif.makernotes.OlympusRawDevelopment2MakernoteDirectory.*;
+
+/**
+ * Provides human-readable String representations of tag values stored in a {@link OlympusRawDevelopment2MakernoteDirectory}.
+ * <p>
+ * Some Description functions converted from Exiftool version 10.10 created by Phil Harvey
+ * http://www.sno.phy.queensu.ca/~phil/exiftool/
+ * lib\Image\ExifTool\Olympus.pm
+ *
+ * @author Kevin Mott https://github.com/kwhopper
+ * @author Drew Noakes https://drewnoakes.com
+ */
+@SuppressWarnings("WeakerAccess")
+public class OlympusRawDevelopment2MakernoteDescriptor extends TagDescriptor<OlympusRawDevelopment2MakernoteDirectory>
+{
+    public OlympusRawDevelopment2MakernoteDescriptor(@NotNull OlympusRawDevelopment2MakernoteDirectory directory)
+    {
+        super(directory);
+    }
+
+    @Override
+    @Nullable
+    public String getDescription(int tagType)
+    {
+        switch (tagType) {
+            case TagRawDevVersion:
+                return getRawDevVersionDescription();
+            case TagRawDevExposureBiasValue:
+                return getRawDevExposureBiasValueDescription();
+            case TagRawDevColorSpace:
+                return getRawDevColorSpaceDescription();
+            case TagRawDevNoiseReduction:
+                return getRawDevNoiseReductionDescription();
+            case TagRawDevEngine:
+                return getRawDevEngineDescription();
+            case TagRawDevPictureMode:
+                return getRawDevPictureModeDescription();
+            case TagRawDevPmBwFilter:
+                return getRawDevPmBwFilterDescription();
+            case TagRawDevPmPictureTone:
+                return getRawDevPmPictureToneDescription();
+            case TagRawDevArtFilter:
+                return getRawDevArtFilterDescription();
+            default:
+                return super.getDescription(tagType);
+        }
+    }
+
+    @Nullable
+    public String getRawDevVersionDescription()
+    {
+        return getVersionBytesDescription(TagRawDevVersion, 4);
+    }
+
+    @Nullable
+    public String getRawDevExposureBiasValueDescription()
+    {
+        return getIndexedDescription(TagRawDevExposureBiasValue, 
+                1, "Color Temperature", "Gray Point");
+    }
+
+    @Nullable
+    public String getRawDevColorSpaceDescription()
+    {
+        return getIndexedDescription(TagRawDevColorSpace,
+            "sRGB", "Adobe RGB", "Pro Photo RGB");
+    }
+
+    @Nullable
+    public String getRawDevNoiseReductionDescription()
+    {
+        Integer value = _directory.getInteger(TagRawDevNoiseReduction);
+        if (value == null)
+            return null;
+
+        if (value == 0)
+            return "(none)";
+
+        StringBuilder sb = new StringBuilder();
+        int v = value;
+
+        if ((v        & 1) != 0) sb.append("Noise Reduction, ");
+        if (((v >> 1) & 1) != 0) sb.append("Noise Filter, ");
+        if (((v >> 2) & 1) != 0) sb.append("Noise Filter (ISO Boost), ");
+
+        return sb.substring(0, sb.length() - 2);
+    }
+
+    @Nullable
+    public String getRawDevEngineDescription()
+    {
+        return getIndexedDescription(TagRawDevEngine,
+            "High Speed", "High Function", "Advanced High Speed", "Advanced High Function");
+    }
+    
+    @Nullable
+    public String getRawDevPictureModeDescription()
+    {
+        Integer value = _directory.getInteger(TagRawDevPictureMode);
+        if (value == null)
+            return null;
+
+        switch (value)
+        {
+            case 1:
+                return "Vivid";
+            case 2:
+                return "Natural";
+            case 3:
+                return "Muted";
+            case 256:
+                return "Monotone";
+            case 512:
+                return "Sepia";
+            default:
+                return "Unknown (" + value + ")";
+        }
+    }
+
+    @Nullable
+    public String getRawDevPmBwFilterDescription()
+    {
+        return getIndexedDescription(TagRawDevPmBwFilter,
+            "Neutral", "Yellow", "Orange", "Red", "Green");
+    }
+    
+    @Nullable
+    public String getRawDevPmPictureToneDescription()
+    {
+        return getIndexedDescription(TagRawDevPmPictureTone,
+            "Neutral", "Sepia", "Blue", "Purple", "Green");
+    }
+
+    @Nullable
+    public String getRawDevArtFilterDescription()
+    {
+        return getFilterDescription(TagRawDevArtFilter);
+    }
+    
+    @Nullable
+    public String getFilterDescription(int tag)
+    {
+        int[] values = _directory.getIntArray(tag);
+        if (values == null || values.length == 0)
+            return null;
+
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < values.length; i++) {
+            if (i == 0)
+                sb.append(_filters.containsKey((short)values[i]) ? _filters.get((short)values[i]) : "[unknown]");
+            else
+                sb.append(values[i]).append("; ");
+            sb.append("; ");
+        }
+
+        return sb.substring(0, sb.length() - 2);
+    }
+
+    // RawDevArtFilter values
+    private static final HashMap<Integer, String> _filters = new HashMap<Integer, String>();
+
+    static {
+        _filters.put(0, "Off");
+        _filters.put(1, "Soft Focus");
+        _filters.put(2, "Pop Art");
+        _filters.put(3, "Pale & Light Color");
+        _filters.put(4, "Light Tone");
+        _filters.put(5, "Pin Hole");
+        _filters.put(6, "Grainy Film");
+        _filters.put(9, "Diorama");
+        _filters.put(10, "Cross Process");
+        _filters.put(12, "Fish Eye");
+        _filters.put(13, "Drawing");
+        _filters.put(14, "Gentle Sepia");
+        _filters.put(15, "Pale & Light Color II");
+        _filters.put(16, "Pop Art II");
+        _filters.put(17, "Pin Hole II");
+        _filters.put(18, "Pin Hole III");
+        _filters.put(19, "Grainy Film II");
+        _filters.put(20, "Dramatic Tone");
+        _filters.put(21, "Punk");
+        _filters.put(22, "Soft Focus 2");
+        _filters.put(23, "Sparkle");
+        _filters.put(24, "Watercolor");
+        _filters.put(25, "Key Line");
+        _filters.put(26, "Key Line II");
+        _filters.put(27, "Miniature");
+        _filters.put(28, "Reflection");
+        _filters.put(29, "Fragmented");
+        _filters.put(31, "Cross Process II");
+        _filters.put(32, "Dramatic Tone II");
+        _filters.put(33, "Watercolor I");
+        _filters.put(34, "Watercolor II");
+        _filters.put(35, "Diorama II");
+        _filters.put(36, "Vintage");
+        _filters.put(37, "Vintage II");
+        _filters.put(38, "Vintage III");
+        _filters.put(39, "Partial Color");
+        _filters.put(40, "Partial Color II");
+        _filters.put(41, "Partial Color III");
+    }
+}

--- a/Source/com/drew/metadata/exif/makernotes/OlympusRawDevelopment2MakernoteDescriptor.java
+++ b/Source/com/drew/metadata/exif/makernotes/OlympusRawDevelopment2MakernoteDescriptor.java
@@ -24,7 +24,6 @@ import com.drew.lang.annotations.NotNull;
 import com.drew.lang.annotations.Nullable;
 import com.drew.metadata.TagDescriptor;
 
-import java.text.DecimalFormat;
 import java.util.HashMap;
 
 import static com.drew.metadata.exif.makernotes.OlympusRawDevelopment2MakernoteDirectory.*;

--- a/Source/com/drew/metadata/exif/makernotes/OlympusRawDevelopment2MakernoteDirectory.java
+++ b/Source/com/drew/metadata/exif/makernotes/OlympusRawDevelopment2MakernoteDirectory.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2002-2015 Drew Noakes
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ * More information about this project is available at:
+ *
+ *    https://drewnoakes.com/code/exif/
+ *    https://github.com/drewnoakes/metadata-extractor
+ */
+package com.drew.metadata.exif.makernotes;
+
+import com.drew.lang.annotations.NotNull;
+import com.drew.metadata.Directory;
+
+import java.util.HashMap;
+
+/**
+ * The Olympus raw development 2 makernote is used by many manufacturers (Epson, Konica, Minolta and Agfa...), and as such contains some tags
+ * that appear specific to those manufacturers.
+ *
+ * @author Kevin Mott https://github.com/kwhopper
+ * @author Drew Noakes https://drewnoakes.com
+ */
+@SuppressWarnings("WeakerAccess")
+public class OlympusRawDevelopment2MakernoteDirectory extends Directory
+{    
+    public static final int TagRawDevVersion = 0x0000;
+    public static final int TagRawDevExposureBiasValue = 0x0100;
+    public static final int TagRawDevWhiteBalance = 0x0101;
+    public static final int TagRawDevWhiteBalanceValue = 0x0102;
+    public static final int TagRawDevWbFineAdjustment = 0x0103;
+    public static final int TagRawDevGrayPoint = 0x0104;
+    public static final int TagRawDevContrastValue = 0x0105;
+    public static final int TagRawDevSharpnessValue = 0x0106;
+    public static final int TagRawDevSaturationEmphasis = 0x0107;
+    public static final int TagRawDevMemoryColorEmphasis = 0x0108;
+    public static final int TagRawDevColorSpace = 0x0109;
+    public static final int TagRawDevNoiseReduction = 0x010a;
+    public static final int TagRawDevEngine = 0x010b;
+    public static final int TagRawDevPictureMode = 0x010c;
+    public static final int TagRawDevPmSaturation = 0x010d;
+    public static final int TagRawDevPmContrast = 0x010e;
+    public static final int TagRawDevPmSharpness = 0x010f;
+    public static final int TagRawDevPmBwFilter = 0x0110;
+    public static final int TagRawDevPmPictureTone = 0x0111;
+    public static final int TagRawDevGradation = 0x0112;
+    public static final int TagRawDevSaturation3 = 0x0113;
+    public static final int TagRawDevAutoGradation = 0x0119;
+    public static final int TagRawDevPmNoiseFilter = 0x0120;
+    public static final int TagRawDevArtFilter = 0x0121;
+
+    @NotNull
+    protected static final HashMap<Integer, String> _tagNameMap = new HashMap<Integer, String>();
+
+    static {        
+        _tagNameMap.put(TagRawDevVersion, "Raw Dev Version");
+        _tagNameMap.put(TagRawDevExposureBiasValue, "Raw Dev Exposure Bias Value");
+        _tagNameMap.put(TagRawDevWhiteBalance, "Raw Dev White Balance");
+        _tagNameMap.put(TagRawDevWhiteBalanceValue, "Raw Dev White Balance Value");
+        _tagNameMap.put(TagRawDevWbFineAdjustment, "Raw Dev WB Fine Adjustment");
+        _tagNameMap.put(TagRawDevGrayPoint, "Raw Dev Gray Point");
+        _tagNameMap.put(TagRawDevContrastValue, "Raw Dev Contrast Value");
+        _tagNameMap.put(TagRawDevSharpnessValue, "Raw Dev Sharpness Value");
+        _tagNameMap.put(TagRawDevSaturationEmphasis, "Raw Dev Saturation Emphasis");
+        _tagNameMap.put(TagRawDevMemoryColorEmphasis, "Raw Dev Memory Color Emphasis");
+        _tagNameMap.put(TagRawDevColorSpace, "Raw Dev Color Space");
+        _tagNameMap.put(TagRawDevNoiseReduction, "Raw Dev Noise Reduction");
+        _tagNameMap.put(TagRawDevEngine, "Raw Dev Engine");
+        _tagNameMap.put(TagRawDevPictureMode, "Raw Dev Picture Mode");
+        _tagNameMap.put(TagRawDevPmSaturation, "Raw Dev PM Saturation");
+        _tagNameMap.put(TagRawDevPmContrast, "Raw Dev PM Contrast");
+        _tagNameMap.put(TagRawDevPmSharpness, "Raw Dev PM Sharpness");
+        _tagNameMap.put(TagRawDevPmBwFilter, "Raw Dev PM BW Filter");
+        _tagNameMap.put(TagRawDevPmPictureTone, "Raw Dev PM Picture Tone");
+        _tagNameMap.put(TagRawDevGradation, "Raw Dev Gradation");
+        _tagNameMap.put(TagRawDevSaturation3, "Raw Dev Saturation 3");
+        _tagNameMap.put(TagRawDevAutoGradation, "Raw Dev Auto Gradation");
+        _tagNameMap.put(TagRawDevPmNoiseFilter, "Raw Dev PM Noise Filter");
+        _tagNameMap.put(TagRawDevArtFilter, "Raw Dev Art Filter");
+    }
+
+    public OlympusRawDevelopment2MakernoteDirectory()
+    {
+        this.setDescriptor(new OlympusRawDevelopment2MakernoteDescriptor(this));
+    }
+
+    @Override
+    @NotNull
+    public String getName()
+    {
+        return "Olympus Raw Development 2";
+    }
+
+    @Override
+    @NotNull
+    protected HashMap<Integer, String> getTagNameMap()
+    {
+        return _tagNameMap;
+    }
+}

--- a/Source/com/drew/metadata/exif/makernotes/OlympusRawDevelopmentMakernoteDescriptor.java
+++ b/Source/com/drew/metadata/exif/makernotes/OlympusRawDevelopmentMakernoteDescriptor.java
@@ -1,0 +1,158 @@
+/*
+ * Copyright 2002-2015 Drew Noakes
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ * More information about this project is available at:
+ *
+ *    https://drewnoakes.com/code/exif/
+ *    https://github.com/drewnoakes/metadata-extractor
+ */
+package com.drew.metadata.exif.makernotes;
+
+import com.drew.lang.annotations.NotNull;
+import com.drew.lang.annotations.Nullable;
+import com.drew.metadata.TagDescriptor;
+
+import java.text.DecimalFormat;
+import java.util.HashMap;
+
+import static com.drew.metadata.exif.makernotes.OlympusRawDevelopmentMakernoteDirectory.*;
+
+/**
+ * Provides human-readable String representations of tag values stored in a {@link OlympusRawDevelopmentMakernoteDirectory}.
+ * <p>
+ * Some Description functions converted from Exiftool version 10.10 created by Phil Harvey
+ * http://www.sno.phy.queensu.ca/~phil/exiftool/
+ * lib\Image\ExifTool\Olympus.pm
+ *
+ * @author Kevin Mott https://github.com/kwhopper
+ * @author Drew Noakes https://drewnoakes.com
+ */
+@SuppressWarnings("WeakerAccess")
+public class OlympusRawDevelopmentMakernoteDescriptor extends TagDescriptor<OlympusRawDevelopmentMakernoteDirectory>
+{
+    public OlympusRawDevelopmentMakernoteDescriptor(@NotNull OlympusRawDevelopmentMakernoteDirectory directory)
+    {
+        super(directory);
+    }
+
+    @Override
+    @Nullable
+    public String getDescription(int tagType)
+    {
+        switch (tagType) {
+            case TagRawDevVersion:
+                return getRawDevVersionDescription();
+            case TagRawDevColorSpace:
+                return getRawDevColorSpaceDescription();
+            case TagRawDevEngine:
+                return getRawDevEngineDescription();
+            case TagRawDevNoiseReduction:
+                return getRawDevNoiseReductionDescription();
+            case TagRawDevEditStatus:
+                return getRawDevEditStatusDescription();
+            case TagRawDevSettings:
+                return getRawDevSettingsDescription();
+            default:
+                return super.getDescription(tagType);
+        }
+    }
+
+    @Nullable
+    public String getRawDevVersionDescription()
+    {
+        return getVersionBytesDescription(TagRawDevVersion, 4);
+    }
+
+    @Nullable
+    public String getRawDevColorSpaceDescription()
+    {
+        return getIndexedDescription(TagRawDevColorSpace,
+            "sRGB", "Adobe RGB", "Pro Photo RGB");
+    }
+
+    @Nullable
+    public String getRawDevEngineDescription()
+    {
+        return getIndexedDescription(TagRawDevEngine,
+            "High Speed", "High Function", "Advanced High Speed", "Advanced High Function");
+    }
+
+    @Nullable
+    public String getRawDevNoiseReductionDescription()
+    {
+        Integer value = _directory.getInteger(TagRawDevNoiseReduction);
+        if (value == null)
+            return null;
+
+        if (value == 0)
+            return "(none)";
+
+        StringBuilder sb = new StringBuilder();
+        int v = value;
+
+        if ((v        & 1) != 0) sb.append("Noise Reduction, ");
+        if (((v >> 1) & 1) != 0) sb.append("Noise Filter, ");
+        if (((v >> 2) & 1) != 0) sb.append("Noise Filter (ISO Boost), ");
+
+        return sb.substring(0, sb.length() - 2);
+    }
+
+    @Nullable
+    public String getRawDevEditStatusDescription()
+    {
+        Integer value = _directory.getInteger(TagRawDevEditStatus);
+        if (value == null)
+            return null;
+
+        switch (value)
+        {
+            case 0:
+                return "Original";
+            case 1:
+                return "Edited (Landscape)";
+            case 6:
+            case 8:
+                return "Edited (Portrait)";
+            default:
+                return "Unknown (" + value + ")";
+        }
+    }
+
+    @Nullable
+    public String getRawDevSettingsDescription()
+    {
+        Integer value = _directory.getInteger(TagRawDevSettings);
+        if (value == null)
+            return null;
+
+        if (value == 0)
+            return "(none)";
+
+        StringBuilder sb = new StringBuilder();
+        int v = value;
+
+        if ((v        & 1) != 0) sb.append("WB Color Temp, ");
+        if (((v >> 1) & 1) != 0) sb.append("WB Gray Point, ");
+        if (((v >> 2) & 1) != 0) sb.append("Saturation, ");
+        if (((v >> 3) & 1) != 0) sb.append("Contrast, ");
+        if (((v >> 4) & 1) != 0) sb.append("Sharpness, ");
+        if (((v >> 5) & 1) != 0) sb.append("Color Space, ");
+        if (((v >> 6) & 1) != 0) sb.append("High Function, ");
+        if (((v >> 7) & 1) != 0) sb.append("Noise Reduction, ");
+
+        return sb.substring(0, sb.length() - 2);
+    }
+
+}

--- a/Source/com/drew/metadata/exif/makernotes/OlympusRawDevelopmentMakernoteDescriptor.java
+++ b/Source/com/drew/metadata/exif/makernotes/OlympusRawDevelopmentMakernoteDescriptor.java
@@ -24,9 +24,6 @@ import com.drew.lang.annotations.NotNull;
 import com.drew.lang.annotations.Nullable;
 import com.drew.metadata.TagDescriptor;
 
-import java.text.DecimalFormat;
-import java.util.HashMap;
-
 import static com.drew.metadata.exif.makernotes.OlympusRawDevelopmentMakernoteDirectory.*;
 
 /**

--- a/Source/com/drew/metadata/exif/makernotes/OlympusRawDevelopmentMakernoteDirectory.java
+++ b/Source/com/drew/metadata/exif/makernotes/OlympusRawDevelopmentMakernoteDirectory.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2002-2015 Drew Noakes
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ * More information about this project is available at:
+ *
+ *    https://drewnoakes.com/code/exif/
+ *    https://github.com/drewnoakes/metadata-extractor
+ */
+package com.drew.metadata.exif.makernotes;
+
+import com.drew.lang.annotations.NotNull;
+import com.drew.metadata.Directory;
+
+import java.util.HashMap;
+
+/**
+ * The Olympus raw development makernote is used by many manufacturers (Epson, Konica, Minolta and Agfa...), and as such contains some tags
+ * that appear specific to those manufacturers.
+ *
+ * @author Kevin Mott https://github.com/kwhopper
+ * @author Drew Noakes https://drewnoakes.com
+ */
+@SuppressWarnings("WeakerAccess")
+public class OlympusRawDevelopmentMakernoteDirectory extends Directory
+{
+    public static final int TagRawDevVersion = 0x0000;
+    public static final int TagRawDevExposureBiasValue = 0x0100;
+    public static final int TagRawDevWhiteBalanceValue = 0x0101;
+    public static final int TagRawDevWbFineAdjustment = 0x0102;
+    public static final int TagRawDevGrayPoint = 0x0103;
+    public static final int TagRawDevSaturationEmphasis = 0x0104;
+    public static final int TagRawDevMemoryColorEmphasis = 0x0105;
+    public static final int TagRawDevContrastValue = 0x0106;
+    public static final int TagRawDevSharpnessValue = 0x0107;
+    public static final int TagRawDevColorSpace = 0x0108;
+    public static final int TagRawDevEngine = 0x0109;
+    public static final int TagRawDevNoiseReduction = 0x010a;
+    public static final int TagRawDevEditStatus = 0x010b;
+    public static final int TagRawDevSettings = 0x010c;
+
+    @NotNull
+    protected static final HashMap<Integer, String> _tagNameMap = new HashMap<Integer, String>();
+
+    static {
+        _tagNameMap.put(TagRawDevVersion, "Raw Dev Version");
+        _tagNameMap.put(TagRawDevExposureBiasValue, "Raw Dev Exposure Bias Value");
+        _tagNameMap.put(TagRawDevWhiteBalanceValue, "Raw Dev White Balance Value");
+        _tagNameMap.put(TagRawDevWbFineAdjustment, "Raw Dev WB Fine Adjustment");
+        _tagNameMap.put(TagRawDevGrayPoint, "Raw Dev Gray Point");
+        _tagNameMap.put(TagRawDevSaturationEmphasis, "Raw Dev Saturation Emphasis");
+        _tagNameMap.put(TagRawDevMemoryColorEmphasis, "Raw Dev Memory Color Emphasis");
+        _tagNameMap.put(TagRawDevContrastValue, "Raw Dev Contrast Value");
+        _tagNameMap.put(TagRawDevSharpnessValue, "Raw Dev Sharpness Value");
+        _tagNameMap.put(TagRawDevColorSpace, "Raw Dev Color Space");
+        _tagNameMap.put(TagRawDevEngine, "Raw Dev Engine");
+        _tagNameMap.put(TagRawDevNoiseReduction, "Raw Dev Noise Reduction");
+        _tagNameMap.put(TagRawDevEditStatus, "Raw Dev Edit Status");
+        _tagNameMap.put(TagRawDevSettings, "Raw Dev Settings");
+    }
+
+    public OlympusRawDevelopmentMakernoteDirectory()
+    {
+        this.setDescriptor(new OlympusRawDevelopmentMakernoteDescriptor(this));
+    }
+
+    @Override
+    @NotNull
+    public String getName()
+    {
+        return "Olympus Raw Development";
+    }
+
+    @Override
+    @NotNull
+    protected HashMap<Integer, String> getTagNameMap()
+    {
+        return _tagNameMap;
+    }
+}

--- a/Source/com/drew/metadata/exif/makernotes/OlympusRawInfoMakernoteDescriptor.java
+++ b/Source/com/drew/metadata/exif/makernotes/OlympusRawInfoMakernoteDescriptor.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright 2002-2015 Drew Noakes
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ * More information about this project is available at:
+ *
+ *    https://drewnoakes.com/code/exif/
+ *    https://github.com/drewnoakes/metadata-extractor
+ */
+package com.drew.metadata.exif.makernotes;
+
+import com.drew.lang.Rational;
+import com.drew.lang.annotations.NotNull;
+import com.drew.lang.annotations.Nullable;
+import com.drew.metadata.TagDescriptor;
+
+import static com.drew.metadata.exif.makernotes.OlympusRawInfoMakernoteDirectory.*;
+
+/**
+ * Provides human-readable String representations of tag values stored in a {@link OlympusRawInfoMakernoteDirectory}.
+ * <p>
+ * Some Description functions converted from Exiftool version 10.33 created by Phil Harvey
+ * http://www.sno.phy.queensu.ca/~phil/exiftool/
+ * lib\Image\ExifTool\Olympus.pm
+ *
+ * @author Kevin Mott https://github.com/kwhopper
+ * @author Drew Noakes https://drewnoakes.com
+ */
+@SuppressWarnings("WeakerAccess")
+public class OlympusRawInfoMakernoteDescriptor extends TagDescriptor<OlympusRawInfoMakernoteDirectory>
+{
+    public OlympusRawInfoMakernoteDescriptor(@NotNull OlympusRawInfoMakernoteDirectory directory)
+    {
+        super(directory);
+    }
+
+    @Override
+    @Nullable
+    public String getDescription(int tagType)
+    {
+        switch (tagType) {
+            case TagRawInfoVersion:
+                return getVersionBytesDescription(TagRawInfoVersion, 4);
+            case TagColorMatrix2:
+                return getColorMatrix2Description();
+            case TagYCbCrCoefficients:
+                return getYCbCrCoefficientsDescription();
+            case TagLightSource:
+                return getOlympusLightSourceDescription();
+            default:
+                return super.getDescription(tagType);
+        }
+    }
+
+    @Nullable
+    public String getColorMatrix2Description()
+    {
+        int[] values = _directory.getIntArray(TagColorMatrix2);
+        if (values == null)
+            return null;
+
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < values.length; i++) {
+            sb.append((short)values[i]);
+            if (i < values.length - 1)
+                sb.append(" ");
+        }
+        return sb.length() == 0 ? null : sb.toString();
+    }
+
+    @Nullable
+    public String getYCbCrCoefficientsDescription()
+    {
+        int[] values = _directory.getIntArray(TagYCbCrCoefficients);
+        if (values == null)
+            return null;
+
+        Rational[] ret = new Rational[values.length / 2];
+        for(int i = 0; i < values.length / 2; i++)
+        {
+            ret[i] = new Rational((short)values[2*i], (short)values[2*i + 1]);
+        }
+
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < ret.length; i++) {
+            sb.append(ret[i].doubleValue());
+            if (i < ret.length - 1)
+                sb.append(" ");
+        }
+        return sb.length() == 0 ? null : sb.toString();
+    }
+    
+    @Nullable
+    public String getOlympusLightSourceDescription()
+    {
+        Integer value = _directory.getInteger(TagLightSource);
+        if (value == null)
+            return null;
+
+        switch (value.shortValue())
+        {
+            case 0:
+                return "Unknown";
+            case 16:
+                return "Shade";
+            case 17:
+                return "Cloudy";
+            case 18:
+                return "Fine Weather";
+            case 20:
+                return "Tungsten (Incandescent)";
+            case 22:
+                return "Evening Sunlight";
+            case 33:
+                return "Daylight Fluorescent";
+            case 34:
+                return "Day White Fluorescent";
+            case 35:
+                return "Cool White Fluorescent";
+            case 36:
+                return "White Fluorescent";
+            case 256:
+                return "One Touch White Balance";
+            case 512:
+                return "Custom 1-4";
+            default:
+                return "Unknown (" + value + ")";
+        }
+    }
+}

--- a/Source/com/drew/metadata/exif/makernotes/OlympusRawInfoMakernoteDirectory.java
+++ b/Source/com/drew/metadata/exif/makernotes/OlympusRawInfoMakernoteDirectory.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright 2002-2015 Drew Noakes
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ * More information about this project is available at:
+ *
+ *    https://drewnoakes.com/code/exif/
+ *    https://github.com/drewnoakes/metadata-extractor
+ */
+package com.drew.metadata.exif.makernotes;
+
+import com.drew.lang.annotations.NotNull;
+import com.drew.metadata.Directory;
+
+import java.util.HashMap;
+
+/**
+ * These tags are found only in ORF images of some models (eg. C8080WZ)
+ *
+ * @author Kevin Mott https://github.com/kwhopper
+ * @author Drew Noakes https://drewnoakes.com
+ */
+@SuppressWarnings("WeakerAccess")
+public class OlympusRawInfoMakernoteDirectory extends Directory
+{
+    public static final int TagRawInfoVersion = 0x0000;
+    public static final int TagWbRbLevelsUsed = 0x0100;
+    public static final int TagWbRbLevelsAuto = 0x0110;
+    public static final int TagWbRbLevelsShade = 0x0120;
+    public static final int TagWbRbLevelsCloudy = 0x0121;
+    public static final int TagWbRbLevelsFineWeather = 0x0122;
+    public static final int TagWbRbLevelsTungsten = 0x0123;
+    public static final int TagWbRbLevelsEveningSunlight = 0x0124;
+    public static final int TagWbRbLevelsDaylightFluor = 0x0130;
+    public static final int TagWbRbLevelsDayWhiteFluor = 0x0131;
+    public static final int TagWbRbLevelsCoolWhiteFluor = 0x0132;
+    public static final int TagWbRbLevelsWhiteFluorescent = 0x0133;
+
+    public static final int TagColorMatrix2 = 0x0200;
+    public static final int TagCoringFilter = 0x0310;
+    public static final int TagCoringValues = 0x0311;
+    public static final int TagBlackLevel2 = 0x0600;
+    public static final int TagYCbCrCoefficients = 0x0601;
+    public static final int TagValidPixelDepth = 0x0611;
+    public static final int TagCropLeft = 0x0612;
+    public static final int TagCropTop = 0x0613;
+    public static final int TagCropWidth = 0x0614;
+    public static final int TagCropHeight = 0x0615;
+
+    public static final int TagLightSource = 0x1000;
+
+    //the following 5 tags all have 3 values: val, min, max
+    public static final int TagWhiteBalanceComp = 0x1001;
+    public static final int TagSaturationSetting = 0x1010;
+    public static final int TagHueSetting = 0x1011;
+    public static final int TagContrastSetting = 0x1012;
+    public static final int TagSharpnessSetting = 0x1013;
+
+    // settings written by Camedia Master 4.x
+    public static final int TagCmExposureCompensation = 0x2000;
+    public static final int TagCmWhiteBalance = 0x2001;
+    public static final int TagCmWhiteBalanceComp = 0x2002;
+    public static final int TagCmWhiteBalanceGrayPoint = 0x2010;
+    public static final int TagCmSaturation = 0x2020;
+    public static final int TagCmHue = 0x2021;
+    public static final int TagCmContrast = 0x2022;
+    public static final int TagCmSharpness = 0x2023;
+
+    @NotNull
+    protected static final HashMap<Integer, String> _tagNameMap = new HashMap<Integer, String>();
+
+    static {
+        _tagNameMap.put(TagRawInfoVersion, "Raw Info Version");
+        _tagNameMap.put(TagWbRbLevelsUsed, "WB RB Levels Used");
+        _tagNameMap.put(TagWbRbLevelsAuto, "WB RB Levels Auto");
+        _tagNameMap.put(TagWbRbLevelsShade, "WB RB Levels Shade");
+        _tagNameMap.put(TagWbRbLevelsCloudy, "WB RB Levels Cloudy");
+        _tagNameMap.put(TagWbRbLevelsFineWeather, "WB RB Levels Fine Weather");
+        _tagNameMap.put(TagWbRbLevelsTungsten, "WB RB Levels Tungsten");
+        _tagNameMap.put(TagWbRbLevelsEveningSunlight, "WB RB Levels Evening Sunlight");
+        _tagNameMap.put(TagWbRbLevelsDaylightFluor, "WB RB Levels Daylight Fluor");
+        _tagNameMap.put(TagWbRbLevelsDayWhiteFluor, "WB RB Levels Day White Fluor");
+        _tagNameMap.put(TagWbRbLevelsCoolWhiteFluor, "WB RB Levels Cool White Fluor");
+        _tagNameMap.put(TagWbRbLevelsWhiteFluorescent, "WB RB Levels White Fluorescent");
+        _tagNameMap.put(TagColorMatrix2, "Color Matrix 2");
+        _tagNameMap.put(TagCoringFilter, "Coring Filter");
+        _tagNameMap.put(TagCoringValues, "Coring Values");
+        _tagNameMap.put(TagBlackLevel2, "Black Level 2");
+        _tagNameMap.put(TagYCbCrCoefficients, "YCbCrCoefficients");
+        _tagNameMap.put(TagValidPixelDepth, "Valid Pixel Depth");
+        _tagNameMap.put(TagCropLeft, "Crop Left");
+        _tagNameMap.put(TagCropTop, "Crop Top");
+        _tagNameMap.put(TagCropWidth, "Crop Width");
+        _tagNameMap.put(TagCropHeight, "Crop Height");
+        _tagNameMap.put(TagLightSource, "Light Source");
+
+        _tagNameMap.put(TagWhiteBalanceComp, "White Balance Comp");
+        _tagNameMap.put(TagSaturationSetting, "Saturation Setting");
+        _tagNameMap.put(TagHueSetting, "Hue Setting");
+        _tagNameMap.put(TagContrastSetting, "Contrast Setting");
+        _tagNameMap.put(TagSharpnessSetting, "Sharpness Setting");
+
+        _tagNameMap.put(TagCmExposureCompensation, "CM Exposure Compensation");
+        _tagNameMap.put(TagCmWhiteBalance, "CM White Balance");
+        _tagNameMap.put(TagCmWhiteBalanceComp, "CM White Balance Comp");
+        _tagNameMap.put(TagCmWhiteBalanceGrayPoint, "CM White Balance Gray Point");
+        _tagNameMap.put(TagCmSaturation, "CM Saturation");
+        _tagNameMap.put(TagCmHue, "CM Hue");
+        _tagNameMap.put(TagCmContrast, "CM Contrast");
+        _tagNameMap.put(TagCmSharpness, "CM Sharpness");
+    }
+
+    public OlympusRawInfoMakernoteDirectory()
+    {
+        this.setDescriptor(new OlympusRawInfoMakernoteDescriptor(this));
+    }
+
+    @Override
+    @NotNull
+    public String getName()
+    {
+        return "Olympus Raw Info";
+    }
+
+    @Override
+    @NotNull
+    protected HashMap<Integer, String> getTagNameMap()
+    {
+        return _tagNameMap;
+    }
+}


### PR DESCRIPTION
… to dotnet version.

This starts the port from dotnet's Olympus changes to Java. Some changes to the reader and handler were needed to allow some changes to be possible. There will be more coming, but since I'm not a Java guy it would be great if you could make any comments in the PR. I'd like to make sure the formatting and code style of forthcoming PR's are how you want them for Java.

- base Olympus Makernote updates
- CameraSettings updates
- Equipment updates
- RawDevelopment added
- adds the "MMOR\0\0" detector from drewnoakes/metadata-extractor-dotnet#32
- handles formatCode and tagid 0, similar to dotnet
