### PR TITLE
Make Metadata serializable

### DIFF
--- a/Source/com/drew/imaging/png/PngChunkType.java
+++ b/Source/com/drew/imaging/png/PngChunkType.java
@@ -21,7 +21,7 @@
 package com.drew.imaging.png;
 
 import com.drew.lang.annotations.NotNull;
-
+import java.io.Serializable;
 import java.io.UnsupportedEncodingException;
 import java.util.Arrays;
 import java.util.HashSet;
@@ -30,7 +30,8 @@ import java.util.Set;
 /**
  * @author Drew Noakes https://drewnoakes.com
  */
-public class PngChunkType
+@SuppressWarnings("serial")
+public class PngChunkType implements Serializable
 {
     private static final Set<String> _identifiersAllowingMultiples
         = new HashSet<String>(Arrays.asList("IDAT", "sPLT", "iTXt", "tEXt", "zTXt"));

--- a/Source/com/drew/metadata/Directory.java
+++ b/Source/com/drew/metadata/Directory.java
@@ -24,7 +24,7 @@ import com.drew.lang.Rational;
 import com.drew.lang.annotations.NotNull;
 import com.drew.lang.annotations.Nullable;
 import com.drew.lang.annotations.SuppressWarnings;
-
+import java.io.Serializable;
 import java.io.UnsupportedEncodingException;
 import java.lang.reflect.Array;
 import java.text.DateFormat;
@@ -41,7 +41,8 @@ import java.util.regex.Pattern;
  *
  * @author Drew Noakes https://drewnoakes.com
  */
-public abstract class Directory
+@java.lang.SuppressWarnings("serial")
+public abstract class Directory implements Serializable
 {
     private static final DecimalFormat _floatFormat = new DecimalFormat("0.###");
 

--- a/Source/com/drew/metadata/ErrorDirectory.java
+++ b/Source/com/drew/metadata/ErrorDirectory.java
@@ -29,6 +29,7 @@ import java.util.*;
  * @author Drew Noakes https://drewnoakes.com
  */
 
+@SuppressWarnings("serial")
 public final class ErrorDirectory extends Directory
 {
 

--- a/Source/com/drew/metadata/Metadata.java
+++ b/Source/com/drew/metadata/Metadata.java
@@ -22,7 +22,7 @@ package com.drew.metadata;
 
 import com.drew.lang.annotations.NotNull;
 import com.drew.lang.annotations.Nullable;
-
+import java.io.Serializable;
 import java.util.*;
 
 /**
@@ -33,7 +33,8 @@ import java.util.*;
  *
  * @author Drew Noakes https://drewnoakes.com
  */
-public final class Metadata
+@SuppressWarnings("serial")
+public final class Metadata implements Serializable
 {
     /**
      * The list of {@link Directory} instances in this container, in the order they were added.

--- a/Source/com/drew/metadata/StringValue.java
+++ b/Source/com/drew/metadata/StringValue.java
@@ -22,25 +22,31 @@ package com.drew.metadata;
 
 import com.drew.lang.annotations.NotNull;
 import com.drew.lang.annotations.Nullable;
-
+import java.io.IOException;
+import java.io.Serializable;
 import java.io.UnsupportedEncodingException;
 import java.nio.charset.Charset;
 
 /**
  * @author Drew Noakes https://drewnoakes.com
  */
-public final class StringValue
+@SuppressWarnings("serial")
+public final class StringValue implements Serializable
 {
     @NotNull
     private final byte[] _bytes;
 
     @Nullable
-    private final Charset _charset;
+    private transient Charset _charset;
+
+    @Nullable
+    private String _charsetName;
 
     public StringValue(@NotNull byte[] bytes, @Nullable Charset charset)
     {
         _bytes = bytes;
         _charset = charset;
+        _charsetName = charset != null ? charset.name() : null;
     }
 
     @NotNull
@@ -73,4 +79,12 @@ public final class StringValue
 
         return new String(_bytes);
     }
+
+    private void readObject(java.io.ObjectInputStream in) throws IOException, ClassNotFoundException {
+        in.defaultReadObject();
+        if (_charsetName != null) {
+            _charset = Charset.forName(_charsetName);
+        }
+    }
+
 }

--- a/Source/com/drew/metadata/Tag.java
+++ b/Source/com/drew/metadata/Tag.java
@@ -20,6 +20,7 @@
  */
 package com.drew.metadata;
 
+import java.io.Serializable;
 import com.drew.lang.annotations.NotNull;
 import com.drew.lang.annotations.Nullable;
 
@@ -29,7 +30,8 @@ import com.drew.lang.annotations.Nullable;
  *
  * @author Drew Noakes https://drewnoakes.com
  */
-public class Tag
+@SuppressWarnings("serial")
+public class Tag implements Serializable
 {
     private final int _tagType;
     @NotNull

--- a/Source/com/drew/metadata/TagDescriptor.java
+++ b/Source/com/drew/metadata/TagDescriptor.java
@@ -24,7 +24,7 @@ import com.drew.lang.Rational;
 import com.drew.lang.StringUtil;
 import com.drew.lang.annotations.NotNull;
 import com.drew.lang.annotations.Nullable;
-
+import java.io.Serializable;
 import java.io.UnsupportedEncodingException;
 import java.lang.reflect.Array;
 import java.math.RoundingMode;
@@ -42,7 +42,8 @@ import java.util.List;
  *
  * @author Drew Noakes https://drewnoakes.com
  */
-public class TagDescriptor<T extends Directory>
+@SuppressWarnings("serial")
+public class TagDescriptor<T extends Directory> implements Serializable
 {
     @NotNull
     protected final T _directory;

--- a/Source/com/drew/metadata/adobe/AdobeJpegDescriptor.java
+++ b/Source/com/drew/metadata/adobe/AdobeJpegDescriptor.java
@@ -29,7 +29,7 @@ import static com.drew.metadata.adobe.AdobeJpegDirectory.*;
 /**
  * Provides human-readable string versions of the tags stored in an AdobeJpegDirectory.
  */
-@SuppressWarnings("WeakerAccess")
+@SuppressWarnings({ "WeakerAccess", "serial" })
 public class AdobeJpegDescriptor extends TagDescriptor<AdobeJpegDirectory>
 {
     public AdobeJpegDescriptor(AdobeJpegDirectory directory)

--- a/Source/com/drew/metadata/adobe/AdobeJpegDirectory.java
+++ b/Source/com/drew/metadata/adobe/AdobeJpegDirectory.java
@@ -29,7 +29,7 @@ import java.util.HashMap;
 /**
  * Contains image encoding information for DCT filters, as stored by Adobe.
  */
-@SuppressWarnings("WeakerAccess")
+@SuppressWarnings({ "WeakerAccess", "serial" })
 public class AdobeJpegDirectory extends Directory {
 
     public static final int TAG_DCT_ENCODE_VERSION = 0;

--- a/Source/com/drew/metadata/bmp/BmpHeaderDescriptor.java
+++ b/Source/com/drew/metadata/bmp/BmpHeaderDescriptor.java
@@ -29,7 +29,7 @@ import static com.drew.metadata.bmp.BmpHeaderDirectory.*;
 /**
  * @author Drew Noakes https://drewnoakes.com
  */
-@SuppressWarnings("WeakerAccess")
+@SuppressWarnings({ "WeakerAccess", "serial" })
 public class BmpHeaderDescriptor extends TagDescriptor<BmpHeaderDirectory>
 {
     public BmpHeaderDescriptor(@NotNull BmpHeaderDirectory directory)

--- a/Source/com/drew/metadata/bmp/BmpHeaderDirectory.java
+++ b/Source/com/drew/metadata/bmp/BmpHeaderDirectory.java
@@ -28,7 +28,7 @@ import java.util.HashMap;
 /**
  * @author Drew Noakes https://drewnoakes.com
  */
-@SuppressWarnings("WeakerAccess")
+@SuppressWarnings({ "WeakerAccess", "serial" })
 public class BmpHeaderDirectory extends Directory
 {
     public static final int TAG_HEADER_SIZE = -1;

--- a/Source/com/drew/metadata/exif/ExifDescriptorBase.java
+++ b/Source/com/drew/metadata/exif/ExifDescriptorBase.java
@@ -42,7 +42,7 @@ import static com.drew.metadata.exif.ExifDirectoryBase.*;
  *
  * @author Drew Noakes https://drewnoakes.com
  */
-@SuppressWarnings("WeakerAccess")
+@SuppressWarnings({ "WeakerAccess", "serial" })
 public abstract class ExifDescriptorBase<T extends Directory> extends TagDescriptor<T>
 {
     /**

--- a/Source/com/drew/metadata/exif/ExifDirectoryBase.java
+++ b/Source/com/drew/metadata/exif/ExifDirectoryBase.java
@@ -30,7 +30,7 @@ import java.util.HashMap;
  *
  * @author Drew Noakes https://drewnoakes.com
  */
-@SuppressWarnings("WeakerAccess")
+@SuppressWarnings({ "WeakerAccess", "serial" })
 public abstract class ExifDirectoryBase extends Directory
 {
     public static final int TAG_INTEROP_INDEX = 0x0001;

--- a/Source/com/drew/metadata/exif/ExifIFD0Descriptor.java
+++ b/Source/com/drew/metadata/exif/ExifIFD0Descriptor.java
@@ -28,7 +28,7 @@ import com.drew.lang.annotations.NotNull;
  *
  * @author Drew Noakes https://drewnoakes.com
  */
-@SuppressWarnings("WeakerAccess")
+@SuppressWarnings({ "WeakerAccess", "serial" })
 public class ExifIFD0Descriptor extends ExifDescriptorBase<ExifIFD0Directory>
 {
     public ExifIFD0Descriptor(@NotNull ExifIFD0Directory directory)

--- a/Source/com/drew/metadata/exif/ExifIFD0Directory.java
+++ b/Source/com/drew/metadata/exif/ExifIFD0Directory.java
@@ -30,7 +30,7 @@ import java.util.HashMap;
  *
  * @author Drew Noakes https://drewnoakes.com
  */
-@SuppressWarnings("WeakerAccess")
+@SuppressWarnings({ "WeakerAccess", "serial" })
 public class ExifIFD0Directory extends ExifDirectoryBase
 {
     /** This tag is a pointer to the Exif SubIFD. */

--- a/Source/com/drew/metadata/exif/ExifInteropDescriptor.java
+++ b/Source/com/drew/metadata/exif/ExifInteropDescriptor.java
@@ -27,7 +27,7 @@ import com.drew.lang.annotations.NotNull;
  *
  * @author Drew Noakes https://drewnoakes.com
  */
-@SuppressWarnings("WeakerAccess")
+@SuppressWarnings({ "WeakerAccess", "serial" })
 public class ExifInteropDescriptor extends ExifDescriptorBase<ExifInteropDirectory>
 {
     public ExifInteropDescriptor(@NotNull ExifInteropDirectory directory)

--- a/Source/com/drew/metadata/exif/ExifInteropDirectory.java
+++ b/Source/com/drew/metadata/exif/ExifInteropDirectory.java
@@ -29,7 +29,7 @@ import java.util.HashMap;
  *
  * @author Drew Noakes https://drewnoakes.com
  */
-@SuppressWarnings("WeakerAccess")
+@SuppressWarnings({ "WeakerAccess", "serial" })
 public class ExifInteropDirectory extends ExifDirectoryBase
 {
     @NotNull

--- a/Source/com/drew/metadata/exif/ExifSubIFDDescriptor.java
+++ b/Source/com/drew/metadata/exif/ExifSubIFDDescriptor.java
@@ -27,7 +27,7 @@ import com.drew.lang.annotations.NotNull;
  *
  * @author Drew Noakes https://drewnoakes.com
  */
-@SuppressWarnings("WeakerAccess")
+@SuppressWarnings({ "WeakerAccess", "serial" })
 public class ExifSubIFDDescriptor extends ExifDescriptorBase<ExifSubIFDDirectory>
 {
     public ExifSubIFDDescriptor(@NotNull ExifSubIFDDirectory directory)

--- a/Source/com/drew/metadata/exif/ExifSubIFDDirectory.java
+++ b/Source/com/drew/metadata/exif/ExifSubIFDDirectory.java
@@ -32,7 +32,7 @@ import java.util.TimeZone;
  *
  * @author Drew Noakes https://drewnoakes.com
  */
-@SuppressWarnings("WeakerAccess")
+@SuppressWarnings({ "WeakerAccess", "serial" })
 public class ExifSubIFDDirectory extends ExifDirectoryBase
 {
     /** This tag is a pointer to the Exif Interop IFD. */

--- a/Source/com/drew/metadata/exif/ExifThumbnailDescriptor.java
+++ b/Source/com/drew/metadata/exif/ExifThumbnailDescriptor.java
@@ -31,7 +31,7 @@ import static com.drew.metadata.exif.ExifThumbnailDirectory.*;
  *
  * @author Drew Noakes https://drewnoakes.com
  */
-@SuppressWarnings("WeakerAccess")
+@SuppressWarnings({ "WeakerAccess", "serial" })
 public class ExifThumbnailDescriptor extends ExifDescriptorBase<ExifThumbnailDirectory>
 {
     public ExifThumbnailDescriptor(@NotNull ExifThumbnailDirectory directory)

--- a/Source/com/drew/metadata/exif/ExifThumbnailDirectory.java
+++ b/Source/com/drew/metadata/exif/ExifThumbnailDirectory.java
@@ -34,7 +34,7 @@ import java.util.HashMap;
  *
  * @author Drew Noakes https://drewnoakes.com
  */
-@SuppressWarnings("WeakerAccess")
+@SuppressWarnings({ "WeakerAccess", "serial" })
 public class ExifThumbnailDirectory extends ExifDirectoryBase
 {
     /**

--- a/Source/com/drew/metadata/exif/GpsDescriptor.java
+++ b/Source/com/drew/metadata/exif/GpsDescriptor.java
@@ -35,7 +35,7 @@ import static com.drew.metadata.exif.GpsDirectory.*;
  *
  * @author Drew Noakes https://drewnoakes.com
  */
-@SuppressWarnings("WeakerAccess")
+@SuppressWarnings({ "WeakerAccess", "serial" })
 public class GpsDescriptor extends TagDescriptor<GpsDirectory>
 {
     public GpsDescriptor(@NotNull GpsDirectory directory)

--- a/Source/com/drew/metadata/exif/GpsDirectory.java
+++ b/Source/com/drew/metadata/exif/GpsDirectory.java
@@ -37,7 +37,7 @@ import java.util.Locale;
  *
  * @author Drew Noakes https://drewnoakes.com
  */
-@SuppressWarnings("WeakerAccess")
+@SuppressWarnings({ "WeakerAccess", "serial" })
 public class GpsDirectory extends ExifDirectoryBase
 {
     /** GPS tag version GPSVersionID 0 0 BYTE 4 */

--- a/Source/com/drew/metadata/exif/PanasonicRawDistortionDescriptor.java
+++ b/Source/com/drew/metadata/exif/PanasonicRawDistortionDescriptor.java
@@ -34,7 +34,7 @@ import static com.drew.metadata.exif.PanasonicRawDistortionDirectory.*;
  * @author Kevin Mott https://github.com/kwhopper
  * @author Drew Noakes https://drewnoakes.com
  */
-@SuppressWarnings("WeakerAccess")
+@SuppressWarnings({ "WeakerAccess", "serial" })
 public class PanasonicRawDistortionDescriptor extends TagDescriptor<PanasonicRawDistortionDirectory>
 {
     public PanasonicRawDistortionDescriptor(@NotNull PanasonicRawDistortionDirectory directory)

--- a/Source/com/drew/metadata/exif/PanasonicRawDistortionDirectory.java
+++ b/Source/com/drew/metadata/exif/PanasonicRawDistortionDirectory.java
@@ -33,7 +33,7 @@ import java.util.HashMap;
  * @author Kevin Mott https://github.com/kwhopper
  * @author Drew Noakes https://drewnoakes.com
  */
-@SuppressWarnings("WeakerAccess")
+@SuppressWarnings({ "WeakerAccess", "serial" })
 public class PanasonicRawDistortionDirectory extends Directory
 {
     // 0 and 1 are checksums

--- a/Source/com/drew/metadata/exif/PanasonicRawIFD0Descriptor.java
+++ b/Source/com/drew/metadata/exif/PanasonicRawIFD0Descriptor.java
@@ -33,7 +33,7 @@ import static com.drew.metadata.exif.PanasonicRawIFD0Directory.*;
  * @author Kevin Mott https://github.com/kwhopper
  * @author Drew Noakes https://drewnoakes.com
  */
-@SuppressWarnings("WeakerAccess")
+@SuppressWarnings({ "WeakerAccess", "serial" })
 public class PanasonicRawIFD0Descriptor extends TagDescriptor<PanasonicRawIFD0Directory>
 {
     public PanasonicRawIFD0Descriptor(@NotNull PanasonicRawIFD0Directory directory)

--- a/Source/com/drew/metadata/exif/PanasonicRawIFD0Directory.java
+++ b/Source/com/drew/metadata/exif/PanasonicRawIFD0Directory.java
@@ -32,7 +32,7 @@ import java.util.HashMap;
  * @author Kevin Mott https://github.com/kwhopper
  * @author Drew Noakes https://drewnoakes.com
  */
-@SuppressWarnings("WeakerAccess")
+@SuppressWarnings({ "WeakerAccess", "serial" })
 public class PanasonicRawIFD0Directory extends Directory
 {
     public static final int TagPanasonicRawVersion = 0x0001;

--- a/Source/com/drew/metadata/exif/PanasonicRawWbInfo2Descriptor.java
+++ b/Source/com/drew/metadata/exif/PanasonicRawWbInfo2Descriptor.java
@@ -33,7 +33,7 @@ import static com.drew.metadata.exif.PanasonicRawWbInfo2Directory.*;
  * @author Kevin Mott https://github.com/kwhopper
  * @author Drew Noakes https://drewnoakes.com
  */
-@SuppressWarnings("WeakerAccess")
+@SuppressWarnings({ "WeakerAccess", "serial" })
 public class PanasonicRawWbInfo2Descriptor extends TagDescriptor<PanasonicRawWbInfo2Directory>
 {
     public PanasonicRawWbInfo2Descriptor(@NotNull PanasonicRawWbInfo2Directory directory)

--- a/Source/com/drew/metadata/exif/PanasonicRawWbInfo2Directory.java
+++ b/Source/com/drew/metadata/exif/PanasonicRawWbInfo2Directory.java
@@ -33,7 +33,7 @@ import java.util.HashMap;
  * @author Kevin Mott https://github.com/kwhopper
  * @author Drew Noakes https://drewnoakes.com
  */
-@SuppressWarnings("WeakerAccess")
+@SuppressWarnings({ "WeakerAccess", "serial" })
 public class PanasonicRawWbInfo2Directory extends Directory
 {
     public static final int TagNumWbEntries = 0;

--- a/Source/com/drew/metadata/exif/PanasonicRawWbInfoDescriptor.java
+++ b/Source/com/drew/metadata/exif/PanasonicRawWbInfoDescriptor.java
@@ -33,7 +33,7 @@ import static com.drew.metadata.exif.PanasonicRawWbInfoDirectory.*;
  * @author Kevin Mott https://github.com/kwhopper
  * @author Drew Noakes https://drewnoakes.com
  */
-@SuppressWarnings("WeakerAccess")
+@SuppressWarnings({ "WeakerAccess", "serial" })
 public class PanasonicRawWbInfoDescriptor extends TagDescriptor<PanasonicRawWbInfoDirectory>
 {
     public PanasonicRawWbInfoDescriptor(@NotNull PanasonicRawWbInfoDirectory directory)

--- a/Source/com/drew/metadata/exif/PanasonicRawWbInfoDirectory.java
+++ b/Source/com/drew/metadata/exif/PanasonicRawWbInfoDirectory.java
@@ -33,7 +33,7 @@ import java.util.HashMap;
  * @author Kevin Mott https://github.com/kwhopper
  * @author Drew Noakes https://drewnoakes.com
  */
-@SuppressWarnings("WeakerAccess")
+@SuppressWarnings({ "WeakerAccess", "serial" })
 public class PanasonicRawWbInfoDirectory extends Directory
 {
     public static final int TagNumWbEntries = 0;

--- a/Source/com/drew/metadata/exif/PrintIMDescriptor.java
+++ b/Source/com/drew/metadata/exif/PrintIMDescriptor.java
@@ -33,7 +33,7 @@ import static com.drew.metadata.exif.PrintIMDirectory.*;
  * @author Kevin Mott https://github.com/kwhopper
  * @author Drew Noakes https://drewnoakes.com
  */
-@SuppressWarnings("WeakerAccess")
+@SuppressWarnings({ "WeakerAccess", "serial" })
 public class PrintIMDescriptor extends TagDescriptor<PrintIMDirectory>
 {
     public PrintIMDescriptor(@NotNull PrintIMDirectory directory)

--- a/Source/com/drew/metadata/exif/PrintIMDirectory.java
+++ b/Source/com/drew/metadata/exif/PrintIMDirectory.java
@@ -33,7 +33,7 @@ import java.util.HashMap;
  * @author Kevin Mott https://github.com/kwhopper
  * @author Drew Noakes https://drewnoakes.com
  */
-@SuppressWarnings("WeakerAccess")
+@SuppressWarnings({ "WeakerAccess", "serial" })
 public class PrintIMDirectory extends Directory
 {
     public static final int TagPrintImVersion = 0x0000;

--- a/Source/com/drew/metadata/exif/makernotes/AppleMakernoteDescriptor.java
+++ b/Source/com/drew/metadata/exif/makernotes/AppleMakernoteDescriptor.java
@@ -31,7 +31,7 @@ import com.drew.metadata.TagDescriptor;
  *
  * @author Drew Noakes https://drewnoakes.com
  */
-@SuppressWarnings("WeakerAccess")
+@SuppressWarnings({ "WeakerAccess", "serial" })
 public class AppleMakernoteDescriptor extends TagDescriptor<AppleMakernoteDirectory>
 {
     public AppleMakernoteDescriptor(@NotNull AppleMakernoteDirectory directory)

--- a/Source/com/drew/metadata/exif/makernotes/AppleMakernoteDirectory.java
+++ b/Source/com/drew/metadata/exif/makernotes/AppleMakernoteDirectory.java
@@ -32,7 +32,7 @@ import java.util.HashMap;
  *
  * @author Drew Noakes https://drewnoakes.com
  */
-@SuppressWarnings("WeakerAccess")
+@SuppressWarnings({ "WeakerAccess", "serial" })
 public class AppleMakernoteDirectory extends Directory
 {
     public static final int TAG_RUN_TIME = 0x0003;

--- a/Source/com/drew/metadata/exif/makernotes/CanonMakernoteDescriptor.java
+++ b/Source/com/drew/metadata/exif/makernotes/CanonMakernoteDescriptor.java
@@ -34,7 +34,7 @@ import static com.drew.metadata.exif.makernotes.CanonMakernoteDirectory.*;
  *
  * @author Drew Noakes https://drewnoakes.com
  */
-@SuppressWarnings("WeakerAccess")
+@SuppressWarnings({ "WeakerAccess", "serial" })
 public class CanonMakernoteDescriptor extends TagDescriptor<CanonMakernoteDirectory>
 {
     public CanonMakernoteDescriptor(@NotNull CanonMakernoteDirectory directory)

--- a/Source/com/drew/metadata/exif/makernotes/CanonMakernoteDirectory.java
+++ b/Source/com/drew/metadata/exif/makernotes/CanonMakernoteDirectory.java
@@ -34,7 +34,7 @@ import java.util.HashMap;
  *
  * @author Drew Noakes https://drewnoakes.com
  */
-@SuppressWarnings("WeakerAccess")
+@SuppressWarnings({ "WeakerAccess", "serial" })
 public class CanonMakernoteDirectory extends Directory
 {
     // These TAG_*_ARRAY Exif tags map to arrays of int16 values which are split out into separate 'fake' tags.

--- a/Source/com/drew/metadata/exif/makernotes/CasioType1MakernoteDescriptor.java
+++ b/Source/com/drew/metadata/exif/makernotes/CasioType1MakernoteDescriptor.java
@@ -31,7 +31,7 @@ import static com.drew.metadata.exif.makernotes.CasioType1MakernoteDirectory.*;
  *
  * @author Drew Noakes https://drewnoakes.com
  */
-@SuppressWarnings("WeakerAccess")
+@SuppressWarnings({ "WeakerAccess", "serial" })
 public class CasioType1MakernoteDescriptor extends TagDescriptor<CasioType1MakernoteDirectory>
 {
     public CasioType1MakernoteDescriptor(@NotNull CasioType1MakernoteDirectory directory)

--- a/Source/com/drew/metadata/exif/makernotes/CasioType1MakernoteDirectory.java
+++ b/Source/com/drew/metadata/exif/makernotes/CasioType1MakernoteDirectory.java
@@ -33,7 +33,7 @@ import java.util.HashMap;
  *
  * @author Drew Noakes https://drewnoakes.com
  */
-@SuppressWarnings("WeakerAccess")
+@SuppressWarnings({ "WeakerAccess", "serial" })
 public class CasioType1MakernoteDirectory extends Directory
 {
     public static final int TAG_RECORDING_MODE = 0x0001;

--- a/Source/com/drew/metadata/exif/makernotes/CasioType2MakernoteDescriptor.java
+++ b/Source/com/drew/metadata/exif/makernotes/CasioType2MakernoteDescriptor.java
@@ -31,7 +31,7 @@ import static com.drew.metadata.exif.makernotes.CasioType2MakernoteDirectory.*;
  *
  * @author Drew Noakes https://drewnoakes.com
  */
-@SuppressWarnings("WeakerAccess")
+@SuppressWarnings({ "WeakerAccess", "serial" })
 public class CasioType2MakernoteDescriptor extends TagDescriptor<CasioType2MakernoteDirectory>
 {
     public CasioType2MakernoteDescriptor(@NotNull CasioType2MakernoteDirectory directory)

--- a/Source/com/drew/metadata/exif/makernotes/CasioType2MakernoteDirectory.java
+++ b/Source/com/drew/metadata/exif/makernotes/CasioType2MakernoteDirectory.java
@@ -33,7 +33,7 @@ import java.util.HashMap;
  *
  * @author Drew Noakes https://drewnoakes.com
  */
-@SuppressWarnings("WeakerAccess")
+@SuppressWarnings({ "WeakerAccess", "serial" })
 public class CasioType2MakernoteDirectory extends Directory
 {
     /**

--- a/Source/com/drew/metadata/exif/makernotes/FujifilmMakernoteDescriptor.java
+++ b/Source/com/drew/metadata/exif/makernotes/FujifilmMakernoteDescriptor.java
@@ -48,7 +48,7 @@ import static com.drew.metadata.exif.makernotes.FujifilmMakernoteDirectory.*;
  *
  * @author Drew Noakes https://drewnoakes.com
  */
-@SuppressWarnings("WeakerAccess")
+@SuppressWarnings({ "WeakerAccess", "serial" })
 public class FujifilmMakernoteDescriptor extends TagDescriptor<FujifilmMakernoteDirectory>
 {
     public FujifilmMakernoteDescriptor(@NotNull FujifilmMakernoteDirectory directory)

--- a/Source/com/drew/metadata/exif/makernotes/FujifilmMakernoteDirectory.java
+++ b/Source/com/drew/metadata/exif/makernotes/FujifilmMakernoteDirectory.java
@@ -30,7 +30,7 @@ import java.util.HashMap;
  *
  * @author Drew Noakes https://drewnoakes.com
  */
-@SuppressWarnings("WeakerAccess")
+@SuppressWarnings({ "WeakerAccess", "serial" })
 public class FujifilmMakernoteDirectory extends Directory
 {
     public static final int TAG_MAKERNOTE_VERSION = 0x0000;

--- a/Source/com/drew/metadata/exif/makernotes/KodakMakernoteDescriptor.java
+++ b/Source/com/drew/metadata/exif/makernotes/KodakMakernoteDescriptor.java
@@ -31,7 +31,7 @@ import static com.drew.metadata.exif.makernotes.KodakMakernoteDirectory.*;
  *
  * @author Drew Noakes https://drewnoakes.com
  */
-@SuppressWarnings("WeakerAccess")
+@SuppressWarnings({ "WeakerAccess", "serial" })
 public class KodakMakernoteDescriptor extends TagDescriptor<KodakMakernoteDirectory>
 {
     public KodakMakernoteDescriptor(@NotNull KodakMakernoteDirectory directory)

--- a/Source/com/drew/metadata/exif/makernotes/KodakMakernoteDirectory.java
+++ b/Source/com/drew/metadata/exif/makernotes/KodakMakernoteDirectory.java
@@ -30,7 +30,7 @@ import java.util.HashMap;
  *
  * @author Drew Noakes https://drewnoakes.com
  */
-@SuppressWarnings("WeakerAccess")
+@SuppressWarnings({ "WeakerAccess", "serial" })
 public class KodakMakernoteDirectory extends Directory
 {
     public final static int TAG_KODAK_MODEL = 0;

--- a/Source/com/drew/metadata/exif/makernotes/KyoceraMakernoteDescriptor.java
+++ b/Source/com/drew/metadata/exif/makernotes/KyoceraMakernoteDescriptor.java
@@ -38,7 +38,7 @@ import static com.drew.metadata.exif.makernotes.KyoceraMakernoteDirectory.*;
  *
  * @author Drew Noakes https://drewnoakes.com
  */
-@SuppressWarnings("WeakerAccess")
+@SuppressWarnings({ "WeakerAccess", "serial" })
 public class KyoceraMakernoteDescriptor extends TagDescriptor<KyoceraMakernoteDirectory>
 {
     public KyoceraMakernoteDescriptor(@NotNull KyoceraMakernoteDirectory directory)

--- a/Source/com/drew/metadata/exif/makernotes/KyoceraMakernoteDirectory.java
+++ b/Source/com/drew/metadata/exif/makernotes/KyoceraMakernoteDirectory.java
@@ -30,7 +30,7 @@ import java.util.HashMap;
  *
  * @author Drew Noakes https://drewnoakes.com
  */
-@SuppressWarnings("WeakerAccess")
+@SuppressWarnings({ "WeakerAccess", "serial" })
 public class KyoceraMakernoteDirectory extends Directory
 {
     public static final int TAG_PROPRIETARY_THUMBNAIL = 0x0001;

--- a/Source/com/drew/metadata/exif/makernotes/LeicaMakernoteDescriptor.java
+++ b/Source/com/drew/metadata/exif/makernotes/LeicaMakernoteDescriptor.java
@@ -33,7 +33,7 @@ import static com.drew.metadata.exif.makernotes.LeicaMakernoteDirectory.*;
  *
  * @author Drew Noakes https://drewnoakes.com
  */
-@SuppressWarnings("WeakerAccess")
+@SuppressWarnings({ "WeakerAccess", "serial" })
 public class LeicaMakernoteDescriptor extends TagDescriptor<LeicaMakernoteDirectory>
 {
     public LeicaMakernoteDescriptor(@NotNull LeicaMakernoteDirectory directory)

--- a/Source/com/drew/metadata/exif/makernotes/LeicaMakernoteDirectory.java
+++ b/Source/com/drew/metadata/exif/makernotes/LeicaMakernoteDirectory.java
@@ -32,7 +32,7 @@ import java.util.HashMap;
  *
  * @author Drew Noakes https://drewnoakes.com
  */
-@SuppressWarnings("WeakerAccess")
+@SuppressWarnings({ "WeakerAccess", "serial" })
 public class LeicaMakernoteDirectory extends Directory
 {
     public static final int TAG_QUALITY = 0x0300;

--- a/Source/com/drew/metadata/exif/makernotes/LeicaType5MakernoteDescriptor.java
+++ b/Source/com/drew/metadata/exif/makernotes/LeicaType5MakernoteDescriptor.java
@@ -34,7 +34,7 @@ import static com.drew.metadata.exif.makernotes.LeicaType5MakernoteDirectory.*;
  * @author Kevin Mott https://github.com/kwhopper
  * @author Drew Noakes https://drewnoakes.com
  */
-@SuppressWarnings("WeakerAccess")
+@SuppressWarnings({ "WeakerAccess", "serial" })
 public class LeicaType5MakernoteDescriptor extends TagDescriptor<LeicaType5MakernoteDirectory>
 {
     public LeicaType5MakernoteDescriptor(@NotNull LeicaType5MakernoteDirectory directory)

--- a/Source/com/drew/metadata/exif/makernotes/LeicaType5MakernoteDirectory.java
+++ b/Source/com/drew/metadata/exif/makernotes/LeicaType5MakernoteDirectory.java
@@ -33,7 +33,7 @@ import java.util.HashMap;
  * @author Kevin Mott https://github.com/kwhopper
  * @author Drew Noakes https://drewnoakes.com
  */
-@SuppressWarnings("WeakerAccess")
+@SuppressWarnings({ "WeakerAccess", "serial" })
 public class LeicaType5MakernoteDirectory extends Directory
 {
     public static final int TagLensModel = 0x0303;

--- a/Source/com/drew/metadata/exif/makernotes/NikonType1MakernoteDescriptor.java
+++ b/Source/com/drew/metadata/exif/makernotes/NikonType1MakernoteDescriptor.java
@@ -43,7 +43,7 @@ import static com.drew.metadata.exif.makernotes.NikonType1MakernoteDirectory.*;
  *
  * @author Drew Noakes https://drewnoakes.com
  */
-@SuppressWarnings("WeakerAccess")
+@SuppressWarnings({ "WeakerAccess", "serial" })
 public class NikonType1MakernoteDescriptor extends TagDescriptor<NikonType1MakernoteDirectory>
 {
     public NikonType1MakernoteDescriptor(@NotNull NikonType1MakernoteDirectory directory)

--- a/Source/com/drew/metadata/exif/makernotes/NikonType1MakernoteDirectory.java
+++ b/Source/com/drew/metadata/exif/makernotes/NikonType1MakernoteDirectory.java
@@ -39,7 +39,7 @@ import java.util.HashMap;
  *
  * @author Drew Noakes https://drewnoakes.com
  */
-@SuppressWarnings("WeakerAccess")
+@SuppressWarnings({ "WeakerAccess", "serial" })
 public class NikonType1MakernoteDirectory extends Directory
 {
     public static final int TAG_UNKNOWN_1 = 0x0002;

--- a/Source/com/drew/metadata/exif/makernotes/NikonType2MakernoteDescriptor.java
+++ b/Source/com/drew/metadata/exif/makernotes/NikonType2MakernoteDescriptor.java
@@ -36,7 +36,7 @@ import static com.drew.metadata.exif.makernotes.NikonType2MakernoteDirectory.*;
  *
  * @author Drew Noakes https://drewnoakes.com
  */
-@SuppressWarnings("WeakerAccess")
+@SuppressWarnings({ "WeakerAccess", "serial" })
 public class NikonType2MakernoteDescriptor extends TagDescriptor<NikonType2MakernoteDirectory>
 {
     public NikonType2MakernoteDescriptor(@NotNull NikonType2MakernoteDirectory directory)

--- a/Source/com/drew/metadata/exif/makernotes/NikonType2MakernoteDirectory.java
+++ b/Source/com/drew/metadata/exif/makernotes/NikonType2MakernoteDirectory.java
@@ -44,7 +44,7 @@ import java.util.HashMap;
  *
  * @author Drew Noakes https://drewnoakes.com
  */
-@SuppressWarnings("WeakerAccess")
+@SuppressWarnings({ "WeakerAccess", "serial" })
 public class NikonType2MakernoteDirectory extends Directory
 {
     /**

--- a/Source/com/drew/metadata/exif/makernotes/OlympusCameraSettingsMakernoteDescriptor.java
+++ b/Source/com/drew/metadata/exif/makernotes/OlympusCameraSettingsMakernoteDescriptor.java
@@ -40,7 +40,7 @@ import static com.drew.metadata.exif.makernotes.OlympusCameraSettingsMakernoteDi
  * @author Kevin Mott https://github.com/kwhopper
  * @author Drew Noakes https://drewnoakes.com
  */
-@SuppressWarnings("WeakerAccess")
+@SuppressWarnings({ "WeakerAccess", "serial" })
 public class OlympusCameraSettingsMakernoteDescriptor extends TagDescriptor<OlympusCameraSettingsMakernoteDirectory>
 {
     public OlympusCameraSettingsMakernoteDescriptor(@NotNull OlympusCameraSettingsMakernoteDirectory directory)

--- a/Source/com/drew/metadata/exif/makernotes/OlympusCameraSettingsMakernoteDirectory.java
+++ b/Source/com/drew/metadata/exif/makernotes/OlympusCameraSettingsMakernoteDirectory.java
@@ -32,7 +32,7 @@ import java.util.HashMap;
  * @author Kevin Mott https://github.com/kwhopper
  * @author Drew Noakes https://drewnoakes.com
  */
-@SuppressWarnings("WeakerAccess")
+@SuppressWarnings({ "WeakerAccess", "serial" })
 public class OlympusCameraSettingsMakernoteDirectory extends Directory
 {
     public static final int TagCameraSettingsVersion = 0x0000;

--- a/Source/com/drew/metadata/exif/makernotes/OlympusEquipmentMakernoteDescriptor.java
+++ b/Source/com/drew/metadata/exif/makernotes/OlympusEquipmentMakernoteDescriptor.java
@@ -39,7 +39,7 @@ import static com.drew.metadata.exif.makernotes.OlympusEquipmentMakernoteDirecto
  * @author Kevin Mott https://github.com/kwhopper
  * @author Drew Noakes https://drewnoakes.com
  */
-@SuppressWarnings("WeakerAccess")
+@SuppressWarnings({ "WeakerAccess", "serial" })
 public class OlympusEquipmentMakernoteDescriptor extends TagDescriptor<OlympusEquipmentMakernoteDirectory>
 {
     public OlympusEquipmentMakernoteDescriptor(@NotNull OlympusEquipmentMakernoteDirectory directory)

--- a/Source/com/drew/metadata/exif/makernotes/OlympusEquipmentMakernoteDirectory.java
+++ b/Source/com/drew/metadata/exif/makernotes/OlympusEquipmentMakernoteDirectory.java
@@ -32,7 +32,7 @@ import java.util.HashMap;
  * @author Kevin Mott https://github.com/kwhopper
  * @author Drew Noakes https://drewnoakes.com
  */
-@SuppressWarnings("WeakerAccess")
+@SuppressWarnings({ "WeakerAccess", "serial" })
 public class OlympusEquipmentMakernoteDirectory extends Directory
 {
     public static final int TAG_EQUIPMENT_VERSION = 0x0000;

--- a/Source/com/drew/metadata/exif/makernotes/OlympusFocusInfoMakernoteDescriptor.java
+++ b/Source/com/drew/metadata/exif/makernotes/OlympusFocusInfoMakernoteDescriptor.java
@@ -37,7 +37,7 @@ import static com.drew.metadata.exif.makernotes.OlympusFocusInfoMakernoteDirecto
  * @author Kevin Mott https://github.com/kwhopper
  * @author Drew Noakes https://drewnoakes.com
  */
-@SuppressWarnings("WeakerAccess")
+@SuppressWarnings({ "WeakerAccess", "serial" })
 public class OlympusFocusInfoMakernoteDescriptor extends TagDescriptor<OlympusFocusInfoMakernoteDirectory>
 {
     public OlympusFocusInfoMakernoteDescriptor(@NotNull OlympusFocusInfoMakernoteDirectory directory)

--- a/Source/com/drew/metadata/exif/makernotes/OlympusFocusInfoMakernoteDirectory.java
+++ b/Source/com/drew/metadata/exif/makernotes/OlympusFocusInfoMakernoteDirectory.java
@@ -32,7 +32,7 @@ import java.util.HashMap;
  * @author Kevin Mott https://github.com/kwhopper
  * @author Drew Noakes https://drewnoakes.com
  */
-@SuppressWarnings("WeakerAccess")
+@SuppressWarnings({ "WeakerAccess", "serial" })
 public class OlympusFocusInfoMakernoteDirectory extends Directory
 {
     public static final int TagFocusInfoVersion = 0x0000;

--- a/Source/com/drew/metadata/exif/makernotes/OlympusImageProcessingMakernoteDescriptor.java
+++ b/Source/com/drew/metadata/exif/makernotes/OlympusImageProcessingMakernoteDescriptor.java
@@ -36,7 +36,7 @@ import static com.drew.metadata.exif.makernotes.OlympusImageProcessingMakernoteD
  * @author Kevin Mott https://github.com/kwhopper
  * @author Drew Noakes https://drewnoakes.com
  */
-@SuppressWarnings("WeakerAccess")
+@SuppressWarnings({ "WeakerAccess", "serial" })
 public class OlympusImageProcessingMakernoteDescriptor extends TagDescriptor<OlympusImageProcessingMakernoteDirectory>
 {
     public OlympusImageProcessingMakernoteDescriptor(@NotNull OlympusImageProcessingMakernoteDirectory directory)

--- a/Source/com/drew/metadata/exif/makernotes/OlympusImageProcessingMakernoteDirectory.java
+++ b/Source/com/drew/metadata/exif/makernotes/OlympusImageProcessingMakernoteDirectory.java
@@ -32,7 +32,7 @@ import java.util.HashMap;
  * @author Kevin Mott https://github.com/kwhopper
  * @author Drew Noakes https://drewnoakes.com
  */
-@SuppressWarnings("WeakerAccess")
+@SuppressWarnings({ "WeakerAccess", "serial" })
 public class OlympusImageProcessingMakernoteDirectory extends Directory
 {
     public static final int TagImageProcessingVersion = 0x0000;

--- a/Source/com/drew/metadata/exif/makernotes/OlympusMakernoteDescriptor.java
+++ b/Source/com/drew/metadata/exif/makernotes/OlympusMakernoteDescriptor.java
@@ -39,7 +39,7 @@ import java.lang.reflect.Array;
  *
  * @author Drew Noakes https://drewnoakes.com
  */
-@SuppressWarnings("WeakerAccess")
+@SuppressWarnings({ "WeakerAccess", "serial" })
 public class OlympusMakernoteDescriptor extends TagDescriptor<OlympusMakernoteDirectory>
 {
     // TODO extend support for some offset-encoded byte[] tags: http://www.ozhiker.com/electronics/pjmt/jpeg_info/olympus_mn.html

--- a/Source/com/drew/metadata/exif/makernotes/OlympusMakernoteDirectory.java
+++ b/Source/com/drew/metadata/exif/makernotes/OlympusMakernoteDirectory.java
@@ -33,7 +33,7 @@ import java.util.HashMap;
  *
  * @author Drew Noakes https://drewnoakes.com
  */
-@SuppressWarnings("WeakerAccess")
+@SuppressWarnings({ "WeakerAccess", "serial" })
 public class OlympusMakernoteDirectory extends Directory
 {
     /** Used by Konica / Minolta cameras. */

--- a/Source/com/drew/metadata/exif/makernotes/OlympusRawDevelopment2MakernoteDescriptor.java
+++ b/Source/com/drew/metadata/exif/makernotes/OlympusRawDevelopment2MakernoteDescriptor.java
@@ -38,7 +38,7 @@ import static com.drew.metadata.exif.makernotes.OlympusRawDevelopment2MakernoteD
  * @author Kevin Mott https://github.com/kwhopper
  * @author Drew Noakes https://drewnoakes.com
  */
-@SuppressWarnings("WeakerAccess")
+@SuppressWarnings({ "WeakerAccess", "serial" })
 public class OlympusRawDevelopment2MakernoteDescriptor extends TagDescriptor<OlympusRawDevelopment2MakernoteDirectory>
 {
     public OlympusRawDevelopment2MakernoteDescriptor(@NotNull OlympusRawDevelopment2MakernoteDirectory directory)

--- a/Source/com/drew/metadata/exif/makernotes/OlympusRawDevelopment2MakernoteDirectory.java
+++ b/Source/com/drew/metadata/exif/makernotes/OlympusRawDevelopment2MakernoteDirectory.java
@@ -32,7 +32,7 @@ import java.util.HashMap;
  * @author Kevin Mott https://github.com/kwhopper
  * @author Drew Noakes https://drewnoakes.com
  */
-@SuppressWarnings("WeakerAccess")
+@SuppressWarnings({ "WeakerAccess", "serial" })
 public class OlympusRawDevelopment2MakernoteDirectory extends Directory
 {    
     public static final int TagRawDevVersion = 0x0000;

--- a/Source/com/drew/metadata/exif/makernotes/OlympusRawDevelopmentMakernoteDescriptor.java
+++ b/Source/com/drew/metadata/exif/makernotes/OlympusRawDevelopmentMakernoteDescriptor.java
@@ -36,7 +36,7 @@ import static com.drew.metadata.exif.makernotes.OlympusRawDevelopmentMakernoteDi
  * @author Kevin Mott https://github.com/kwhopper
  * @author Drew Noakes https://drewnoakes.com
  */
-@SuppressWarnings("WeakerAccess")
+@SuppressWarnings({ "WeakerAccess", "serial" })
 public class OlympusRawDevelopmentMakernoteDescriptor extends TagDescriptor<OlympusRawDevelopmentMakernoteDirectory>
 {
     public OlympusRawDevelopmentMakernoteDescriptor(@NotNull OlympusRawDevelopmentMakernoteDirectory directory)

--- a/Source/com/drew/metadata/exif/makernotes/OlympusRawDevelopmentMakernoteDirectory.java
+++ b/Source/com/drew/metadata/exif/makernotes/OlympusRawDevelopmentMakernoteDirectory.java
@@ -32,7 +32,7 @@ import java.util.HashMap;
  * @author Kevin Mott https://github.com/kwhopper
  * @author Drew Noakes https://drewnoakes.com
  */
-@SuppressWarnings("WeakerAccess")
+@SuppressWarnings({ "WeakerAccess", "serial" })
 public class OlympusRawDevelopmentMakernoteDirectory extends Directory
 {
     public static final int TagRawDevVersion = 0x0000;

--- a/Source/com/drew/metadata/exif/makernotes/OlympusRawInfoMakernoteDescriptor.java
+++ b/Source/com/drew/metadata/exif/makernotes/OlympusRawInfoMakernoteDescriptor.java
@@ -37,7 +37,7 @@ import static com.drew.metadata.exif.makernotes.OlympusRawInfoMakernoteDirectory
  * @author Kevin Mott https://github.com/kwhopper
  * @author Drew Noakes https://drewnoakes.com
  */
-@SuppressWarnings("WeakerAccess")
+@SuppressWarnings({ "WeakerAccess", "serial" })
 public class OlympusRawInfoMakernoteDescriptor extends TagDescriptor<OlympusRawInfoMakernoteDirectory>
 {
     public OlympusRawInfoMakernoteDescriptor(@NotNull OlympusRawInfoMakernoteDirectory directory)

--- a/Source/com/drew/metadata/exif/makernotes/OlympusRawInfoMakernoteDirectory.java
+++ b/Source/com/drew/metadata/exif/makernotes/OlympusRawInfoMakernoteDirectory.java
@@ -31,7 +31,7 @@ import java.util.HashMap;
  * @author Kevin Mott https://github.com/kwhopper
  * @author Drew Noakes https://drewnoakes.com
  */
-@SuppressWarnings("WeakerAccess")
+@SuppressWarnings({ "WeakerAccess", "serial" })
 public class OlympusRawInfoMakernoteDirectory extends Directory
 {
     public static final int TagRawInfoVersion = 0x0000;

--- a/Source/com/drew/metadata/exif/makernotes/PanasonicMakernoteDescriptor.java
+++ b/Source/com/drew/metadata/exif/makernotes/PanasonicMakernoteDescriptor.java
@@ -46,7 +46,7 @@ import static com.drew.metadata.exif.makernotes.PanasonicMakernoteDirectory.*;
  * @author Drew Noakes https://drewnoakes.com
  * @author Philipp Sandhaus
  */
-@SuppressWarnings("WeakerAccess")
+@SuppressWarnings({ "WeakerAccess", "serial" })
 public class PanasonicMakernoteDescriptor extends TagDescriptor<PanasonicMakernoteDirectory>
 {
     public PanasonicMakernoteDescriptor(@NotNull PanasonicMakernoteDirectory directory)

--- a/Source/com/drew/metadata/exif/makernotes/PanasonicMakernoteDirectory.java
+++ b/Source/com/drew/metadata/exif/makernotes/PanasonicMakernoteDirectory.java
@@ -37,7 +37,7 @@ import java.util.HashMap;
  * @author Drew Noakes https://drewnoakes.com
  * @author Philipp Sandhaus
  */
-@SuppressWarnings("WeakerAccess")
+@SuppressWarnings({ "WeakerAccess", "serial" })
 public class PanasonicMakernoteDirectory extends Directory
 {
 

--- a/Source/com/drew/metadata/exif/makernotes/PentaxMakernoteDescriptor.java
+++ b/Source/com/drew/metadata/exif/makernotes/PentaxMakernoteDescriptor.java
@@ -34,7 +34,7 @@ import static com.drew.metadata.exif.makernotes.PentaxMakernoteDirectory.*;
  *
  * @author Drew Noakes https://drewnoakes.com
  */
-@SuppressWarnings("WeakerAccess")
+@SuppressWarnings({ "WeakerAccess", "serial" })
 public class PentaxMakernoteDescriptor extends TagDescriptor<PentaxMakernoteDirectory>
 {
     public PentaxMakernoteDescriptor(@NotNull PentaxMakernoteDirectory directory)

--- a/Source/com/drew/metadata/exif/makernotes/PentaxMakernoteDirectory.java
+++ b/Source/com/drew/metadata/exif/makernotes/PentaxMakernoteDirectory.java
@@ -30,7 +30,7 @@ import java.util.HashMap;
  *
  * @author Drew Noakes https://drewnoakes.com
  */
-@SuppressWarnings("WeakerAccess")
+@SuppressWarnings({ "WeakerAccess", "serial" })
 public class PentaxMakernoteDirectory extends Directory
 {
     /**

--- a/Source/com/drew/metadata/exif/makernotes/RicohMakernoteDescriptor.java
+++ b/Source/com/drew/metadata/exif/makernotes/RicohMakernoteDescriptor.java
@@ -32,7 +32,7 @@ import com.drew.metadata.TagDescriptor;
  *
  * @author Drew Noakes https://drewnoakes.com
  */
-@SuppressWarnings("WeakerAccess")
+@SuppressWarnings({ "WeakerAccess", "serial" })
 public class RicohMakernoteDescriptor extends TagDescriptor<RicohMakernoteDirectory>
 {
     public RicohMakernoteDescriptor(@NotNull RicohMakernoteDirectory directory)

--- a/Source/com/drew/metadata/exif/makernotes/RicohMakernoteDirectory.java
+++ b/Source/com/drew/metadata/exif/makernotes/RicohMakernoteDirectory.java
@@ -30,7 +30,7 @@ import java.util.HashMap;
  *
  * @author Drew Noakes https://drewnoakes.com
  */
-@SuppressWarnings("WeakerAccess")
+@SuppressWarnings({ "WeakerAccess", "serial" })
 public class RicohMakernoteDirectory extends Directory
 {
     public static final int TAG_MAKERNOTE_DATA_TYPE = 0x0001;

--- a/Source/com/drew/metadata/exif/makernotes/SamsungType2MakernoteDescriptor.java
+++ b/Source/com/drew/metadata/exif/makernotes/SamsungType2MakernoteDescriptor.java
@@ -35,7 +35,7 @@ import static com.drew.metadata.exif.makernotes.SamsungType2MakernoteDirectory.*
  * @author Kevin Mott https://github.com/kwhopper
  * @author Drew Noakes https://drewnoakes.com
  */
-@SuppressWarnings("WeakerAccess")
+@SuppressWarnings({ "WeakerAccess", "serial" })
 public class SamsungType2MakernoteDescriptor extends TagDescriptor<SamsungType2MakernoteDirectory>
 {
     public SamsungType2MakernoteDescriptor(@NotNull SamsungType2MakernoteDirectory directory)

--- a/Source/com/drew/metadata/exif/makernotes/SamsungType2MakernoteDirectory.java
+++ b/Source/com/drew/metadata/exif/makernotes/SamsungType2MakernoteDirectory.java
@@ -34,7 +34,7 @@ import java.util.HashMap;
  * @author Kevin Mott https://github.com/kwhopper
  * @author Drew Noakes https://drewnoakes.com
  */
-@SuppressWarnings("WeakerAccess")
+@SuppressWarnings({ "WeakerAccess", "serial" })
 public class SamsungType2MakernoteDirectory extends Directory
 {
     // This list is incomplete

--- a/Source/com/drew/metadata/exif/makernotes/SanyoMakernoteDescriptor.java
+++ b/Source/com/drew/metadata/exif/makernotes/SanyoMakernoteDescriptor.java
@@ -32,7 +32,7 @@ import static com.drew.metadata.exif.makernotes.SanyoMakernoteDirectory.*;
  *
  * @author Drew Noakes https://drewnoakes.com
  */
-@SuppressWarnings("WeakerAccess")
+@SuppressWarnings({ "WeakerAccess", "serial" })
 public class SanyoMakernoteDescriptor extends TagDescriptor<SanyoMakernoteDirectory>
 {
     public SanyoMakernoteDescriptor(@NotNull SanyoMakernoteDirectory directory)

--- a/Source/com/drew/metadata/exif/makernotes/SanyoMakernoteDirectory.java
+++ b/Source/com/drew/metadata/exif/makernotes/SanyoMakernoteDirectory.java
@@ -31,7 +31,7 @@ import java.util.HashMap;
  *
  * @author Drew Noakes https://drewnoakes.com
  */
-@SuppressWarnings("WeakerAccess")
+@SuppressWarnings({ "WeakerAccess", "serial" })
 public class SanyoMakernoteDirectory extends Directory
 {
     public static final int TAG_MAKERNOTE_OFFSET = 0x00ff;

--- a/Source/com/drew/metadata/exif/makernotes/SigmaMakernoteDescriptor.java
+++ b/Source/com/drew/metadata/exif/makernotes/SigmaMakernoteDescriptor.java
@@ -32,7 +32,7 @@ import static com.drew.metadata.exif.makernotes.SigmaMakernoteDirectory.*;
  *
  * @author Drew Noakes https://drewnoakes.com
  */
-@SuppressWarnings("WeakerAccess")
+@SuppressWarnings({ "WeakerAccess", "serial" })
 public class SigmaMakernoteDescriptor extends TagDescriptor<SigmaMakernoteDirectory>
 {
     public SigmaMakernoteDescriptor(@NotNull SigmaMakernoteDirectory directory)

--- a/Source/com/drew/metadata/exif/makernotes/SigmaMakernoteDirectory.java
+++ b/Source/com/drew/metadata/exif/makernotes/SigmaMakernoteDirectory.java
@@ -31,7 +31,7 @@ import java.util.HashMap;
  *
  * @author Drew Noakes https://drewnoakes.com
  */
-@SuppressWarnings("WeakerAccess")
+@SuppressWarnings({ "WeakerAccess", "serial" })
 public class SigmaMakernoteDirectory extends Directory
 {
     public static final int TAG_SERIAL_NUMBER = 0x2;

--- a/Source/com/drew/metadata/exif/makernotes/SonyType1MakernoteDescriptor.java
+++ b/Source/com/drew/metadata/exif/makernotes/SonyType1MakernoteDescriptor.java
@@ -32,7 +32,7 @@ import static com.drew.metadata.exif.makernotes.SonyType1MakernoteDirectory.*;
  *
  * @author Drew Noakes https://drewnoakes.com
  */
-@SuppressWarnings("WeakerAccess")
+@SuppressWarnings({ "WeakerAccess", "serial" })
 public class SonyType1MakernoteDescriptor extends TagDescriptor<SonyType1MakernoteDirectory>
 {
     public SonyType1MakernoteDescriptor(@NotNull SonyType1MakernoteDirectory directory)

--- a/Source/com/drew/metadata/exif/makernotes/SonyType1MakernoteDirectory.java
+++ b/Source/com/drew/metadata/exif/makernotes/SonyType1MakernoteDirectory.java
@@ -30,7 +30,7 @@ import java.util.HashMap;
  *
  * @author Drew Noakes https://drewnoakes.com
  */
-@SuppressWarnings("WeakerAccess")
+@SuppressWarnings({ "WeakerAccess", "serial" })
 public class SonyType1MakernoteDirectory extends Directory
 {
     public static final int TAG_CAMERA_INFO = 0x0010;

--- a/Source/com/drew/metadata/exif/makernotes/SonyType6MakernoteDescriptor.java
+++ b/Source/com/drew/metadata/exif/makernotes/SonyType6MakernoteDescriptor.java
@@ -32,7 +32,7 @@ import static com.drew.metadata.exif.makernotes.SonyType6MakernoteDirectory.*;
  *
  * @author Drew Noakes https://drewnoakes.com
  */
-@SuppressWarnings("WeakerAccess")
+@SuppressWarnings({ "WeakerAccess", "serial" })
 public class SonyType6MakernoteDescriptor extends TagDescriptor<SonyType6MakernoteDirectory>
 {
     public SonyType6MakernoteDescriptor(@NotNull SonyType6MakernoteDirectory directory)

--- a/Source/com/drew/metadata/exif/makernotes/SonyType6MakernoteDirectory.java
+++ b/Source/com/drew/metadata/exif/makernotes/SonyType6MakernoteDirectory.java
@@ -31,7 +31,7 @@ import java.util.HashMap;
  *
  * @author Drew Noakes https://drewnoakes.com
  */
-@SuppressWarnings("WeakerAccess")
+@SuppressWarnings({ "WeakerAccess", "serial" })
 public class SonyType6MakernoteDirectory extends Directory
 {
     public static final int TAG_MAKERNOTE_THUMB_OFFSET = 0x0513;

--- a/Source/com/drew/metadata/file/FileMetadataDescriptor.java
+++ b/Source/com/drew/metadata/file/FileMetadataDescriptor.java
@@ -29,7 +29,7 @@ import static com.drew.metadata.file.FileMetadataDirectory.*;
 /**
  * @author Drew Noakes https://drewnoakes.com
  */
-@SuppressWarnings("WeakerAccess")
+@SuppressWarnings({ "WeakerAccess", "serial" })
 public class FileMetadataDescriptor extends TagDescriptor<FileMetadataDirectory>
 {
     public FileMetadataDescriptor(@NotNull FileMetadataDirectory directory)

--- a/Source/com/drew/metadata/file/FileMetadataDirectory.java
+++ b/Source/com/drew/metadata/file/FileMetadataDirectory.java
@@ -28,7 +28,7 @@ import java.util.HashMap;
 /**
  * @author Drew Noakes https://drewnoakes.com
  */
-@SuppressWarnings("WeakerAccess")
+@SuppressWarnings({ "WeakerAccess", "serial" })
 public class FileMetadataDirectory extends Directory
 {
     public static final int TAG_FILE_NAME = 1;

--- a/Source/com/drew/metadata/gif/GifAnimationDescriptor.java
+++ b/Source/com/drew/metadata/gif/GifAnimationDescriptor.java
@@ -30,7 +30,7 @@ import static com.drew.metadata.gif.GifAnimationDirectory.*;
  * @author Drew Noakes https://drewnoakes.com
  * @author Kevin Mott https://github.com/kwhopper
  */
-@SuppressWarnings("WeakerAccess")
+@SuppressWarnings({ "WeakerAccess", "serial" })
 public class GifAnimationDescriptor extends TagDescriptor<GifAnimationDirectory>
 {
     public GifAnimationDescriptor(@NotNull GifAnimationDirectory directory)

--- a/Source/com/drew/metadata/gif/GifAnimationDirectory.java
+++ b/Source/com/drew/metadata/gif/GifAnimationDirectory.java
@@ -29,7 +29,7 @@ import java.util.HashMap;
  * @author Drew Noakes https://drewnoakes.com
  * @author Kevin Mott https://github.com/kwhopper
  */
-@SuppressWarnings("WeakerAccess")
+@SuppressWarnings({ "WeakerAccess", "serial" })
 public class GifAnimationDirectory extends Directory
 {
     public static final int TAG_ITERATION_COUNT = 1;

--- a/Source/com/drew/metadata/gif/GifCommentDescriptor.java
+++ b/Source/com/drew/metadata/gif/GifCommentDescriptor.java
@@ -29,7 +29,7 @@ import static com.drew.metadata.gif.GifCommentDirectory.*;
  * @author Drew Noakes https://drewnoakes.com
  * @author Kevin Mott https://github.com/kwhopper
  */
-@SuppressWarnings("WeakerAccess")
+@SuppressWarnings({ "WeakerAccess", "serial" })
 public class GifCommentDescriptor extends TagDescriptor<GifCommentDirectory>
 {
     public GifCommentDescriptor(@NotNull GifCommentDirectory directory)

--- a/Source/com/drew/metadata/gif/GifCommentDirectory.java
+++ b/Source/com/drew/metadata/gif/GifCommentDirectory.java
@@ -30,7 +30,7 @@ import java.util.HashMap;
  * @author Drew Noakes https://drewnoakes.com
  * @author Kevin Mott https://github.com/kwhopper
  */
-@SuppressWarnings("WeakerAccess")
+@SuppressWarnings({ "WeakerAccess", "serial" })
 public class GifCommentDirectory extends Directory
 {
     public static final int TAG_COMMENT = 1;

--- a/Source/com/drew/metadata/gif/GifControlDescriptor.java
+++ b/Source/com/drew/metadata/gif/GifControlDescriptor.java
@@ -29,7 +29,7 @@ import static com.drew.metadata.gif.GifControlDirectory.*;
  * @author Drew Noakes https://drewnoakes.com
  * @author Kevin Mott https://github.com/kwhopper
  */
-@SuppressWarnings("WeakerAccess")
+@SuppressWarnings({ "WeakerAccess", "serial" })
 public class GifControlDescriptor extends TagDescriptor<GifControlDirectory>
 {
     public GifControlDescriptor(@NotNull GifControlDirectory directory)

--- a/Source/com/drew/metadata/gif/GifControlDirectory.java
+++ b/Source/com/drew/metadata/gif/GifControlDirectory.java
@@ -29,7 +29,7 @@ import java.util.HashMap;
  * @author Drew Noakes https://drewnoakes.com
  * @author Kevin Mott https://github.com/kwhopper
  */
-@SuppressWarnings("WeakerAccess")
+@SuppressWarnings({ "WeakerAccess", "serial" })
 public class GifControlDirectory extends Directory
 {
     public static final int TAG_DELAY = 1;

--- a/Source/com/drew/metadata/gif/GifHeaderDescriptor.java
+++ b/Source/com/drew/metadata/gif/GifHeaderDescriptor.java
@@ -26,7 +26,7 @@ import com.drew.metadata.TagDescriptor;
 /**
  * @author Drew Noakes https://drewnoakes.com
  */
-@SuppressWarnings("WeakerAccess")
+@SuppressWarnings({ "WeakerAccess", "serial" })
 public class GifHeaderDescriptor extends TagDescriptor<GifHeaderDirectory>
 {
     public GifHeaderDescriptor(@NotNull GifHeaderDirectory directory)

--- a/Source/com/drew/metadata/gif/GifHeaderDirectory.java
+++ b/Source/com/drew/metadata/gif/GifHeaderDirectory.java
@@ -28,7 +28,7 @@ import java.util.HashMap;
 /**
  * @author Drew Noakes https://drewnoakes.com
  */
-@SuppressWarnings("WeakerAccess")
+@SuppressWarnings({ "WeakerAccess", "serial" })
 public class GifHeaderDirectory extends Directory
 {
     public static final int TAG_GIF_FORMAT_VERSION = 1;

--- a/Source/com/drew/metadata/gif/GifImageDescriptor.java
+++ b/Source/com/drew/metadata/gif/GifImageDescriptor.java
@@ -29,7 +29,7 @@ import static com.drew.metadata.gif.GifImageDirectory.*;
  * @author Drew Noakes https://drewnoakes.com
  * @author Kevin Mott https://github.com/kwhopper
  */
-@SuppressWarnings("WeakerAccess")
+@SuppressWarnings({ "WeakerAccess", "serial" })
 public class GifImageDescriptor extends TagDescriptor<GifImageDirectory>
 {
     public GifImageDescriptor(@NotNull GifImageDirectory directory)

--- a/Source/com/drew/metadata/gif/GifImageDirectory.java
+++ b/Source/com/drew/metadata/gif/GifImageDirectory.java
@@ -29,7 +29,7 @@ import java.util.HashMap;
  * @author Drew Noakes https://drewnoakes.com
  * @author Kevin Mott https://github.com/kwhopper
  */
-@SuppressWarnings("WeakerAccess")
+@SuppressWarnings({ "WeakerAccess", "serial" })
 public class GifImageDirectory extends Directory
 {
     public static final int TAG_LEFT = 1;

--- a/Source/com/drew/metadata/icc/IccDescriptor.java
+++ b/Source/com/drew/metadata/icc/IccDescriptor.java
@@ -37,7 +37,7 @@ import static com.drew.metadata.icc.IccDirectory.*;
  * @author Yuri Binev
  * @author Drew Noakes https://drewnoakes.com
  */
-@SuppressWarnings("WeakerAccess")
+@SuppressWarnings({ "WeakerAccess", "serial" })
 public class IccDescriptor extends TagDescriptor<IccDirectory>
 {
     public IccDescriptor(@NotNull IccDirectory directory)

--- a/Source/com/drew/metadata/icc/IccDirectory.java
+++ b/Source/com/drew/metadata/icc/IccDirectory.java
@@ -29,7 +29,7 @@ import java.util.HashMap;
  * @author Yuri Binev
  * @author Drew Noakes https://drewnoakes.com
  */
-@SuppressWarnings("WeakerAccess")
+@SuppressWarnings({ "WeakerAccess", "serial" })
 public class IccDirectory extends Directory
 {
     // These (smaller valued) tags have an integer value that's equal to their offset within the ICC data buffer.

--- a/Source/com/drew/metadata/ico/IcoDescriptor.java
+++ b/Source/com/drew/metadata/ico/IcoDescriptor.java
@@ -30,7 +30,7 @@ import static com.drew.metadata.ico.IcoDirectory.*;
 /**
  * @author Drew Noakes https://drewnoakes.com
  */
-@SuppressWarnings("WeakerAccess")
+@SuppressWarnings({ "WeakerAccess", "serial" })
 public class IcoDescriptor extends TagDescriptor<IcoDirectory>
 {
     public IcoDescriptor(@NotNull IcoDirectory directory)

--- a/Source/com/drew/metadata/ico/IcoDirectory.java
+++ b/Source/com/drew/metadata/ico/IcoDirectory.java
@@ -28,7 +28,7 @@ import java.util.HashMap;
 /**
  * @author Drew Noakes https://drewnoakes.com
  */
-@SuppressWarnings("WeakerAccess")
+@SuppressWarnings({ "WeakerAccess", "serial" })
 public class IcoDirectory extends Directory
 {
     public static final int TAG_IMAGE_TYPE = 1;

--- a/Source/com/drew/metadata/iptc/IptcDescriptor.java
+++ b/Source/com/drew/metadata/iptc/IptcDescriptor.java
@@ -34,7 +34,7 @@ import static com.drew.metadata.iptc.IptcDirectory.*;
  *
  * @author Drew Noakes https://drewnoakes.com
  */
-@SuppressWarnings("WeakerAccess")
+@SuppressWarnings({ "WeakerAccess", "serial" })
 public class IptcDescriptor extends TagDescriptor<IptcDirectory>
 {
     public IptcDescriptor(@NotNull IptcDirectory directory)

--- a/Source/com/drew/metadata/iptc/IptcDirectory.java
+++ b/Source/com/drew/metadata/iptc/IptcDirectory.java
@@ -37,7 +37,7 @@ import java.util.List;
  *
  * @author Drew Noakes https://drewnoakes.com
  */
-@SuppressWarnings("WeakerAccess")
+@SuppressWarnings({ "WeakerAccess", "serial" })
 public class IptcDirectory extends Directory
 {
     // IPTC EnvelopeRecord Tags

--- a/Source/com/drew/metadata/jfif/JfifDescriptor.java
+++ b/Source/com/drew/metadata/jfif/JfifDescriptor.java
@@ -36,7 +36,7 @@ import static com.drew.metadata.jfif.JfifDirectory.*;
  *
  * @author Yuri Binev, Drew Noakes
  */
-@SuppressWarnings("WeakerAccess")
+@SuppressWarnings({ "WeakerAccess", "serial" })
 public class JfifDescriptor extends TagDescriptor<JfifDirectory>
 {
     public JfifDescriptor(@NotNull JfifDirectory directory)

--- a/Source/com/drew/metadata/jfif/JfifDirectory.java
+++ b/Source/com/drew/metadata/jfif/JfifDirectory.java
@@ -31,7 +31,7 @@ import java.util.HashMap;
  *
  * @author Yuri Binev, Drew Noakes
  */
-@SuppressWarnings("WeakerAccess")
+@SuppressWarnings({ "WeakerAccess", "serial" })
 public class JfifDirectory extends Directory
 {
     public static final int TAG_VERSION = 5;

--- a/Source/com/drew/metadata/jfxx/JfxxDescriptor.java
+++ b/Source/com/drew/metadata/jfxx/JfxxDescriptor.java
@@ -36,7 +36,7 @@ import static com.drew.metadata.jfxx.JfxxDirectory.*;
  *
  * @author Drew Noakes
  */
-@SuppressWarnings("WeakerAccess")
+@SuppressWarnings({ "WeakerAccess", "serial" })
 public class JfxxDescriptor extends TagDescriptor<JfxxDirectory>
 {
     public JfxxDescriptor(@NotNull JfxxDirectory directory)

--- a/Source/com/drew/metadata/jfxx/JfxxDirectory.java
+++ b/Source/com/drew/metadata/jfxx/JfxxDirectory.java
@@ -31,7 +31,7 @@ import java.util.HashMap;
  *
  * @author Drew Noakes
  */
-@SuppressWarnings("WeakerAccess")
+@SuppressWarnings({ "WeakerAccess", "serial" })
 public class JfxxDirectory extends Directory
 {
     public static final int TAG_EXTENSION_CODE = 5;

--- a/Source/com/drew/metadata/jpeg/JpegCommentDescriptor.java
+++ b/Source/com/drew/metadata/jpeg/JpegCommentDescriptor.java
@@ -29,7 +29,7 @@ import com.drew.metadata.TagDescriptor;
  *
  * @author Drew Noakes https://drewnoakes.com
  */
-@SuppressWarnings("WeakerAccess")
+@SuppressWarnings({ "WeakerAccess", "serial" })
 public class JpegCommentDescriptor extends TagDescriptor<JpegCommentDirectory>
 {
     public JpegCommentDescriptor(@NotNull JpegCommentDirectory directory)

--- a/Source/com/drew/metadata/jpeg/JpegCommentDirectory.java
+++ b/Source/com/drew/metadata/jpeg/JpegCommentDirectory.java
@@ -30,7 +30,7 @@ import java.util.HashMap;
  *
  * @author Drew Noakes https://drewnoakes.com
  */
-@SuppressWarnings("WeakerAccess")
+@SuppressWarnings({ "WeakerAccess", "serial" })
 public class JpegCommentDirectory extends Directory
 {
     /**

--- a/Source/com/drew/metadata/jpeg/JpegDescriptor.java
+++ b/Source/com/drew/metadata/jpeg/JpegDescriptor.java
@@ -32,7 +32,7 @@ import static com.drew.metadata.jpeg.JpegDirectory.*;
  *
  * @author Drew Noakes https://drewnoakes.com
  */
-@SuppressWarnings("WeakerAccess")
+@SuppressWarnings({ "WeakerAccess", "serial" })
 public class JpegDescriptor extends TagDescriptor<JpegDirectory>
 {
     public JpegDescriptor(@NotNull JpegDirectory directory)

--- a/Source/com/drew/metadata/jpeg/JpegDirectory.java
+++ b/Source/com/drew/metadata/jpeg/JpegDirectory.java
@@ -32,7 +32,7 @@ import java.util.HashMap;
  *
  * @author Darrell Silver http://www.darrellsilver.com and Drew Noakes https://drewnoakes.com
  */
-@SuppressWarnings("WeakerAccess")
+@SuppressWarnings({ "WeakerAccess", "serial" })
 public class JpegDirectory extends Directory
 {
     public static final int TAG_COMPRESSION_TYPE = -3;

--- a/Source/com/drew/metadata/pcx/PcxDescriptor.java
+++ b/Source/com/drew/metadata/pcx/PcxDescriptor.java
@@ -30,7 +30,7 @@ import static com.drew.metadata.pcx.PcxDirectory.*;
 /**
  * @author Drew Noakes https://drewnoakes.com
  */
-@SuppressWarnings("WeakerAccess")
+@SuppressWarnings({ "WeakerAccess", "serial" })
 public class PcxDescriptor extends TagDescriptor<PcxDirectory>
 {
     public PcxDescriptor(@NotNull PcxDirectory directory)

--- a/Source/com/drew/metadata/pcx/PcxDirectory.java
+++ b/Source/com/drew/metadata/pcx/PcxDirectory.java
@@ -28,7 +28,7 @@ import java.util.HashMap;
 /**
  * @author Drew Noakes https://drewnoakes.com
  */
-@SuppressWarnings("WeakerAccess")
+@SuppressWarnings({ "WeakerAccess", "serial" })
 public class PcxDirectory extends Directory
 {
     public static final int TAG_VERSION        = 1;

--- a/Source/com/drew/metadata/photoshop/DuckyDirectory.java
+++ b/Source/com/drew/metadata/photoshop/DuckyDirectory.java
@@ -32,7 +32,7 @@ import java.util.HashMap;
  *
  * @author Drew Noakes https://drewnoakes.com
  */
-@SuppressWarnings("WeakerAccess")
+@SuppressWarnings({ "WeakerAccess", "serial" })
 public class DuckyDirectory extends Directory
 {
     public static final int TAG_QUALITY = 1;

--- a/Source/com/drew/metadata/photoshop/PhotoshopDescriptor.java
+++ b/Source/com/drew/metadata/photoshop/PhotoshopDescriptor.java
@@ -35,7 +35,7 @@ import static com.drew.metadata.photoshop.PhotoshopDirectory.*;
  * @author Yuri Binev
  * @author Drew Noakes https://drewnoakes.com
  */
-@SuppressWarnings("WeakerAccess")
+@SuppressWarnings({ "WeakerAccess", "serial" })
 public class PhotoshopDescriptor extends TagDescriptor<PhotoshopDirectory>
 {
     public PhotoshopDescriptor(@NotNull PhotoshopDirectory directory)

--- a/Source/com/drew/metadata/photoshop/PhotoshopDirectory.java
+++ b/Source/com/drew/metadata/photoshop/PhotoshopDirectory.java
@@ -33,7 +33,7 @@ import java.util.HashMap;
  * @author Drew Noakes https://drewnoakes.com
  * @author Yuri Binev
  */
-@SuppressWarnings("WeakerAccess")
+@SuppressWarnings({ "WeakerAccess", "serial" })
 public class PhotoshopDirectory extends Directory
 {
     public static final int TAG_CHANNELS_ROWS_COLUMNS_DEPTH_MODE                  = 0x03E8;

--- a/Source/com/drew/metadata/photoshop/PsdHeaderDescriptor.java
+++ b/Source/com/drew/metadata/photoshop/PsdHeaderDescriptor.java
@@ -30,7 +30,7 @@ import static com.drew.metadata.photoshop.PsdHeaderDirectory.*;
 /**
  * @author Drew Noakes https://drewnoakes.com
  */
-@SuppressWarnings("WeakerAccess")
+@SuppressWarnings({ "WeakerAccess", "serial" })
 public class PsdHeaderDescriptor extends TagDescriptor<PsdHeaderDirectory>
 {
     public PsdHeaderDescriptor(@NotNull PsdHeaderDirectory directory)

--- a/Source/com/drew/metadata/photoshop/PsdHeaderDirectory.java
+++ b/Source/com/drew/metadata/photoshop/PsdHeaderDirectory.java
@@ -31,7 +31,7 @@ import java.util.HashMap;
  *
  * @author Drew Noakes https://drewnoakes.com
  */
-@SuppressWarnings("WeakerAccess")
+@SuppressWarnings({ "WeakerAccess", "serial" })
 public class PsdHeaderDirectory extends Directory
 {
     /**

--- a/Source/com/drew/metadata/png/PngChromaticitiesDirectory.java
+++ b/Source/com/drew/metadata/png/PngChromaticitiesDirectory.java
@@ -29,7 +29,7 @@ import java.util.HashMap;
 /**
  * @author Drew Noakes https://drewnoakes.com
  */
-@SuppressWarnings("WeakerAccess")
+@SuppressWarnings({ "WeakerAccess", "serial" })
 public class PngChromaticitiesDirectory extends Directory
 {
     public static final int TAG_WHITE_POINT_X = 1;

--- a/Source/com/drew/metadata/png/PngDescriptor.java
+++ b/Source/com/drew/metadata/png/PngDescriptor.java
@@ -36,7 +36,7 @@ import static com.drew.metadata.png.PngDirectory.*;
 /**
  * @author Drew Noakes https://drewnoakes.com
  */
-@SuppressWarnings("WeakerAccess")
+@SuppressWarnings({ "WeakerAccess", "serial" })
 public class PngDescriptor extends TagDescriptor<PngDirectory>
 {
     public PngDescriptor(@NotNull PngDirectory directory)

--- a/Source/com/drew/metadata/png/PngDirectory.java
+++ b/Source/com/drew/metadata/png/PngDirectory.java
@@ -29,7 +29,7 @@ import java.util.HashMap;
 /**
  * @author Drew Noakes https://drewnoakes.com
  */
-@SuppressWarnings("WeakerAccess")
+@SuppressWarnings({ "WeakerAccess", "serial" })
 public class PngDirectory extends Directory
 {
     public static final int TAG_IMAGE_WIDTH = 1;

--- a/Source/com/drew/metadata/webp/WebpDescriptor.java
+++ b/Source/com/drew/metadata/webp/WebpDescriptor.java
@@ -27,7 +27,7 @@ import com.drew.metadata.TagDescriptor;
 /**
  * @author Drew Noakes https://drewnoakes.com
  */
-@SuppressWarnings("WeakerAccess")
+@SuppressWarnings({ "WeakerAccess", "serial" })
 public class WebpDescriptor extends TagDescriptor<WebpDirectory>
 {
     public WebpDescriptor(@NotNull WebpDirectory directory)

--- a/Source/com/drew/metadata/webp/WebpDirectory.java
+++ b/Source/com/drew/metadata/webp/WebpDirectory.java
@@ -28,7 +28,7 @@ import java.util.HashMap;
 /**
  * @author Drew Noakes https://drewnoakes.com
  */
-@SuppressWarnings("WeakerAccess")
+@SuppressWarnings({ "WeakerAccess", "serial" })
 public class WebpDirectory extends Directory
 {
     public static final int TAG_IMAGE_HEIGHT = 1;

--- a/Source/com/drew/metadata/xmp/XmpDescriptor.java
+++ b/Source/com/drew/metadata/xmp/XmpDescriptor.java
@@ -34,7 +34,7 @@ import static com.drew.metadata.xmp.XmpDirectory.*;
  *
  * @author Torsten Skadell, Drew Noakes https://drewnoakes.com
  */
-@SuppressWarnings("WeakerAccess")
+@SuppressWarnings({ "WeakerAccess", "serial" })
 public class XmpDescriptor extends TagDescriptor<XmpDirectory>
 {
     // TODO some of these methods look similar to those found in Exif*Descriptor... extract common functionality from both

--- a/Tests/com/drew/metadata/MockDirectory.java
+++ b/Tests/com/drew/metadata/MockDirectory.java
@@ -29,6 +29,7 @@ import java.util.HashMap;
  *
  * @author Drew Noakes https://drewnoakes.com
  */
+@SuppressWarnings("serial")
 public class MockDirectory extends Directory
 {
     private final HashMap<Integer, String> _tagNameMap;


### PR DESCRIPTION
I'd like to store the ```Metadata``` instances to a database where I can retrieve them without having to reparse the source (which might not be easily accessible). I gave it a go and it doesn't seem like making this serializable poses much trouble.

The only problem I came across was ```XMPMeta``` in ```XMPDirectory``` which isn't serializable and is an external class. Since it's created "on demand" I take it that this isn't crucial to have, it might look to me that it's an instance used during parsing that you've chosen to also offer in it's original form "just in case"? I simply made it ```transient``` meaning it will be lost on serialization. I really can't judge if that will pose any serious issue for a deserialized instance.

Provided that the issue with ```XMPMeta``` isn't serious, it seems this is all it takes to make ```Metadata``` serializable. The exact details of how Java handles serialization internally is still not 100% clear to me, so there could be some other reason why you have opted to not make it serializable. But, if the case is that it simply never came up and loosing ```XMPMeta``` on deserialization is acceptable I'd appreciate if you'd take this into consideration.

As a side note, your POM states Java 1.5, but it won't compile until Java 1.6 since ```DecimalFormat.setRoundingMode()``` is used many places and wasn't introduced until Java 1.6.

I also ran Findbugs to make sure this didn't create any new ones. While it doesn't, it found some existing issues that might pose a problem. As usual, most of them probably aren't very serious. I've attached a PDF of the report:

[Metadata-extractor.pdf](https://github.com/drewnoakes/metadata-extractor/files/676351/Metadata-extractor.pdf)

```GC_UNRELATED_TYPES``` and ```NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE``` could be of interest.