### PR TITLE
Implement Metadata filter

### DIFF
--- a/Source/com/drew/imaging/bmp/BmpMetadataReader.java
+++ b/Source/com/drew/imaging/bmp/BmpMetadataReader.java
@@ -23,8 +23,10 @@ package com.drew.imaging.bmp;
 
 import com.drew.lang.StreamReader;
 import com.drew.lang.annotations.NotNull;
+import com.drew.lang.annotations.Nullable;
 import com.drew.metadata.Metadata;
 import com.drew.metadata.bmp.BmpReader;
+import com.drew.metadata.filter.MetadataFilter;
 
 import java.io.*;
 
@@ -38,10 +40,16 @@ public class BmpMetadataReader
     @NotNull
     public static Metadata readMetadata(@NotNull File file) throws IOException
     {
+        return readMetadata(file, null);
+    }
+
+    @NotNull
+    public static Metadata readMetadata(@NotNull File file, @Nullable final MetadataFilter filter) throws IOException
+    {
         FileInputStream stream = null;
         try {
             stream = new FileInputStream(file);
-            return readMetadata(stream);
+            return readMetadata(stream, filter);
         } finally {
             if (stream != null) {
                 stream.close();
@@ -52,8 +60,14 @@ public class BmpMetadataReader
     @NotNull
     public static Metadata readMetadata(@NotNull InputStream inputStream)
     {
+        return readMetadata(inputStream, null);
+    }
+
+    @NotNull
+    public static Metadata readMetadata(@NotNull InputStream inputStream, @Nullable final MetadataFilter filter)
+    {
         Metadata metadata = new Metadata();
-        new BmpReader().extract(new StreamReader(inputStream), metadata);
+        new BmpReader().extract(new StreamReader(inputStream), metadata, filter);
         return metadata;
     }
 }

--- a/Source/com/drew/imaging/gif/GifMetadataReader.java
+++ b/Source/com/drew/imaging/gif/GifMetadataReader.java
@@ -23,8 +23,10 @@ package com.drew.imaging.gif;
 
 import com.drew.lang.StreamReader;
 import com.drew.lang.annotations.NotNull;
+import com.drew.lang.annotations.Nullable;
 import com.drew.metadata.Metadata;
 import com.drew.metadata.file.FileMetadataReader;
+import com.drew.metadata.filter.MetadataFilter;
 import com.drew.metadata.gif.GifReader;
 
 import java.io.File;
@@ -42,22 +44,34 @@ public class GifMetadataReader
     @NotNull
     public static Metadata readMetadata(@NotNull File file) throws IOException
     {
+        return readMetadata(file, null);
+    }
+
+    @NotNull
+    public static Metadata readMetadata(@NotNull File file, @Nullable final MetadataFilter filter) throws IOException
+    {
         InputStream inputStream = new FileInputStream(file);
         Metadata metadata;
         try {
-            metadata = readMetadata(inputStream);
+            metadata = readMetadata(inputStream, filter);
         } finally {
             inputStream.close();
         }
-        new FileMetadataReader().read(file, metadata);
+        new FileMetadataReader().read(file, metadata, filter);
         return metadata;
     }
 
     @NotNull
     public static Metadata readMetadata(@NotNull InputStream inputStream)
     {
+        return readMetadata(inputStream, null);
+    }
+
+    @NotNull
+    public static Metadata readMetadata(@NotNull InputStream inputStream, @Nullable final MetadataFilter filter)
+    {
         Metadata metadata = new Metadata();
-        new GifReader().extract(new StreamReader(inputStream), metadata);
+        new GifReader().extract(new StreamReader(inputStream), metadata, filter);
         return metadata;
     }
 }

--- a/Source/com/drew/imaging/ico/IcoMetadataReader.java
+++ b/Source/com/drew/imaging/ico/IcoMetadataReader.java
@@ -22,8 +22,10 @@ package com.drew.imaging.ico;
 
 import com.drew.lang.StreamReader;
 import com.drew.lang.annotations.NotNull;
+import com.drew.lang.annotations.Nullable;
 import com.drew.metadata.Metadata;
 import com.drew.metadata.file.FileMetadataReader;
+import com.drew.metadata.filter.MetadataFilter;
 import com.drew.metadata.ico.IcoReader;
 
 import java.io.*;
@@ -38,22 +40,34 @@ public class IcoMetadataReader
     @NotNull
     public static Metadata readMetadata(@NotNull File file) throws IOException
     {
+        return readMetadata(file, null);
+    }
+
+    @NotNull
+    public static Metadata readMetadata(@NotNull File file, @Nullable final MetadataFilter filter) throws IOException
+    {
         InputStream inputStream = new FileInputStream(file);
         Metadata metadata;
         try {
-            metadata = readMetadata(inputStream);
+            metadata = readMetadata(inputStream, filter);
         } finally {
             inputStream.close();
         }
-        new FileMetadataReader().read(file, metadata);
+        new FileMetadataReader().read(file, metadata, filter);
         return metadata;
     }
 
     @NotNull
     public static Metadata readMetadata(@NotNull InputStream inputStream)
     {
+        return readMetadata(inputStream, null);
+    }
+
+    @NotNull
+    public static Metadata readMetadata(@NotNull InputStream inputStream, @Nullable final MetadataFilter filter)
+    {
         Metadata metadata = new Metadata();
-        new IcoReader().extract(new StreamReader(inputStream), metadata);
+        new IcoReader().extract(new StreamReader(inputStream), metadata, filter);
         return metadata;
     }
 }

--- a/Source/com/drew/imaging/jpeg/JpegMetadataReader.java
+++ b/Source/com/drew/imaging/jpeg/JpegMetadataReader.java
@@ -27,6 +27,7 @@ import com.drew.metadata.Metadata;
 import com.drew.metadata.adobe.AdobeJpegReader;
 import com.drew.metadata.exif.ExifReader;
 import com.drew.metadata.file.FileMetadataReader;
+import com.drew.metadata.filter.MetadataFilter;
 import com.drew.metadata.icc.IccReader;
 import com.drew.metadata.iptc.IptcReader;
 import com.drew.metadata.jfif.JfifReader;
@@ -69,43 +70,77 @@ public class JpegMetadataReader
     @NotNull
     public static Metadata readMetadata(@NotNull InputStream inputStream, @Nullable Iterable<JpegSegmentMetadataReader> readers) throws JpegProcessingException, IOException
     {
+        return readMetadata(inputStream, readers, null);
+    }
+
+    @NotNull
+    public static Metadata readMetadata(@NotNull InputStream inputStream, @Nullable Iterable<JpegSegmentMetadataReader> readers, @Nullable final MetadataFilter filter) throws JpegProcessingException, IOException
+    {
         Metadata metadata = new Metadata();
-        process(metadata, inputStream, readers);
+        process(metadata, inputStream, readers, filter);
         return metadata;
     }
 
     @NotNull
     public static Metadata readMetadata(@NotNull InputStream inputStream) throws JpegProcessingException, IOException
     {
-        return readMetadata(inputStream, null);
+        return readMetadata(inputStream, null, null);
+    }
+
+    @NotNull
+    public static Metadata readMetadata(@NotNull InputStream inputStream, @Nullable final MetadataFilter filter) throws JpegProcessingException, IOException
+    {
+        return readMetadata(inputStream, null, filter);
     }
 
     @NotNull
     public static Metadata readMetadata(@NotNull File file, @Nullable Iterable<JpegSegmentMetadataReader> readers) throws JpegProcessingException, IOException
     {
+        return readMetadata(file, readers, null);
+    }
+
+    @NotNull
+    public static Metadata readMetadata(@NotNull File file, @Nullable Iterable<JpegSegmentMetadataReader> readers, @Nullable final MetadataFilter filter) throws JpegProcessingException, IOException
+    {
         InputStream inputStream = new FileInputStream(file);
         Metadata metadata;
         try {
-            metadata = readMetadata(inputStream, readers);
+            metadata = readMetadata(inputStream, readers, filter);
         } finally {
             inputStream.close();
         }
-        new FileMetadataReader().read(file, metadata);
+        new FileMetadataReader().read(file, metadata, filter);
         return metadata;
     }
 
     @NotNull
     public static Metadata readMetadata(@NotNull File file) throws JpegProcessingException, IOException
     {
-        return readMetadata(file, null);
+        return readMetadata(file, null, null);
+    }
+
+    @NotNull
+    public static Metadata readMetadata(@NotNull File file, @Nullable final MetadataFilter filter) throws JpegProcessingException, IOException
+    {
+        return readMetadata(file, null, filter);
     }
 
     public static void process(@NotNull Metadata metadata, @NotNull InputStream inputStream) throws JpegProcessingException, IOException
     {
-        process(metadata, inputStream, null);
+        process(metadata, inputStream, null, null);
+    }
+
+    public static void process(@NotNull Metadata metadata, @NotNull InputStream inputStream, @Nullable final MetadataFilter filter) throws JpegProcessingException, IOException
+    {
+        process(metadata, inputStream, null, filter);
     }
 
     public static void process(@NotNull Metadata metadata, @NotNull InputStream inputStream, @Nullable Iterable<JpegSegmentMetadataReader> readers) throws JpegProcessingException, IOException
+    {
+        process(metadata, inputStream, readers, null);
+    }
+
+    public static void process(@NotNull Metadata metadata, @NotNull InputStream inputStream, @Nullable Iterable<JpegSegmentMetadataReader> readers, @Nullable final MetadataFilter filter) throws JpegProcessingException, IOException
     {
         if (readers == null)
             readers = ALL_READERS;
@@ -119,15 +154,20 @@ public class JpegMetadataReader
 
         JpegSegmentData segmentData = JpegSegmentReader.readSegments(new StreamReader(inputStream), segmentTypes);
 
-        processJpegSegmentData(metadata, readers, segmentData);
+        processJpegSegmentData(metadata, readers, segmentData, filter);
     }
 
     public static void processJpegSegmentData(Metadata metadata, Iterable<JpegSegmentMetadataReader> readers, JpegSegmentData segmentData)
     {
+        processJpegSegmentData(metadata, readers, segmentData, null);
+    }
+
+    public static void processJpegSegmentData(Metadata metadata, Iterable<JpegSegmentMetadataReader> readers, JpegSegmentData segmentData, @Nullable final MetadataFilter filter)
+    {
         // Pass the appropriate byte arrays to each reader.
         for (JpegSegmentMetadataReader reader : readers) {
             for (JpegSegmentType segmentType : reader.getSegmentTypes()) {
-                reader.readJpegSegments(segmentData.getSegments(segmentType), metadata, segmentType);
+                reader.readJpegSegments(segmentData.getSegments(segmentType), metadata, segmentType, filter);
             }
         }
     }

--- a/Source/com/drew/imaging/jpeg/JpegSegmentMetadataReader.java
+++ b/Source/com/drew/imaging/jpeg/JpegSegmentMetadataReader.java
@@ -1,7 +1,9 @@
 package com.drew.imaging.jpeg;
 
 import com.drew.lang.annotations.NotNull;
+import com.drew.lang.annotations.Nullable;
 import com.drew.metadata.Metadata;
+import com.drew.metadata.filter.MetadataFilter;
 
 /**
  * Defines an object that extracts metadata from in JPEG segments.
@@ -23,4 +25,15 @@ public interface JpegSegmentMetadataReader
      * @param segmentType The {@link JpegSegmentType} being read.
      */
     void readJpegSegments(@NotNull final Iterable<byte[]> segments, @NotNull final Metadata metadata, @NotNull final JpegSegmentType segmentType);
+
+    /**
+     * Extracts metadata from all instances of a particular JPEG segment type.
+     *
+     * @param segments A sequence of byte arrays from which the metadata should be extracted. These are in the order
+     *                 encountered in the original file.
+     * @param metadata The {@link Metadata} object into which extracted values should be merged.
+     * @param segmentType The {@link JpegSegmentType} being read.
+     * @param filter a {@link MetadataFilter} or <code>null</code>.
+     */
+    void readJpegSegments(@NotNull final Iterable<byte[]> segments, @NotNull final Metadata metadata, @NotNull final JpegSegmentType segmentType, @Nullable final MetadataFilter filter);
 }

--- a/Source/com/drew/imaging/pcx/PcxMetadataReader.java
+++ b/Source/com/drew/imaging/pcx/PcxMetadataReader.java
@@ -22,8 +22,10 @@ package com.drew.imaging.pcx;
 
 import com.drew.lang.StreamReader;
 import com.drew.lang.annotations.NotNull;
+import com.drew.lang.annotations.Nullable;
 import com.drew.metadata.Metadata;
 import com.drew.metadata.file.FileMetadataReader;
+import com.drew.metadata.filter.MetadataFilter;
 import com.drew.metadata.pcx.PcxReader;
 
 import java.io.*;
@@ -38,22 +40,34 @@ public class PcxMetadataReader
     @NotNull
     public static Metadata readMetadata(@NotNull File file) throws IOException
     {
+        return readMetadata(file, null);
+    }
+
+    @NotNull
+    public static Metadata readMetadata(@NotNull File file, @Nullable final MetadataFilter filter) throws IOException
+    {
         InputStream inputStream = new FileInputStream(file);
         Metadata metadata;
         try {
-            metadata = readMetadata(inputStream);
+            metadata = readMetadata(inputStream, filter);
         } finally {
             inputStream.close();
         }
-        new FileMetadataReader().read(file, metadata);
+        new FileMetadataReader().read(file, metadata, filter);
         return metadata;
     }
 
     @NotNull
     public static Metadata readMetadata(@NotNull InputStream inputStream)
     {
+        return readMetadata(inputStream, null);
+    }
+
+    @NotNull
+    public static Metadata readMetadata(@NotNull InputStream inputStream, @Nullable final MetadataFilter filter)
+    {
         Metadata metadata = new Metadata();
-        new PcxReader().extract(new StreamReader(inputStream), metadata);
+        new PcxReader().extract(new StreamReader(inputStream), metadata, filter);
         return metadata;
     }
 }

--- a/Source/com/drew/imaging/png/PngMetadataReader.java
+++ b/Source/com/drew/imaging/png/PngMetadataReader.java
@@ -22,9 +22,11 @@ package com.drew.imaging.png;
 
 import com.drew.lang.*;
 import com.drew.lang.annotations.NotNull;
+import com.drew.lang.annotations.Nullable;
 import com.drew.metadata.Metadata;
 import com.drew.metadata.StringValue;
 import com.drew.metadata.file.FileMetadataReader;
+import com.drew.metadata.filter.MetadataFilter;
 import com.drew.metadata.icc.IccReader;
 import com.drew.metadata.png.PngChromaticitiesDirectory;
 import com.drew.metadata.png.PngDirectory;
@@ -79,19 +81,31 @@ public class PngMetadataReader
     @NotNull
     public static Metadata readMetadata(@NotNull File file) throws PngProcessingException, IOException
     {
+        return readMetadata(file, null);
+    }
+
+    @NotNull
+    public static Metadata readMetadata(@NotNull File file, @Nullable final MetadataFilter filter) throws PngProcessingException, IOException
+    {
         InputStream inputStream = new FileInputStream(file);
         Metadata metadata;
         try {
-            metadata = readMetadata(inputStream);
+            metadata = readMetadata(inputStream, filter);
         } finally {
             inputStream.close();
         }
-        new FileMetadataReader().read(file, metadata);
+        new FileMetadataReader().read(file, metadata, filter);
         return metadata;
     }
 
     @NotNull
     public static Metadata readMetadata(@NotNull InputStream inputStream) throws PngProcessingException, IOException
+    {
+        return readMetadata(inputStream, null);
+    }
+
+    @NotNull
+    public static Metadata readMetadata(@NotNull InputStream inputStream, @Nullable final MetadataFilter filter) throws PngProcessingException, IOException
     {
         Iterable<PngChunk> chunks = new PngChunkReader().extract(new StreamReader(inputStream), _desiredChunkTypes);
 
@@ -99,7 +113,7 @@ public class PngMetadataReader
 
         for (PngChunk chunk : chunks) {
             try {
-                processChunk(metadata, chunk);
+                processChunk(metadata, chunk, filter);
             } catch (Exception e) {
                 e.printStackTrace(System.err);
             }
@@ -108,156 +122,185 @@ public class PngMetadataReader
         return metadata;
     }
 
-    private static void processChunk(@NotNull Metadata metadata, @NotNull PngChunk chunk) throws PngProcessingException, IOException
+    private static void processChunk(@NotNull Metadata metadata, @NotNull PngChunk chunk, @Nullable final MetadataFilter filter) throws PngProcessingException, IOException
     {
+        if (filter != null && !filter.directoryFilter(PngDirectory.class))
+            return;
+
         PngChunkType chunkType = chunk.getType();
         byte[] bytes = chunk.getBytes();
 
         if (chunkType.equals(PngChunkType.IHDR)) {
-            PngHeader header = new PngHeader(bytes);
-            PngDirectory directory = new PngDirectory(PngChunkType.IHDR);
-            directory.setInt(PngDirectory.TAG_IMAGE_WIDTH, header.getImageWidth());
-            directory.setInt(PngDirectory.TAG_IMAGE_HEIGHT, header.getImageHeight());
-            directory.setInt(PngDirectory.TAG_BITS_PER_SAMPLE, header.getBitsPerSample());
-            directory.setInt(PngDirectory.TAG_COLOR_TYPE, header.getColorType().getNumericValue());
-            directory.setInt(PngDirectory.TAG_COMPRESSION_TYPE, header.getCompressionType());
-            directory.setInt(PngDirectory.TAG_FILTER_METHOD, header.getFilterMethod());
-            directory.setInt(PngDirectory.TAG_INTERLACE_METHOD, header.getInterlaceMethod());
-            metadata.addDirectory(directory);
-        } else if (chunkType.equals(PngChunkType.PLTE)) {
-            PngDirectory directory = new PngDirectory(PngChunkType.PLTE);
-            directory.setInt(PngDirectory.TAG_PALETTE_SIZE, bytes.length / 3);
-            metadata.addDirectory(directory);
-        } else if (chunkType.equals(PngChunkType.tRNS)) {
-            PngDirectory directory = new PngDirectory(PngChunkType.tRNS);
-            directory.setInt(PngDirectory.TAG_PALETTE_HAS_TRANSPARENCY, 1);
-            metadata.addDirectory(directory);
-        } else if (chunkType.equals(PngChunkType.sRGB)) {
-            int srgbRenderingIntent = bytes[0];
-            PngDirectory directory = new PngDirectory(PngChunkType.sRGB);
-            directory.setInt(PngDirectory.TAG_SRGB_RENDERING_INTENT, srgbRenderingIntent);
-            metadata.addDirectory(directory);
-        } else if (chunkType.equals(PngChunkType.cHRM)) {
-            PngChromaticities chromaticities = new PngChromaticities(bytes);
-            PngChromaticitiesDirectory directory = new PngChromaticitiesDirectory();
-            directory.setInt(PngChromaticitiesDirectory.TAG_WHITE_POINT_X, chromaticities.getWhitePointX());
-            directory.setInt(PngChromaticitiesDirectory.TAG_WHITE_POINT_Y, chromaticities.getWhitePointY());
-            directory.setInt(PngChromaticitiesDirectory.TAG_RED_X, chromaticities.getRedX());
-            directory.setInt(PngChromaticitiesDirectory.TAG_RED_Y, chromaticities.getRedY());
-            directory.setInt(PngChromaticitiesDirectory.TAG_GREEN_X, chromaticities.getGreenX());
-            directory.setInt(PngChromaticitiesDirectory.TAG_GREEN_Y, chromaticities.getGreenY());
-            directory.setInt(PngChromaticitiesDirectory.TAG_BLUE_X, chromaticities.getBlueX());
-            directory.setInt(PngChromaticitiesDirectory.TAG_BLUE_Y, chromaticities.getBlueY());
-            metadata.addDirectory(directory);
-        } else if (chunkType.equals(PngChunkType.gAMA)) {
-            int gammaInt = ByteConvert.toInt32BigEndian(bytes);
-            new SequentialByteArrayReader(bytes).getInt32();
-            PngDirectory directory = new PngDirectory(PngChunkType.gAMA);
-            directory.setDouble(PngDirectory.TAG_GAMMA, gammaInt / 100000.0);
-            metadata.addDirectory(directory);
-        } else if (chunkType.equals(PngChunkType.iCCP)) {
-            SequentialReader reader = new SequentialByteArrayReader(bytes);
-            byte[] profileNameBytes = reader.getNullTerminatedBytes(79);
-            PngDirectory directory = new PngDirectory(PngChunkType.iCCP);
-            directory.setStringValue(PngDirectory.TAG_ICC_PROFILE_NAME, new StringValue(profileNameBytes, _latin1Encoding));
-            byte compressionMethod = reader.getInt8();
-            if (compressionMethod == 0) {
-                // Only compression method allowed by the spec is zero: deflate
-                int bytesLeft = bytes.length - profileNameBytes.length - 2;
-                byte[] compressedProfile = reader.getBytes(bytesLeft);
-                InflaterInputStream inflateStream = new InflaterInputStream(new ByteArrayInputStream(compressedProfile));
-                new IccReader().extract(new RandomAccessStreamReader(inflateStream), metadata, directory);
-                inflateStream.close();
-            } else {
-                directory.addError("Invalid compression method value");
-            }
-            metadata.addDirectory(directory);
-        } else if (chunkType.equals(PngChunkType.bKGD)) {
-            PngDirectory directory = new PngDirectory(PngChunkType.bKGD);
-            directory.setByteArray(PngDirectory.TAG_BACKGROUND_COLOR, bytes);
-            metadata.addDirectory(directory);
-        } else if (chunkType.equals(PngChunkType.tEXt)) {
-            SequentialReader reader = new SequentialByteArrayReader(bytes);
-            byte[] keywordBytes = reader.getNullTerminatedBytes(79);
-            StringValue keyword = new StringValue(keywordBytes, _latin1Encoding);
-            int bytesLeft = bytes.length - keywordBytes.length - 1;
-            StringValue value = reader.getNullTerminatedStringValue(bytesLeft, _latin1Encoding);
-            List<KeyValuePair> textPairs = new ArrayList<KeyValuePair>();
-            textPairs.add(new KeyValuePair(keyword, value));
-            PngDirectory directory = new PngDirectory(PngChunkType.iTXt);
-            directory.setObject(PngDirectory.TAG_TEXTUAL_DATA, textPairs);
-            metadata.addDirectory(directory);
-        } else if (chunkType.equals(PngChunkType.iTXt)) {
-            SequentialReader reader = new SequentialByteArrayReader(bytes);
-            byte[] keywordBytes = reader.getNullTerminatedBytes(79);
-            byte compressionFlag = reader.getInt8();
-            byte compressionMethod = reader.getInt8();
-            // TODO we currently ignore languageTagBytes and translatedKeywordBytes
-            byte[] languageTagBytes = reader.getNullTerminatedBytes(bytes.length);
-            byte[] translatedKeywordBytes = reader.getNullTerminatedBytes(bytes.length);
-            int bytesLeft = bytes.length - keywordBytes.length - 1 - 1 - 1 - languageTagBytes.length - 1 - translatedKeywordBytes.length - 1;
-            byte[] textBytes = null;
-            if (compressionFlag == 0) {
-                textBytes = reader.getNullTerminatedBytes(bytesLeft);
-            } else if (compressionFlag == 1) {
-                if (compressionMethod == 0) {
-                    textBytes = StreamUtil.readAllBytes(new InflaterInputStream(new ByteArrayInputStream(bytes, bytes.length - bytesLeft, bytesLeft)));
-                } else {
-                    PngDirectory directory = new PngDirectory(PngChunkType.iTXt);
-                    directory.addError("Invalid compression method value");
-                    metadata.addDirectory(directory);
-                }
-            } else {
-                PngDirectory directory = new PngDirectory(PngChunkType.iTXt);
-                directory.addError("Invalid compression flag value");
+            if (filter == null || filter.directoryFilter(PngDirectory.class)) {
+                PngHeader header = new PngHeader(bytes);
+                PngDirectory directory = new PngDirectory(PngChunkType.IHDR);
+                directory.setInt(PngDirectory.TAG_IMAGE_WIDTH, header.getImageWidth(), filter);
+                directory.setInt(PngDirectory.TAG_IMAGE_HEIGHT, header.getImageHeight(), filter);
+                directory.setInt(PngDirectory.TAG_BITS_PER_SAMPLE, header.getBitsPerSample(), filter);
+                directory.setInt(PngDirectory.TAG_COLOR_TYPE, header.getColorType().getNumericValue(), filter);
+                directory.setInt(PngDirectory.TAG_COMPRESSION_TYPE, header.getCompressionType(), filter);
+                directory.setInt(PngDirectory.TAG_FILTER_METHOD, header.getFilterMethod(), filter);
+                directory.setInt(PngDirectory.TAG_INTERLACE_METHOD, header.getInterlaceMethod(), filter);
                 metadata.addDirectory(directory);
             }
-
-            if (textBytes != null) {
-                StringValue keyword = new StringValue(keywordBytes, _latin1Encoding);
-                if (keyword.toString().equals("XML:com.adobe.xmp")) {
-                    // NOTE in testing images, the XMP has parsed successfully, but we are not extracting tags from it as necessary
-                    new XmpReader().extract(textBytes, metadata);
+        } else if (chunkType.equals(PngChunkType.PLTE)) {
+            if (filter == null || filter.directoryFilter(PngDirectory.class)) {
+                PngDirectory directory = new PngDirectory(PngChunkType.PLTE);
+                directory.setInt(PngDirectory.TAG_PALETTE_SIZE, bytes.length / 3, filter);
+                metadata.addDirectory(directory);
+            }
+        } else if (chunkType.equals(PngChunkType.tRNS)) {
+            if (filter == null || filter.directoryFilter(PngDirectory.class)) {
+                PngDirectory directory = new PngDirectory(PngChunkType.tRNS);
+                directory.setInt(PngDirectory.TAG_PALETTE_HAS_TRANSPARENCY, 1, filter);
+                metadata.addDirectory(directory);
+            }
+        } else if (chunkType.equals(PngChunkType.sRGB)) {
+            if (filter == null || filter.directoryFilter(PngDirectory.class)) {
+                int srgbRenderingIntent = bytes[0];
+                PngDirectory directory = new PngDirectory(PngChunkType.sRGB);
+                directory.setInt(PngDirectory.TAG_SRGB_RENDERING_INTENT, srgbRenderingIntent, filter);
+                metadata.addDirectory(directory);
+            }
+        } else if (chunkType.equals(PngChunkType.cHRM)) {
+            if (filter == null || filter.directoryFilter(PngChromaticitiesDirectory.class)) {
+                PngChromaticities chromaticities = new PngChromaticities(bytes);
+                PngChromaticitiesDirectory directory = new PngChromaticitiesDirectory();
+                directory.setInt(PngChromaticitiesDirectory.TAG_WHITE_POINT_X, chromaticities.getWhitePointX(), filter);
+                directory.setInt(PngChromaticitiesDirectory.TAG_WHITE_POINT_Y, chromaticities.getWhitePointY(), filter);
+                directory.setInt(PngChromaticitiesDirectory.TAG_RED_X, chromaticities.getRedX(), filter);
+                directory.setInt(PngChromaticitiesDirectory.TAG_RED_Y, chromaticities.getRedY(), filter);
+                directory.setInt(PngChromaticitiesDirectory.TAG_GREEN_X, chromaticities.getGreenX(), filter);
+                directory.setInt(PngChromaticitiesDirectory.TAG_GREEN_Y, chromaticities.getGreenY(), filter);
+                directory.setInt(PngChromaticitiesDirectory.TAG_BLUE_X, chromaticities.getBlueX(), filter);
+                directory.setInt(PngChromaticitiesDirectory.TAG_BLUE_Y, chromaticities.getBlueY(), filter);
+                metadata.addDirectory(directory);
+            }
+        } else if (chunkType.equals(PngChunkType.gAMA)) {
+            if (filter == null || filter.directoryFilter(PngDirectory.class)) {
+                int gammaInt = ByteConvert.toInt32BigEndian(bytes);
+                new SequentialByteArrayReader(bytes).getInt32();
+                PngDirectory directory = new PngDirectory(PngChunkType.gAMA);
+                directory.setDouble(PngDirectory.TAG_GAMMA, gammaInt / 100000.0, filter);
+                metadata.addDirectory(directory);
+            }
+        } else if (chunkType.equals(PngChunkType.iCCP)) {
+            if (filter == null || filter.directoryFilter(PngDirectory.class)) {
+                SequentialReader reader = new SequentialByteArrayReader(bytes);
+                byte[] profileNameBytes = reader.getNullTerminatedBytes(79);
+                PngDirectory directory = new PngDirectory(PngChunkType.iCCP);
+                directory.setStringValue(PngDirectory.TAG_ICC_PROFILE_NAME, new StringValue(profileNameBytes, _latin1Encoding), filter);
+                byte compressionMethod = reader.getInt8();
+                if (compressionMethod == 0) {
+                    // Only compression method allowed by the spec is zero: deflate
+                    int bytesLeft = bytes.length - profileNameBytes.length - 2;
+                    byte[] compressedProfile = reader.getBytes(bytesLeft);
+                    InflaterInputStream inflateStream = new InflaterInputStream(new ByteArrayInputStream(compressedProfile));
+                    new IccReader().extract(new RandomAccessStreamReader(inflateStream), metadata, directory, filter);
+                    inflateStream.close();
                 } else {
-                    List<KeyValuePair> textPairs = new ArrayList<KeyValuePair>();
-                    textPairs.add(new KeyValuePair(keyword, new StringValue(textBytes, _latin1Encoding)));
+                    directory.addError("Invalid compression method value");
+                }
+                metadata.addDirectory(directory);
+            }
+        } else if (chunkType.equals(PngChunkType.bKGD)) {
+            if (filter == null || filter.directoryFilter(PngDirectory.class)) {
+                PngDirectory directory = new PngDirectory(PngChunkType.bKGD);
+                directory.setByteArray(PngDirectory.TAG_BACKGROUND_COLOR, bytes, filter);
+                metadata.addDirectory(directory);
+            }
+        } else if (chunkType.equals(PngChunkType.tEXt)) {
+            if (filter == null || filter.directoryFilter(PngDirectory.class)) {
+                SequentialReader reader = new SequentialByteArrayReader(bytes);
+                byte[] keywordBytes = reader.getNullTerminatedBytes(79);
+                StringValue keyword = new StringValue(keywordBytes, _latin1Encoding);
+                int bytesLeft = bytes.length - keywordBytes.length - 1;
+                StringValue value = reader.getNullTerminatedStringValue(bytesLeft, _latin1Encoding);
+                List<KeyValuePair> textPairs = new ArrayList<KeyValuePair>();
+                textPairs.add(new KeyValuePair(keyword, value));
+                PngDirectory directory = new PngDirectory(PngChunkType.iTXt);
+                directory.setObject(PngDirectory.TAG_TEXTUAL_DATA, textPairs, filter);
+                metadata.addDirectory(directory);
+            }
+        } else if (chunkType.equals(PngChunkType.iTXt)) {
+            if (filter == null || filter.directoryFilter(PngDirectory.class)) {
+                SequentialReader reader = new SequentialByteArrayReader(bytes);
+                byte[] keywordBytes = reader.getNullTerminatedBytes(79);
+                byte compressionFlag = reader.getInt8();
+                byte compressionMethod = reader.getInt8();
+                // TODO we currently ignore languageTagBytes and translatedKeywordBytes
+                byte[] languageTagBytes = reader.getNullTerminatedBytes(bytes.length);
+                byte[] translatedKeywordBytes = reader.getNullTerminatedBytes(bytes.length);
+                int bytesLeft = bytes.length - keywordBytes.length - 1 - 1 - 1 - languageTagBytes.length - 1 - translatedKeywordBytes.length - 1;
+                byte[] textBytes = null;
+                if (compressionFlag == 0) {
+                    textBytes = reader.getNullTerminatedBytes(bytesLeft);
+                } else if (compressionFlag == 1) {
+                    if (compressionMethod == 0) {
+                        textBytes = StreamUtil.readAllBytes(new InflaterInputStream(new ByteArrayInputStream(bytes, bytes.length - bytesLeft, bytesLeft)));
+                    } else {
+                        PngDirectory directory = new PngDirectory(PngChunkType.iTXt);
+                        directory.addError("Invalid compression method value");
+                        metadata.addDirectory(directory);
+                    }
+                } else {
                     PngDirectory directory = new PngDirectory(PngChunkType.iTXt);
-                    directory.setObject(PngDirectory.TAG_TEXTUAL_DATA, textPairs);
+                    directory.addError("Invalid compression flag value");
                     metadata.addDirectory(directory);
+                }
+
+                if (textBytes != null) {
+                    StringValue keyword = new StringValue(keywordBytes, _latin1Encoding);
+                    if (keyword.toString().equals("XML:com.adobe.xmp")) {
+                        // NOTE in testing images, the XMP has parsed successfully, but we are not extracting tags from it as necessary
+                        new XmpReader().extract(textBytes, metadata, filter);
+                    } else {
+                        List<KeyValuePair> textPairs = new ArrayList<KeyValuePair>();
+                        textPairs.add(new KeyValuePair(keyword, new StringValue(textBytes, _latin1Encoding)));
+                        PngDirectory directory = new PngDirectory(PngChunkType.iTXt);
+                        directory.setObject(PngDirectory.TAG_TEXTUAL_DATA, textPairs, filter);
+                        metadata.addDirectory(directory);
+                    }
                 }
             }
         } else if (chunkType.equals(PngChunkType.tIME)) {
-            SequentialByteArrayReader reader = new SequentialByteArrayReader(bytes);
-            int year = reader.getUInt16();
-            int month = reader.getUInt8();
-            int day = reader.getUInt8();
-            int hour = reader.getUInt8();
-            int minute = reader.getUInt8();
-            int second = reader.getUInt8();
-            PngDirectory directory = new PngDirectory(PngChunkType.tIME);
-            if (DateUtil.isValidDate(year, month - 1, day) && DateUtil.isValidTime(hour, minute, second)) {
-                String dateString = String.format("%04d:%02d:%02d %02d:%02d:%02d", year, month, day, hour, minute, second);
-                directory.setString(PngDirectory.TAG_LAST_MODIFICATION_TIME, dateString);
-            } else {
-                directory.addError(String.format(
-                    "PNG tIME data describes an invalid date/time: year=%d month=%d day=%d hour=%d minute=%d second=%d",
-                    year, month, day, hour, minute, second));
+            if (filter == null || filter.directoryFilter(PngDirectory.class)) {
+                SequentialByteArrayReader reader = new SequentialByteArrayReader(bytes);
+                int year = reader.getUInt16();
+                int month = reader.getUInt8();
+                int day = reader.getUInt8();
+                int hour = reader.getUInt8();
+                int minute = reader.getUInt8();
+                int second = reader.getUInt8();
+                PngDirectory directory = new PngDirectory(PngChunkType.tIME);
+                if (DateUtil.isValidDate(year, month - 1, day) && DateUtil.isValidTime(hour, minute, second)) {
+                    String dateString = String.format("%04d:%02d:%02d %02d:%02d:%02d", year, month, day, hour, minute, second);
+                    directory.setString(PngDirectory.TAG_LAST_MODIFICATION_TIME, dateString, filter);
+                } else {
+                    directory.addError(String.format(
+                        "PNG tIME data describes an invalid date/time: year=%d month=%d day=%d hour=%d minute=%d second=%d",
+                        year, month, day, hour, minute, second));
+                }
+                metadata.addDirectory(directory);
             }
-            metadata.addDirectory(directory);
         } else if (chunkType.equals(PngChunkType.pHYs)) {
-            SequentialByteArrayReader reader = new SequentialByteArrayReader(bytes);
-            int pixelsPerUnitX = reader.getInt32();
-            int pixelsPerUnitY = reader.getInt32();
-            byte unitSpecifier = reader.getInt8();
-            PngDirectory directory = new PngDirectory(PngChunkType.pHYs);
-            directory.setInt(PngDirectory.TAG_PIXELS_PER_UNIT_X, pixelsPerUnitX);
-            directory.setInt(PngDirectory.TAG_PIXELS_PER_UNIT_Y, pixelsPerUnitY);
-            directory.setInt(PngDirectory.TAG_UNIT_SPECIFIER, unitSpecifier);
-            metadata.addDirectory(directory);
+            if (filter == null || filter.directoryFilter(PngDirectory.class)) {
+                SequentialByteArrayReader reader = new SequentialByteArrayReader(bytes);
+                int pixelsPerUnitX = reader.getInt32();
+                int pixelsPerUnitY = reader.getInt32();
+                byte unitSpecifier = reader.getInt8();
+                PngDirectory directory = new PngDirectory(PngChunkType.pHYs);
+                directory.setInt(PngDirectory.TAG_PIXELS_PER_UNIT_X, pixelsPerUnitX, filter);
+                directory.setInt(PngDirectory.TAG_PIXELS_PER_UNIT_Y, pixelsPerUnitY, filter);
+                directory.setInt(PngDirectory.TAG_UNIT_SPECIFIER, unitSpecifier, filter);
+                metadata.addDirectory(directory);
+            }
         } else if (chunkType.equals(PngChunkType.sBIT)) {
-            PngDirectory directory = new PngDirectory(PngChunkType.sBIT);
-            directory.setByteArray(PngDirectory.TAG_SIGNIFICANT_BITS, bytes);
-            metadata.addDirectory(directory);
+            if (filter == null || filter.directoryFilter(PngDirectory.class)) {
+                PngDirectory directory = new PngDirectory(PngChunkType.sBIT);
+                directory.setByteArray(PngDirectory.TAG_SIGNIFICANT_BITS, bytes, filter);
+                metadata.addDirectory(directory);
+            }
         }
     }
 }

--- a/Source/com/drew/imaging/psd/PsdMetadataReader.java
+++ b/Source/com/drew/imaging/psd/PsdMetadataReader.java
@@ -23,8 +23,10 @@ package com.drew.imaging.psd;
 
 import com.drew.lang.StreamReader;
 import com.drew.lang.annotations.NotNull;
+import com.drew.lang.annotations.Nullable;
 import com.drew.metadata.Metadata;
 import com.drew.metadata.file.FileMetadataReader;
+import com.drew.metadata.filter.MetadataFilter;
 import com.drew.metadata.photoshop.PsdReader;
 
 import java.io.*;
@@ -39,22 +41,34 @@ public class PsdMetadataReader
     @NotNull
     public static Metadata readMetadata(@NotNull File file) throws IOException
     {
+        return readMetadata(file, null);
+    }
+
+    @NotNull
+    public static Metadata readMetadata(@NotNull File file, @Nullable final MetadataFilter filter) throws IOException
+    {
         Metadata metadata = new Metadata();
         InputStream stream = new FileInputStream(file);
         try {
-            new PsdReader().extract(new StreamReader(stream), metadata);
+            new PsdReader().extract(new StreamReader(stream), metadata, filter);
         } finally {
             stream.close();
         }
-        new FileMetadataReader().read(file, metadata);
+        new FileMetadataReader().read(file, metadata, filter);
         return metadata;
     }
 
     @NotNull
     public static Metadata readMetadata(@NotNull InputStream inputStream)
     {
+        return readMetadata(inputStream, null);
+    }
+
+    @NotNull
+    public static Metadata readMetadata(@NotNull InputStream inputStream, @Nullable final MetadataFilter filter)
+    {
         Metadata metadata = new Metadata();
-        new PsdReader().extract(new StreamReader(inputStream), metadata);
+        new PsdReader().extract(new StreamReader(inputStream), metadata, filter);
         return metadata;
     }
 }

--- a/Source/com/drew/imaging/raf/RafMetadataReader.java
+++ b/Source/com/drew/imaging/raf/RafMetadataReader.java
@@ -23,7 +23,9 @@ package com.drew.imaging.raf;
 import com.drew.imaging.jpeg.JpegMetadataReader;
 import com.drew.imaging.jpeg.JpegProcessingException;
 import com.drew.lang.annotations.NotNull;
+import com.drew.lang.annotations.Nullable;
 import com.drew.metadata.Metadata;
+import com.drew.metadata.filter.MetadataFilter;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -38,6 +40,12 @@ public class RafMetadataReader
 {
     @NotNull
     public static Metadata readMetadata(@NotNull InputStream inputStream) throws JpegProcessingException, IOException
+    {
+        return readMetadata(inputStream, null);
+    }
+
+    @NotNull
+    public static Metadata readMetadata(@NotNull InputStream inputStream, @Nullable final MetadataFilter filter) throws JpegProcessingException, IOException
     {
         if (!inputStream.markSupported())
             throw new IOException("Stream must support mark/reset");
@@ -62,7 +70,7 @@ public class RafMetadataReader
             }
         }
 
-        return JpegMetadataReader.readMetadata(inputStream);
+        return JpegMetadataReader.readMetadata(inputStream, filter);
     }
 
     private RafMetadataReader() throws Exception

--- a/Source/com/drew/imaging/riff/RiffHandler.java
+++ b/Source/com/drew/imaging/riff/RiffHandler.java
@@ -21,6 +21,8 @@
 package com.drew.imaging.riff;
 
 import com.drew.lang.annotations.NotNull;
+import com.drew.lang.annotations.Nullable;
+import com.drew.metadata.filter.MetadataFilter;
 
 /**
  * Interface of an class capable of handling events raised during the reading of a RIFF file
@@ -62,4 +64,17 @@ public interface RiffHandler
      * @param payload they payload of the chunk as a byte array
      */
     void processChunk(@NotNull String fourCC, @NotNull byte[] payload);
+
+    /**
+     * Perform whatever processing is necessary for the type of chunk with its
+     * payload.
+     *
+     * This is only called if a previous call to {@link RiffHandler#shouldAcceptChunk(String)}
+     * with the same <code>fourCC</code> returned <code>true</code>.
+     *
+     * @param fourCC the four character code of the chunk
+     * @param payload they payload of the chunk as a byte array
+     * @param a {@link MetadataFilter} or <code>null</code>
+     */
+    void processChunk(@NotNull String fourCC, @NotNull byte[] payload, @Nullable final MetadataFilter filter);
 }

--- a/Source/com/drew/imaging/riff/RiffReader.java
+++ b/Source/com/drew/imaging/riff/RiffReader.java
@@ -22,6 +22,8 @@ package com.drew.imaging.riff;
 
 import com.drew.lang.SequentialReader;
 import com.drew.lang.annotations.NotNull;
+import com.drew.lang.annotations.Nullable;
+import com.drew.metadata.filter.MetadataFilter;
 
 import java.io.IOException;
 
@@ -49,6 +51,23 @@ public class RiffReader
      */
     public void processRiff(@NotNull final SequentialReader reader,
                             @NotNull final RiffHandler handler) throws RiffProcessingException, IOException
+    {
+        processRiff(reader, handler, null);
+    }
+
+    /**
+     * Processes a RIFF data sequence.
+     *
+     * @param reader the {@link SequentialReader} from which the data should be read
+     * @param handler the {@link RiffHandler} that will coordinate processing and accept read values
+     * @param a {@link MetadataFilter} or <code>null</code>
+     * @throws RiffProcessingException if an error occurred during the processing of RIFF data that could not be
+     *                                 ignored or recovered from
+     * @throws IOException an error occurred while accessing the required data
+     */
+    public void processRiff(@NotNull final SequentialReader reader,
+                            @NotNull final RiffHandler handler,
+                            @Nullable final MetadataFilter filter) throws RiffProcessingException, IOException
     {
         // RIFF files are always little-endian
         reader.setMotorolaByteOrder(false);
@@ -84,7 +103,7 @@ public class RiffReader
 
             if (handler.shouldAcceptChunk(chunkFourCC)) {
                 // TODO is it feasible to avoid copying the chunk here, and to pass the sequential reader to the handler?
-                handler.processChunk(chunkFourCC, reader.getBytes(chunkSize));
+                handler.processChunk(chunkFourCC, reader.getBytes(chunkSize), filter);
             } else {
                 reader.skip(chunkSize);
             }

--- a/Source/com/drew/imaging/tiff/TiffHandler.java
+++ b/Source/com/drew/imaging/tiff/TiffHandler.java
@@ -25,6 +25,7 @@ import com.drew.lang.Rational;
 import com.drew.lang.annotations.NotNull;
 import com.drew.lang.annotations.Nullable;
 import com.drew.metadata.StringValue;
+import com.drew.metadata.filter.MetadataFilter;
 
 import java.io.IOException;
 import java.util.Set;
@@ -47,8 +48,21 @@ public interface TiffHandler
      */
     void setTiffMarker(int marker) throws TiffProcessingException;
 
+    /**
+     * Receives the 2-byte marker found in the TIFF header.
+     * <p>
+     * Implementations are not obligated to use this information for any purpose, though it may be useful for
+     * validation or perhaps differentiating the type of mapping to use for observed tags and IFDs.
+     *
+     * @param marker the 2-byte value found at position 2 of the TIFF header
+     */
+    void setTiffMarker(int marker, @Nullable MetadataFilter filter) throws TiffProcessingException;
+
     boolean tryEnterSubIfd(int tagId);
+    boolean tryEnterSubIfd(int tagId, @Nullable MetadataFilter filter);
+
     boolean hasFollowerIfd();
+    boolean hasFollowerIfd(@Nullable MetadataFilter filter);
 
     void endingIFD();
 
@@ -64,27 +78,35 @@ public interface TiffHandler
                              int tagId,
                              int byteCount) throws IOException;
 
+    boolean customProcessTag(int tagOffset,
+                             @NotNull Set<Integer> processedIfdOffsets,
+                             int tiffHeaderOffset,
+                             @NotNull RandomAccessReader reader,
+                             int tagId,
+                             int byteCount,
+                             @Nullable MetadataFilter filter) throws IOException;
+
     void warn(@NotNull String message);
     void error(@NotNull String message);
 
-    void setByteArray(int tagId, @NotNull byte[] bytes);
-    void setString(int tagId, @NotNull StringValue string);
-    void setRational(int tagId, @NotNull Rational rational);
-    void setRationalArray(int tagId, @NotNull Rational[] array);
-    void setFloat(int tagId, float float32);
-    void setFloatArray(int tagId, @NotNull float[] array);
-    void setDouble(int tagId, double double64);
-    void setDoubleArray(int tagId, @NotNull double[] array);
-    void setInt8s(int tagId, byte int8s);
-    void setInt8sArray(int tagId, @NotNull byte[] array);
-    void setInt8u(int tagId, short int8u);
-    void setInt8uArray(int tagId, @NotNull short[] array);
-    void setInt16s(int tagId, int int16s);
-    void setInt16sArray(int tagId, @NotNull short[] array);
-    void setInt16u(int tagId, int int16u);
-    void setInt16uArray(int tagId, @NotNull int[] array);
-    void setInt32s(int tagId, int int32s);
-    void setInt32sArray(int tagId, @NotNull int[] array);
-    void setInt32u(int tagId, long int32u);
-    void setInt32uArray(int tagId, @NotNull long[] array);
+    void setByteArray(int tagId, @NotNull byte[] bytes, @Nullable final MetadataFilter filter);
+    void setString(int tagId, @NotNull StringValue string, @Nullable final MetadataFilter filter);
+    void setRational(int tagId, @NotNull Rational rational, @Nullable final MetadataFilter filter);
+    void setRationalArray(int tagId, @NotNull Rational[] array, @Nullable final MetadataFilter filter);
+    void setFloat(int tagId, float float32, @Nullable final MetadataFilter filter);
+    void setFloatArray(int tagId, @NotNull float[] array, @Nullable final MetadataFilter filter);
+    void setDouble(int tagId, double double64, @Nullable final MetadataFilter filter);
+    void setDoubleArray(int tagId, @NotNull double[] array, @Nullable final MetadataFilter filter);
+    void setInt8s(int tagId, byte int8s, @Nullable final MetadataFilter filter);
+    void setInt8sArray(int tagId, @NotNull byte[] array, @Nullable final MetadataFilter filter);
+    void setInt8u(int tagId, short int8u, @Nullable final MetadataFilter filter);
+    void setInt8uArray(int tagId, @NotNull short[] array, @Nullable final MetadataFilter filter);
+    void setInt16s(int tagId, int int16s, @Nullable final MetadataFilter filter);
+    void setInt16sArray(int tagId, @NotNull short[] array, @Nullable final MetadataFilter filter);
+    void setInt16u(int tagId, int int16u, @Nullable final MetadataFilter filter);
+    void setInt16uArray(int tagId, @NotNull int[] array, @Nullable final MetadataFilter filter);
+    void setInt32s(int tagId, int int32s, @Nullable final MetadataFilter filter);
+    void setInt32sArray(int tagId, @NotNull int[] array, @Nullable final MetadataFilter filter);
+    void setInt32u(int tagId, long int32u, @Nullable final MetadataFilter filter);
+    void setInt32uArray(int tagId, @NotNull long[] array, @Nullable final MetadataFilter filter);
 }

--- a/Source/com/drew/imaging/tiff/TiffMetadataReader.java
+++ b/Source/com/drew/imaging/tiff/TiffMetadataReader.java
@@ -24,9 +24,11 @@ import com.drew.lang.RandomAccessFileReader;
 import com.drew.lang.RandomAccessReader;
 import com.drew.lang.RandomAccessStreamReader;
 import com.drew.lang.annotations.NotNull;
+import com.drew.lang.annotations.Nullable;
 import com.drew.metadata.Metadata;
 import com.drew.metadata.exif.ExifTiffHandler;
 import com.drew.metadata.file.FileMetadataReader;
+import com.drew.metadata.filter.MetadataFilter;
 
 import java.io.*;
 
@@ -42,17 +44,23 @@ public class TiffMetadataReader
     @NotNull
     public static Metadata readMetadata(@NotNull File file) throws IOException, TiffProcessingException
     {
+        return readMetadata(file, null);
+    }
+
+    @NotNull
+    public static Metadata readMetadata(@NotNull File file, @Nullable final MetadataFilter filter) throws IOException, TiffProcessingException
+    {
         Metadata metadata = new Metadata();
         RandomAccessFile randomAccessFile = new RandomAccessFile(file, "r");
 
         try {
             ExifTiffHandler handler = new ExifTiffHandler(metadata, false, null);
-            new TiffReader().processTiff(new RandomAccessFileReader(randomAccessFile), handler, 0);
+            new TiffReader().processTiff(new RandomAccessFileReader(randomAccessFile), handler, 0, filter);
         } finally {
             randomAccessFile.close();
         }
 
-        new FileMetadataReader().read(file, metadata);
+        new FileMetadataReader().read(file, metadata, filter);
 
         return metadata;
     }
@@ -60,19 +68,31 @@ public class TiffMetadataReader
     @NotNull
     public static Metadata readMetadata(@NotNull InputStream inputStream) throws IOException, TiffProcessingException
     {
+        return readMetadata(inputStream, null);
+    }
+
+    @NotNull
+    public static Metadata readMetadata(@NotNull InputStream inputStream, @Nullable final MetadataFilter filter) throws IOException, TiffProcessingException
+    {
         // TIFF processing requires random access, as directories can be scattered throughout the byte sequence.
         // InputStream does not support seeking backwards, so we wrap it with RandomAccessStreamReader, which
         // buffers data from the stream as we seek forward.
 
-        return readMetadata(new RandomAccessStreamReader(inputStream));
+        return readMetadata(new RandomAccessStreamReader(inputStream), filter);
     }
 
     @NotNull
     public static Metadata readMetadata(@NotNull RandomAccessReader reader) throws IOException, TiffProcessingException
     {
+        return readMetadata(reader, null);
+    }
+
+    @NotNull
+    public static Metadata readMetadata(@NotNull RandomAccessReader reader, @Nullable final MetadataFilter filter) throws IOException, TiffProcessingException
+    {
         Metadata metadata = new Metadata();
         ExifTiffHandler handler = new ExifTiffHandler(metadata, false, null);
-        new TiffReader().processTiff(reader, handler, 0);
+        new TiffReader().processTiff(reader, handler, 0, filter);
         return metadata;
     }
 }

--- a/Source/com/drew/imaging/webp/WebpMetadataReader.java
+++ b/Source/com/drew/imaging/webp/WebpMetadataReader.java
@@ -24,8 +24,10 @@ import com.drew.imaging.riff.RiffProcessingException;
 import com.drew.imaging.riff.RiffReader;
 import com.drew.lang.StreamReader;
 import com.drew.lang.annotations.NotNull;
+import com.drew.lang.annotations.Nullable;
 import com.drew.metadata.Metadata;
 import com.drew.metadata.file.FileMetadataReader;
+import com.drew.metadata.filter.MetadataFilter;
 import com.drew.metadata.webp.WebpRiffHandler;
 
 import java.io.*;
@@ -40,22 +42,34 @@ public class WebpMetadataReader
     @NotNull
     public static Metadata readMetadata(@NotNull File file) throws IOException, RiffProcessingException
     {
+        return readMetadata(file, null);
+    }
+
+    @NotNull
+    public static Metadata readMetadata(@NotNull File file, @Nullable final MetadataFilter filter) throws IOException, RiffProcessingException
+    {
         InputStream inputStream = new FileInputStream(file);
         Metadata metadata;
         try {
-            metadata = readMetadata(inputStream);
+            metadata = readMetadata(inputStream, filter);
         } finally {
             inputStream.close();
         }
-        new FileMetadataReader().read(file, metadata);
+        new FileMetadataReader().read(file, metadata, filter);
         return metadata;
     }
 
     @NotNull
     public static Metadata readMetadata(@NotNull InputStream inputStream) throws IOException, RiffProcessingException
     {
+        return readMetadata(inputStream, null);
+    }
+
+    @NotNull
+    public static Metadata readMetadata(@NotNull InputStream inputStream, @Nullable final MetadataFilter filter) throws IOException, RiffProcessingException
+    {
         Metadata metadata = new Metadata();
-        new RiffReader().processRiff(new StreamReader(inputStream), new WebpRiffHandler(metadata));
+        new RiffReader().processRiff(new StreamReader(inputStream), new WebpRiffHandler(metadata), filter);
         return metadata;
     }
 }

--- a/Source/com/drew/metadata/Directory.java
+++ b/Source/com/drew/metadata/Directory.java
@@ -24,6 +24,7 @@ import com.drew.lang.Rational;
 import com.drew.lang.annotations.NotNull;
 import com.drew.lang.annotations.Nullable;
 import com.drew.lang.annotations.SuppressWarnings;
+import com.drew.metadata.filter.MetadataFilter;
 
 import java.io.UnsupportedEncodingException;
 import java.lang.reflect.Array;
@@ -201,7 +202,19 @@ public abstract class Directory
      */
     public void setInt(int tagType, int value)
     {
-        setObject(tagType, value);
+        setObject(tagType, value, null);
+    }
+
+    /**
+     * Sets an <code>int</code> value for the specified tag.
+     *
+     * @param tagType the tag's value as an int
+     * @param value   the value for the specified tag as an int
+     * @param filter  the {@link MetadataFilter} or <code>null</code>
+     */
+    public void setInt(int tagType, int value, @Nullable MetadataFilter filter)
+    {
+        setObject(tagType, value, filter);
     }
 
     /**
@@ -212,7 +225,19 @@ public abstract class Directory
      */
     public void setIntArray(int tagType, @NotNull int[] ints)
     {
-        setObjectArray(tagType, ints);
+        setObjectArray(tagType, ints, null);
+    }
+
+    /**
+     * Sets an <code>int[]</code> (array) for the specified tag.
+     *
+     * @param tagType the tag identifier
+     * @param ints    the int array to store
+     * @param filter  the {@link MetadataFilter} or <code>null</code>
+     */
+    public void setIntArray(int tagType, @NotNull int[] ints, @Nullable MetadataFilter filter)
+    {
+        setObjectArray(tagType, ints, filter);
     }
 
     /**
@@ -223,7 +248,19 @@ public abstract class Directory
      */
     public void setFloat(int tagType, float value)
     {
-        setObject(tagType, value);
+        setObject(tagType, value, null);
+    }
+
+    /**
+     * Sets a <code>float</code> value for the specified tag.
+     *
+     * @param tagType the tag's value as an int
+     * @param value   the value for the specified tag as a float
+     * @param filter  the {@link MetadataFilter} or <code>null</code>
+     */
+    public void setFloat(int tagType, float value, @Nullable MetadataFilter filter)
+    {
+        setObject(tagType, value, filter);
     }
 
     /**
@@ -234,7 +271,19 @@ public abstract class Directory
      */
     public void setFloatArray(int tagType, @NotNull float[] floats)
     {
-        setObjectArray(tagType, floats);
+        setObjectArray(tagType, floats, null);
+    }
+
+    /**
+     * Sets a <code>float[]</code> (array) for the specified tag.
+     *
+     * @param tagType the tag identifier
+     * @param floats  the float array to store
+     * @param filter  the {@link MetadataFilter} or <code>null</code>
+     */
+    public void setFloatArray(int tagType, @NotNull float[] floats, @Nullable MetadataFilter filter)
+    {
+        setObjectArray(tagType, floats, filter);
     }
 
     /**
@@ -245,7 +294,19 @@ public abstract class Directory
      */
     public void setDouble(int tagType, double value)
     {
-        setObject(tagType, value);
+        setObject(tagType, value, null);
+    }
+
+    /**
+     * Sets a <code>double</code> value for the specified tag.
+     *
+     * @param tagType the tag's value as an int
+     * @param value   the value for the specified tag as a double
+     * @param filter  the {@link MetadataFilter} or <code>null</code>
+     */
+    public void setDouble(int tagType, double value, @Nullable MetadataFilter filter)
+    {
+        setObject(tagType, value, filter);
     }
 
     /**
@@ -256,7 +317,19 @@ public abstract class Directory
      */
     public void setDoubleArray(int tagType, @NotNull double[] doubles)
     {
-        setObjectArray(tagType, doubles);
+        setObjectArray(tagType, doubles, null);
+    }
+
+    /**
+     * Sets a <code>double[]</code> (array) for the specified tag.
+     *
+     * @param tagType the tag identifier
+     * @param doubles the double array to store
+     * @param filter  the {@link MetadataFilter} or <code>null</code>
+     */
+    public void setDoubleArray(int tagType, @NotNull double[] doubles, @Nullable MetadataFilter filter)
+    {
+        setObjectArray(tagType, doubles, filter);
     }
 
     /**
@@ -270,7 +343,22 @@ public abstract class Directory
     {
         if (value == null)
             throw new NullPointerException("cannot set a null StringValue");
-        setObject(tagType, value);
+        setObject(tagType, value, null);
+    }
+
+    /**
+     * Sets a <code>StringValue</code> value for the specified tag.
+     *
+     * @param tagType the tag's value as an int
+     * @param value   the value for the specified tag as a StringValue
+     * @param filter  the {@link MetadataFilter} or <code>null</code>
+     */
+    @java.lang.SuppressWarnings({ "ConstantConditions" })
+    public void setStringValue(int tagType, @NotNull StringValue value, @Nullable MetadataFilter filter)
+    {
+        if (value == null)
+            throw new NullPointerException("cannot set a null StringValue");
+        setObject(tagType, value, filter);
     }
 
     /**
@@ -284,7 +372,22 @@ public abstract class Directory
     {
         if (value == null)
             throw new NullPointerException("cannot set a null String");
-        setObject(tagType, value);
+        setObject(tagType, value, null);
+    }
+
+    /**
+     * Sets a <code>String</code> value for the specified tag.
+     *
+     * @param tagType the tag's value as an int
+     * @param value   the value for the specified tag as a String
+     * @param filter  the {@link MetadataFilter} or <code>null</code>
+     */
+    @java.lang.SuppressWarnings({ "ConstantConditions" })
+    public void setString(int tagType, @NotNull String value, @Nullable MetadataFilter filter)
+    {
+        if (value == null)
+            throw new NullPointerException("cannot set a null String");
+        setObject(tagType, value, filter);
     }
 
     /**
@@ -295,7 +398,19 @@ public abstract class Directory
      */
     public void setStringArray(int tagType, @NotNull String[] strings)
     {
-        setObjectArray(tagType, strings);
+        setObjectArray(tagType, strings, null);
+    }
+
+    /**
+     * Sets a <code>String[]</code> (array) for the specified tag.
+     *
+     * @param tagType the tag identifier
+     * @param strings the String array to store
+     * @param filter  the {@link MetadataFilter} or <code>null</code>
+     */
+    public void setStringArray(int tagType, @NotNull String[] strings, @Nullable MetadataFilter filter)
+    {
+        setObjectArray(tagType, strings, filter);
     }
 
     /**
@@ -306,7 +421,19 @@ public abstract class Directory
      */
     public void setStringValueArray(int tagType, @NotNull StringValue[] strings)
     {
-        setObjectArray(tagType, strings);
+        setObjectArray(tagType, strings, null);
+    }
+
+    /**
+     * Sets a <code>StringValue[]</code> (array) for the specified tag.
+     *
+     * @param tagType the tag identifier
+     * @param strings the StringValue array to store
+     * @param filter  the {@link MetadataFilter} or <code>null</code>
+     */
+    public void setStringValueArray(int tagType, @NotNull StringValue[] strings, @Nullable MetadataFilter filter)
+    {
+        setObjectArray(tagType, strings, filter);
     }
 
     /**
@@ -317,7 +444,19 @@ public abstract class Directory
      */
     public void setBoolean(int tagType, boolean value)
     {
-        setObject(tagType, value);
+        setObject(tagType, value, null);
+    }
+
+    /**
+     * Sets a <code>boolean</code> value for the specified tag.
+     *
+     * @param tagType the tag's value as an int
+     * @param value   the value for the specified tag as a boolean
+     * @param filter  the {@link MetadataFilter} or <code>null</code>
+     */
+    public void setBoolean(int tagType, boolean value, @Nullable MetadataFilter filter)
+    {
+        setObject(tagType, value, filter);
     }
 
     /**
@@ -328,7 +467,19 @@ public abstract class Directory
      */
     public void setLong(int tagType, long value)
     {
-        setObject(tagType, value);
+        setObject(tagType, value, null);
+    }
+
+    /**
+     * Sets a <code>long</code> value for the specified tag.
+     *
+     * @param tagType the tag's value as an int
+     * @param value   the value for the specified tag as a long
+     * @param filter  the {@link MetadataFilter} or <code>null</code>
+     */
+    public void setLong(int tagType, long value, @Nullable MetadataFilter filter)
+    {
+        setObject(tagType, value, filter);
     }
 
     /**
@@ -339,7 +490,19 @@ public abstract class Directory
      */
     public void setDate(int tagType, @NotNull java.util.Date value)
     {
-        setObject(tagType, value);
+        setObject(tagType, value, null);
+    }
+
+    /**
+     * Sets a <code>java.util.Date</code> value for the specified tag.
+     *
+     * @param tagType the tag's value as an int
+     * @param value   the value for the specified tag as a java.util.Date
+     * @param filter  the {@link MetadataFilter} or <code>null</code>
+     */
+    public void setDate(int tagType, @NotNull java.util.Date value, @Nullable MetadataFilter filter)
+    {
+        setObject(tagType, value, filter);
     }
 
     /**
@@ -350,7 +513,19 @@ public abstract class Directory
      */
     public void setRational(int tagType, @NotNull Rational rational)
     {
-        setObject(tagType, rational);
+        setObject(tagType, rational, null);
+    }
+
+    /**
+     * Sets a <code>Rational</code> value for the specified tag.
+     *
+     * @param tagType  the tag's value as an int
+     * @param rational rational number
+     * @param filter  the {@link MetadataFilter} or <code>null</code>
+     */
+    public void setRational(int tagType, @NotNull Rational rational, @Nullable MetadataFilter filter)
+    {
+        setObject(tagType, rational, filter);
     }
 
     /**
@@ -361,7 +536,19 @@ public abstract class Directory
      */
     public void setRationalArray(int tagType, @NotNull Rational[] rationals)
     {
-        setObjectArray(tagType, rationals);
+        setObjectArray(tagType, rationals, null);
+    }
+
+    /**
+     * Sets a <code>Rational[]</code> (array) for the specified tag.
+     *
+     * @param tagType   the tag identifier
+     * @param rationals the Rational array to store
+     * @param filter  the {@link MetadataFilter} or <code>null</code>
+     */
+    public void setRationalArray(int tagType, @NotNull Rational[] rationals, @Nullable MetadataFilter filter)
+    {
+        setObjectArray(tagType, rationals, filter);
     }
 
     /**
@@ -372,7 +559,19 @@ public abstract class Directory
      */
     public void setByteArray(int tagType, @NotNull byte[] bytes)
     {
-        setObjectArray(tagType, bytes);
+        setObjectArray(tagType, bytes, null);
+    }
+
+    /**
+     * Sets a <code>byte[]</code> (array) for the specified tag.
+     *
+     * @param tagType the tag identifier
+     * @param bytes   the byte array to store
+     * @param filter  the {@link MetadataFilter} or <code>null</code>
+     */
+    public void setByteArray(int tagType, @NotNull byte[] bytes, @Nullable MetadataFilter filter)
+    {
+        setObjectArray(tagType, bytes, filter);
     }
 
     /**
@@ -385,6 +584,23 @@ public abstract class Directory
     @java.lang.SuppressWarnings( { "ConstantConditions", "UnnecessaryBoxing" })
     public void setObject(int tagType, @NotNull Object value)
     {
+        setObject(tagType, value, null);
+    }
+
+    /**
+     * Sets a <code>Object</code> for the specified tag.
+     *
+     * @param tagType the tag's value as an int
+     * @param value   the value for the specified tag
+     * @param filter  the {@link MetadataFilter} or <code>null</code>
+     * @throws NullPointerException if value is <code>null</code>
+     */
+    @java.lang.SuppressWarnings( { "ConstantConditions", "UnnecessaryBoxing" })
+    public void setObject(int tagType, @NotNull Object value, @Nullable MetadataFilter filter)
+    {
+        if (filter != null && !filter.tagFilter(this, tagType))
+            return;
+
         if (value == null)
             throw new NullPointerException("cannot set a null object");
 
@@ -408,7 +624,20 @@ public abstract class Directory
     public void setObjectArray(int tagType, @NotNull Object array)
     {
         // for now, we don't do anything special -- this method might be a candidate for removal once the dust settles
-        setObject(tagType, array);
+        setObject(tagType, array, null);
+    }
+
+    /**
+     * Sets an array <code>Object</code> for the specified tag.
+     *
+     * @param tagType the tag's value as an int
+     * @param array   the array of values for the specified tag
+     * @param filter  the {@link MetadataFilter} or <code>null</code>
+     */
+    public void setObjectArray(int tagType, @NotNull Object array, @Nullable MetadataFilter filter)
+    {
+        // for now, we don't do anything special -- this method might be a candidate for removal once the dust settles
+        setObject(tagType, array, filter);
     }
 
 // TAG GETTERS

--- a/Source/com/drew/metadata/ErrorDirectory.java
+++ b/Source/com/drew/metadata/ErrorDirectory.java
@@ -21,6 +21,8 @@
 package com.drew.metadata;
 
 import com.drew.lang.annotations.NotNull;
+import com.drew.lang.annotations.Nullable;
+import com.drew.metadata.filter.MetadataFilter;
 import java.util.*;
 
 /**
@@ -74,4 +76,11 @@ public final class ErrorDirectory extends Directory
         throw new UnsupportedOperationException(String.format("Cannot add value to %s.", ErrorDirectory.class.getName()));
     }
     
+    @Override
+    @NotNull
+    public void setObject(int tagType, @NotNull Object value, @Nullable MetadataFilter filter)
+    {
+        throw new UnsupportedOperationException(String.format("Cannot add value to %s.", ErrorDirectory.class.getName()));
+    }
+
 }

--- a/Source/com/drew/metadata/MetadataReader.java
+++ b/Source/com/drew/metadata/MetadataReader.java
@@ -22,6 +22,8 @@ package com.drew.metadata;
 
 import com.drew.lang.RandomAccessReader;
 import com.drew.lang.annotations.NotNull;
+import com.drew.lang.annotations.Nullable;
+import com.drew.metadata.filter.MetadataFilter;
 
 /**
  * Defines an object capable of processing a particular type of metadata from a {@link RandomAccessReader}.
@@ -39,4 +41,13 @@ public interface MetadataReader
      * @param metadata The {@link Metadata} object into which extracted values should be merged.
      */
     void extract(@NotNull final RandomAccessReader reader, @NotNull final Metadata metadata);
+
+    /**
+     * Extracts metadata from <code>reader</code> and merges it into the specified {@link Metadata} object.
+     *
+     * @param reader   The {@link RandomAccessReader} from which the metadata should be extracted.
+     * @param metadata The {@link Metadata} object into which extracted values should be merged.
+     * @param filter   A {@link MetadataFilter} or <code>null</code>.
+     */
+    void extract(@NotNull final RandomAccessReader reader, @NotNull final Metadata metadata, @Nullable final MetadataFilter filter);
 }

--- a/Source/com/drew/metadata/bmp/BmpReader.java
+++ b/Source/com/drew/metadata/bmp/BmpReader.java
@@ -22,7 +22,9 @@ package com.drew.metadata.bmp;
 
 import com.drew.lang.SequentialReader;
 import com.drew.lang.annotations.NotNull;
+import com.drew.lang.annotations.Nullable;
 import com.drew.metadata.Metadata;
+import com.drew.metadata.filter.MetadataFilter;
 
 import java.io.IOException;
 
@@ -33,6 +35,14 @@ public class BmpReader
 {
     public void extract(@NotNull final SequentialReader reader, final @NotNull Metadata metadata)
     {
+        extract(reader, metadata, null);
+    }
+
+    public void extract(@NotNull final SequentialReader reader, final @NotNull Metadata metadata, @Nullable final MetadataFilter filter)
+    {
+        if (filter != null && !filter.directoryFilter(BmpHeaderDirectory.class))
+            return;
+
         BmpHeaderDirectory directory = new BmpHeaderDirectory();
         metadata.addDirectory(directory);
 
@@ -97,27 +107,27 @@ public class BmpReader
 
             int headerSize = reader.getInt32();
 
-            directory.setInt(BmpHeaderDirectory.TAG_HEADER_SIZE, headerSize);
+            directory.setInt(BmpHeaderDirectory.TAG_HEADER_SIZE, headerSize, filter);
 
             // We expect the header size to be either 40 (BITMAPINFOHEADER) or 12 (BITMAPCOREHEADER)
             if (headerSize == 40) {
                 // BITMAPINFOHEADER
-                directory.setInt(BmpHeaderDirectory.TAG_IMAGE_WIDTH, reader.getInt32());
-                directory.setInt(BmpHeaderDirectory.TAG_IMAGE_HEIGHT, reader.getInt32());
-                directory.setInt(BmpHeaderDirectory.TAG_COLOUR_PLANES, reader.getInt16());
-                directory.setInt(BmpHeaderDirectory.TAG_BITS_PER_PIXEL, reader.getInt16());
-                directory.setInt(BmpHeaderDirectory.TAG_COMPRESSION, reader.getInt32());
+                directory.setInt(BmpHeaderDirectory.TAG_IMAGE_WIDTH, reader.getInt32(), filter);
+                directory.setInt(BmpHeaderDirectory.TAG_IMAGE_HEIGHT, reader.getInt32(), filter);
+                directory.setInt(BmpHeaderDirectory.TAG_COLOUR_PLANES, reader.getInt16(), filter);
+                directory.setInt(BmpHeaderDirectory.TAG_BITS_PER_PIXEL, reader.getInt16(), filter);
+                directory.setInt(BmpHeaderDirectory.TAG_COMPRESSION, reader.getInt32(), filter);
                 // skip the pixel data length
                 reader.skip(4);
-                directory.setInt(BmpHeaderDirectory.TAG_X_PIXELS_PER_METER, reader.getInt32());
-                directory.setInt(BmpHeaderDirectory.TAG_Y_PIXELS_PER_METER, reader.getInt32());
-                directory.setInt(BmpHeaderDirectory.TAG_PALETTE_COLOUR_COUNT, reader.getInt32());
-                directory.setInt(BmpHeaderDirectory.TAG_IMPORTANT_COLOUR_COUNT, reader.getInt32());
+                directory.setInt(BmpHeaderDirectory.TAG_X_PIXELS_PER_METER, reader.getInt32(), filter);
+                directory.setInt(BmpHeaderDirectory.TAG_Y_PIXELS_PER_METER, reader.getInt32(), filter);
+                directory.setInt(BmpHeaderDirectory.TAG_PALETTE_COLOUR_COUNT, reader.getInt32(), filter);
+                directory.setInt(BmpHeaderDirectory.TAG_IMPORTANT_COLOUR_COUNT, reader.getInt32(), filter);
             } else if (headerSize == 12) {
-                directory.setInt(BmpHeaderDirectory.TAG_IMAGE_WIDTH, reader.getInt16());
-                directory.setInt(BmpHeaderDirectory.TAG_IMAGE_HEIGHT, reader.getInt16());
-                directory.setInt(BmpHeaderDirectory.TAG_COLOUR_PLANES, reader.getInt16());
-                directory.setInt(BmpHeaderDirectory.TAG_BITS_PER_PIXEL, reader.getInt16());
+                directory.setInt(BmpHeaderDirectory.TAG_IMAGE_WIDTH, reader.getInt16(), filter);
+                directory.setInt(BmpHeaderDirectory.TAG_IMAGE_HEIGHT, reader.getInt16(), filter);
+                directory.setInt(BmpHeaderDirectory.TAG_COLOUR_PLANES, reader.getInt16(), filter);
+                directory.setInt(BmpHeaderDirectory.TAG_BITS_PER_PIXEL, reader.getInt16(), filter);
             } else {
                 directory.addError("Unexpected DIB header size: " + headerSize);
             }

--- a/Source/com/drew/metadata/exif/makernotes/CanonMakernoteDirectory.java
+++ b/Source/com/drew/metadata/exif/makernotes/CanonMakernoteDirectory.java
@@ -21,7 +21,9 @@
 package com.drew.metadata.exif.makernotes;
 
 import com.drew.lang.annotations.NotNull;
+import com.drew.lang.annotations.Nullable;
 import com.drew.metadata.Directory;
+import com.drew.metadata.filter.MetadataFilter;
 
 import java.util.HashMap;
 
@@ -689,11 +691,17 @@ public class CanonMakernoteDirectory extends Directory
     @Override
     public void setObjectArray(int tagType, @NotNull Object array)
     {
+        setObjectArray(tagType, array, null);
+    }
+
+    @Override
+    public void setObjectArray(int tagType, @NotNull Object array, @Nullable final MetadataFilter filter)
+    {
         // TODO is there some way to drop out 'null' or 'zero' values that are present in the array to reduce the noise?
 
         if (!(array instanceof int[])) {
             // no special handling...
-            super.setObjectArray(tagType, array);
+            super.setObjectArray(tagType, array, filter);
             return;
         }
 
@@ -705,25 +713,25 @@ public class CanonMakernoteDirectory extends Directory
             case TAG_CAMERA_SETTINGS_ARRAY: {
                 int[] ints = (int[])array;
                 for (int i = 0; i < ints.length; i++)
-                    setInt(CameraSettings.OFFSET + i, ints[i]);
+                    setInt(CameraSettings.OFFSET + i, ints[i], filter);
                 break;
             }
             case TAG_FOCAL_LENGTH_ARRAY: {
                 int[] ints = (int[])array;
                 for (int i = 0; i < ints.length; i++)
-                    setInt(FocalLength.OFFSET + i, ints[i]);
+                    setInt(FocalLength.OFFSET + i, ints[i], filter);
                 break;
             }
             case TAG_SHOT_INFO_ARRAY: {
                 int[] ints = (int[])array;
                 for (int i = 0; i < ints.length; i++)
-                    setInt(ShotInfo.OFFSET + i, ints[i]);
+                    setInt(ShotInfo.OFFSET + i, ints[i], filter);
                 break;
             }
             case TAG_PANORAMA_ARRAY: {
                 int[] ints = (int[])array;
                 for (int i = 0; i < ints.length; i++)
-                    setInt(Panorama.OFFSET + i, ints[i]);
+                    setInt(Panorama.OFFSET + i, ints[i], filter);
                 break;
             }
             // TODO the interpretation of the custom functions tag depends upon the camera model
@@ -765,7 +773,7 @@ public class CanonMakernoteDirectory extends Directory
                             for (int j = 0; j < areaPositions.length; j++)
                                 areaPositions[j] = (short)values[i + j];
 
-                            super.setObjectArray(AFInfo.OFFSET + tagnumber, areaPositions);
+                            super.setObjectArray(AFInfo.OFFSET + tagnumber, areaPositions, filter);
                         }
                         i += numafpoints - 1;   // assume these bytes are processed and skip
                     }
@@ -779,19 +787,19 @@ public class CanonMakernoteDirectory extends Directory
                             for (int j = 0; j < pointsInFocus.length; j++)
                                 pointsInFocus[j] = (short)values[i + j];
 
-                            super.setObjectArray(AFInfo.OFFSET + tagnumber, pointsInFocus);
+                            super.setObjectArray(AFInfo.OFFSET + tagnumber, pointsInFocus, filter);
                         }
                         i += pointsInFocus.length - 1;  // assume these bytes are processed and skip
                     }
                     else
-                        super.setObjectArray(AFInfo.OFFSET + tagnumber, values[i]);
+                        super.setObjectArray(AFInfo.OFFSET + tagnumber, values[i], filter);
                     tagnumber++;
                 }
                 break;
             }
             default: {
                 // no special handling...
-                super.setObjectArray(tagType, array);
+                super.setObjectArray(tagType, array, filter);
                 break;
             }
         }

--- a/Source/com/drew/metadata/exif/makernotes/OlympusMakernoteDirectory.java
+++ b/Source/com/drew/metadata/exif/makernotes/OlympusMakernoteDirectory.java
@@ -22,7 +22,9 @@ package com.drew.metadata.exif.makernotes;
 
 import com.drew.lang.SequentialByteArrayReader;
 import com.drew.lang.annotations.NotNull;
+import com.drew.lang.annotations.Nullable;
 import com.drew.metadata.Directory;
+import com.drew.metadata.filter.MetadataFilter;
 
 import java.io.IOException;
 import java.util.HashMap;
@@ -464,17 +466,23 @@ public class OlympusMakernoteDirectory extends Directory
         return "Olympus Makernote";
     }
 
-    @Override
+    /*@Override
     public void setByteArray(int tagType, @NotNull byte[] bytes)
     {
+        setByteArray(tagType, bytes, null);
+    }*/
+
+    @Override
+    public void setByteArray(int tagType, @NotNull byte[] bytes, @Nullable final MetadataFilter filter)
+    {
         if (tagType == TAG_CAMERA_SETTINGS_1 || tagType == TAG_CAMERA_SETTINGS_2) {
-            processCameraSettings(bytes);
+            processCameraSettings(bytes, filter);
         } else {
-            super.setByteArray(tagType, bytes);
+            super.setByteArray(tagType, bytes, filter);
         }
     }
 
-    private void processCameraSettings(byte[] bytes)
+    private void processCameraSettings(byte[] bytes, @Nullable final MetadataFilter filter)
     {
         SequentialByteArrayReader reader = new SequentialByteArrayReader(bytes);
         reader.setMotorolaByteOrder(true);
@@ -484,7 +492,7 @@ public class OlympusMakernoteDirectory extends Directory
         try {
             for (int i = 0; i < count; i++) {
                 int value = reader.getInt32();
-                setInt(CameraSettings.OFFSET + i, value);
+                setInt(CameraSettings.OFFSET + i, value, filter);
             }
         } catch (IOException e) {
             // Should never happen, given that we check the length of the bytes beforehand.

--- a/Source/com/drew/metadata/file/FileMetadataReader.java
+++ b/Source/com/drew/metadata/file/FileMetadataReader.java
@@ -21,7 +21,9 @@
 package com.drew.metadata.file;
 
 import com.drew.lang.annotations.NotNull;
+import com.drew.lang.annotations.Nullable;
 import com.drew.metadata.Metadata;
+import com.drew.metadata.filter.MetadataFilter;
 
 import java.io.File;
 import java.io.IOException;
@@ -31,6 +33,14 @@ public class FileMetadataReader
 {
     public void read(@NotNull File file, @NotNull Metadata metadata) throws IOException
     {
+        read(file, metadata, null);
+    }
+
+    public void read(@NotNull File file, @NotNull Metadata metadata, @Nullable final MetadataFilter filter) throws IOException
+    {
+        if (filter != null && !filter.directoryFilter(FileMetadataDirectory.class))
+            return;
+
         if (!file.isFile())
             throw new IOException("File object must reference a file");
         if (!file.exists())
@@ -40,9 +50,9 @@ public class FileMetadataReader
 
         FileMetadataDirectory directory = new FileMetadataDirectory();
 
-        directory.setString(FileMetadataDirectory.TAG_FILE_NAME, file.getName());
-        directory.setLong(FileMetadataDirectory.TAG_FILE_SIZE, file.length());
-        directory.setDate(FileMetadataDirectory.TAG_FILE_MODIFIED_DATE, new Date(file.lastModified()));
+        directory.setString(FileMetadataDirectory.TAG_FILE_NAME, file.getName(), filter);
+        directory.setLong(FileMetadataDirectory.TAG_FILE_SIZE, file.length(), filter);
+        directory.setDate(FileMetadataDirectory.TAG_FILE_MODIFIED_DATE, new Date(file.lastModified()), filter);
 
         metadata.addDirectory(directory);
     }

--- a/Source/com/drew/metadata/filter/FilteredDirectory.java
+++ b/Source/com/drew/metadata/filter/FilteredDirectory.java
@@ -1,0 +1,157 @@
+/*
+ * Copyright 2002-2016 Drew Noakes
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ * More information about this project is available at:
+ *
+ *    https://drewnoakes.com/code/exif/
+ *    https://github.com/drewnoakes/metadata-extractor
+ */
+package com.drew.metadata.filter;
+
+import com.drew.lang.Rational;
+import com.drew.lang.annotations.NotNull;
+import com.drew.lang.annotations.Nullable;
+import com.drew.metadata.Directory;
+import com.drew.metadata.StringValue;
+
+import java.util.Date;
+import java.util.HashMap;
+
+
+/**
+ * A dummy class that doesn't store any values. It is used in place of
+ * instances that have been filtered out.
+ */
+public class FilteredDirectory extends Directory {
+
+    protected final Class<? extends Directory> _substituteFor;
+
+    @NotNull
+    protected static final HashMap<Integer, String> _tagNameMap = new HashMap<Integer, String>();
+
+    public FilteredDirectory(@Nullable Class<? extends Directory> substituteFor) {
+        _substituteFor = substituteFor;
+    }
+
+    @Nullable
+    public Class<? extends Directory> getSubstituteFor() {
+        return _substituteFor;
+    }
+
+    @Override
+    @NotNull
+    public String getName() {
+        return "Filtered";
+    }
+
+    @Override
+    @NotNull
+    protected HashMap<Integer, String> getTagNameMap() {
+        return _tagNameMap;
+    }
+
+    @Override
+    public boolean containsTag(int tagType) {
+        return false;
+    }
+
+    @Override
+    public void addError(String message) {
+    }
+
+    @Override
+    @Nullable
+    public Directory getParent() {
+        if (super.getParent() == null)
+            return null;
+
+        if (super.getParent() instanceof FilteredDirectory)
+            return super.getParent().getParent();
+
+        return super.getParent();
+    }
+
+    @Override
+    public void setInt(int tagType, int value, MetadataFilter filter) {
+    }
+
+    @Override
+    public void setIntArray(int tagType, int[] ints, MetadataFilter filter) {
+    }
+
+    @Override
+    public void setFloat(int tagType, float value, MetadataFilter filter) {
+    }
+
+    @Override
+    public void setFloatArray(int tagType, float[] floats, MetadataFilter filter) {
+    }
+
+    @Override
+    public void setDouble(int tagType, double value, MetadataFilter filter) {
+    }
+
+    @Override
+    public void setDoubleArray(int tagType, double[] doubles, MetadataFilter filter) {
+    }
+
+    @Override
+    public void setStringValue(int tagType, StringValue value, MetadataFilter filter) {
+    }
+
+    @Override
+    public void setString(int tagType, String value, MetadataFilter filter) {
+    }
+
+    @Override
+    public void setStringArray(int tagType, String[] strings, MetadataFilter filter) {
+    }
+
+    @Override
+    public void setStringValueArray(int tagType, StringValue[] strings, MetadataFilter filter) {
+    }
+
+    @Override
+    public void setBoolean(int tagType, boolean value, MetadataFilter filter) {
+    }
+
+    @Override
+    public void setLong(int tagType, long value, MetadataFilter filter) {
+    }
+
+    @Override
+    public void setDate(int tagType, Date value, MetadataFilter filter) {
+    }
+
+    @Override
+    public void setRational(int tagType, Rational rational, MetadataFilter filter) {
+    }
+
+    @Override
+    public void setRationalArray(int tagType, Rational[] rationals, MetadataFilter filter) {
+    }
+
+    @Override
+    public void setByteArray(int tagType, byte[] bytes, MetadataFilter filter) {
+    }
+
+    @Override
+    public void setObject(int tagType, Object value, MetadataFilter filter) {
+    }
+
+    @Override
+    public void setObjectArray(int tagType, Object array, MetadataFilter filter) {
+    }
+}

--- a/Source/com/drew/metadata/filter/MetadataFilter.java
+++ b/Source/com/drew/metadata/filter/MetadataFilter.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2002-2016 Drew Noakes
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ * More information about this project is available at:
+ *
+ *    https://drewnoakes.com/code/exif/
+ *    https://github.com/drewnoakes/metadata-extractor
+ */
+package com.drew.metadata.filter;
+
+import com.drew.lang.annotations.NotNull;
+import com.drew.metadata.Directory;
+
+
+public interface MetadataFilter {
+
+    /**
+     * This method is invoked before every tag is written. Use it to filter
+     * which tags to keep and which to filter out.
+     *
+     * @param directory the {@link Directory} being written to.
+     * @param tagType the tag being written.
+     * @return {@code True} to include the tag or {@code false} to exclude it.
+     */
+    public boolean tagFilter(@NotNull Directory directory, int tagType);
+
+    /**
+     * This method is invoked before every {@link Directory} is added to the
+     * {@link Metadata} instance. Use it to filter which directories to keep
+     * and which to filter out.
+     *
+     * @param directory the {@link Class} of the directory to be added.
+     * @return {@code True} to include the {@link Directory} or {@code false}
+     *         to exclude it.
+     */
+    public boolean directoryFilter(@NotNull Class<? extends Directory> directory);
+
+}

--- a/Source/com/drew/metadata/gif/GifCommentDirectory.java
+++ b/Source/com/drew/metadata/gif/GifCommentDirectory.java
@@ -21,8 +21,10 @@
 package com.drew.metadata.gif;
 
 import com.drew.lang.annotations.NotNull;
+import com.drew.lang.annotations.Nullable;
 import com.drew.metadata.StringValue;
 import com.drew.metadata.Directory;
+import com.drew.metadata.filter.MetadataFilter;
 
 import java.util.HashMap;
 
@@ -45,8 +47,13 @@ public class GifCommentDirectory extends Directory
 
     public GifCommentDirectory(StringValue comment)
     {
+        this(comment, null);
+    }
+
+    public GifCommentDirectory(StringValue comment, @Nullable final MetadataFilter filter)
+    {
         this.setDescriptor(new GifCommentDescriptor(this));
-        setStringValue(TAG_COMMENT, comment);
+        setStringValue(TAG_COMMENT, comment, filter);
     }
 
     @Override

--- a/Source/com/drew/metadata/ico/IcoReader.java
+++ b/Source/com/drew/metadata/ico/IcoReader.java
@@ -22,7 +22,9 @@ package com.drew.metadata.ico;
 
 import com.drew.lang.SequentialReader;
 import com.drew.lang.annotations.NotNull;
+import com.drew.lang.annotations.Nullable;
 import com.drew.metadata.Metadata;
+import com.drew.metadata.filter.MetadataFilter;
 
 import java.io.IOException;
 
@@ -38,6 +40,14 @@ public class IcoReader
 {
     public void extract(@NotNull final SequentialReader reader, @NotNull final Metadata metadata)
     {
+        extract(reader, metadata, null);
+    }
+
+    public void extract(@NotNull final SequentialReader reader, @NotNull final Metadata metadata, @Nullable final MetadataFilter filter)
+    {
+        if (filter != null && !filter.directoryFilter(IcoDirectory.class))
+            return;
+
         reader.setMotorolaByteOrder(false);
 
         int type;
@@ -83,24 +93,24 @@ public class IcoReader
         for (int imageIndex = 0; imageIndex < imageCount; imageIndex++) {
             IcoDirectory directory = new IcoDirectory();
             try {
-                directory.setInt(IcoDirectory.TAG_IMAGE_TYPE, type);
+                directory.setInt(IcoDirectory.TAG_IMAGE_TYPE, type, filter);
 
-                directory.setInt(IcoDirectory.TAG_IMAGE_WIDTH, reader.getUInt8());
-                directory.setInt(IcoDirectory.TAG_IMAGE_HEIGHT, reader.getUInt8());
-                directory.setInt(IcoDirectory.TAG_COLOUR_PALETTE_SIZE, reader.getUInt8());
+                directory.setInt(IcoDirectory.TAG_IMAGE_WIDTH, reader.getUInt8(), filter);
+                directory.setInt(IcoDirectory.TAG_IMAGE_HEIGHT, reader.getUInt8(), filter);
+                directory.setInt(IcoDirectory.TAG_COLOUR_PALETTE_SIZE, reader.getUInt8(), filter);
                 // Ignore this byte (normally zero, though .NET's System.Drawing.Icon.Save method writes 255)
                 reader.getUInt8();
                 if (type == 1) {
                     // Icon
-                    directory.setInt(IcoDirectory.TAG_COLOUR_PLANES, reader.getUInt16());
-                    directory.setInt(IcoDirectory.TAG_BITS_PER_PIXEL, reader.getUInt16());
+                    directory.setInt(IcoDirectory.TAG_COLOUR_PLANES, reader.getUInt16(), filter);
+                    directory.setInt(IcoDirectory.TAG_BITS_PER_PIXEL, reader.getUInt16(), filter);
                 } else {
                     // Cursor
-                    directory.setInt(IcoDirectory.TAG_CURSOR_HOTSPOT_X, reader.getUInt16());
-                    directory.setInt(IcoDirectory.TAG_CURSOR_HOTSPOT_Y, reader.getUInt16());
+                    directory.setInt(IcoDirectory.TAG_CURSOR_HOTSPOT_X, reader.getUInt16(), filter);
+                    directory.setInt(IcoDirectory.TAG_CURSOR_HOTSPOT_Y, reader.getUInt16(), filter);
                 }
-                directory.setLong(IcoDirectory.TAG_IMAGE_SIZE_BYTES, reader.getUInt32());
-                directory.setLong(IcoDirectory.TAG_IMAGE_OFFSET_BYTES, reader.getUInt32());
+                directory.setLong(IcoDirectory.TAG_IMAGE_SIZE_BYTES, reader.getUInt32(), filter);
+                directory.setLong(IcoDirectory.TAG_IMAGE_OFFSET_BYTES, reader.getUInt32(), filter);
             } catch (IOException ex) {
                 directory.addError("Exception reading ICO file metadata: " + ex.getMessage());
             }

--- a/Source/com/drew/metadata/jfxx/JfxxReader.java
+++ b/Source/com/drew/metadata/jfxx/JfxxReader.java
@@ -25,8 +25,10 @@ import com.drew.imaging.jpeg.JpegSegmentType;
 import com.drew.lang.ByteArrayReader;
 import com.drew.lang.RandomAccessReader;
 import com.drew.lang.annotations.NotNull;
+import com.drew.lang.annotations.Nullable;
 import com.drew.metadata.Metadata;
 import com.drew.metadata.MetadataReader;
+import com.drew.metadata.filter.MetadataFilter;
 
 import java.io.IOException;
 import java.util.Collections;
@@ -53,10 +55,15 @@ public class JfxxReader implements JpegSegmentMetadataReader, MetadataReader
 
     public void readJpegSegments(@NotNull Iterable<byte[]> segments, @NotNull Metadata metadata, @NotNull JpegSegmentType segmentType)
     {
+        readJpegSegments(segments, metadata, segmentType, null);
+    }
+
+    public void readJpegSegments(@NotNull Iterable<byte[]> segments, @NotNull Metadata metadata, @NotNull JpegSegmentType segmentType, @Nullable final MetadataFilter filter)
+    {
         for (byte[] segmentBytes : segments) {
             // Skip segments not starting with the required header
             if (segmentBytes.length >= PREAMBLE.length() && PREAMBLE.equals(new String(segmentBytes, 0, PREAMBLE.length())))
-                extract(new ByteArrayReader(segmentBytes), metadata);
+                extract(new ByteArrayReader(segmentBytes), metadata, filter);
         }
     }
 
@@ -66,13 +73,25 @@ public class JfxxReader implements JpegSegmentMetadataReader, MetadataReader
      */
     public void extract(@NotNull final RandomAccessReader reader, @NotNull final Metadata metadata)
     {
+        extract(reader, metadata, null);
+    }
+
+    /**
+     * Performs the JFXX data extraction, adding found values to the specified
+     * instance of {@link Metadata}.
+     */
+    public void extract(@NotNull final RandomAccessReader reader, @NotNull final Metadata metadata, @Nullable final MetadataFilter filter)
+    {
+        if (filter != null && !filter.directoryFilter(JfxxDirectory.class))
+            return;
+
         JfxxDirectory directory = new JfxxDirectory();
         metadata.addDirectory(directory);
 
         try {
             // For JFXX, the tag number is also the offset into the segment
 
-            directory.setInt(JfxxDirectory.TAG_EXTENSION_CODE, reader.getUInt8(JfxxDirectory.TAG_EXTENSION_CODE));
+            directory.setInt(JfxxDirectory.TAG_EXTENSION_CODE, reader.getUInt8(JfxxDirectory.TAG_EXTENSION_CODE), filter);
         } catch (IOException me) {
             directory.addError(me.getMessage());
         }

--- a/Source/com/drew/metadata/jpeg/JpegCommentReader.java
+++ b/Source/com/drew/metadata/jpeg/JpegCommentReader.java
@@ -23,8 +23,10 @@ package com.drew.metadata.jpeg;
 import com.drew.imaging.jpeg.JpegSegmentMetadataReader;
 import com.drew.imaging.jpeg.JpegSegmentType;
 import com.drew.lang.annotations.NotNull;
+import com.drew.lang.annotations.Nullable;
 import com.drew.metadata.Metadata;
 import com.drew.metadata.StringValue;
+import com.drew.metadata.filter.MetadataFilter;
 
 import java.util.Collections;
 
@@ -44,12 +46,20 @@ public class JpegCommentReader implements JpegSegmentMetadataReader
 
     public void readJpegSegments(@NotNull Iterable<byte[]> segments, @NotNull Metadata metadata, @NotNull JpegSegmentType segmentType)
     {
+        readJpegSegments(segments, metadata, segmentType, null);
+    }
+
+    public void readJpegSegments(@NotNull Iterable<byte[]> segments, @NotNull Metadata metadata, @NotNull JpegSegmentType segmentType, @Nullable final MetadataFilter filter)
+    {
+        if (filter != null && !filter.directoryFilter(JpegCommentDirectory.class))
+            return;
+
         for (byte[] segmentBytes : segments) {
             JpegCommentDirectory directory = new JpegCommentDirectory();
             metadata.addDirectory(directory);
 
             // The entire contents of the directory are the comment
-            directory.setStringValue(JpegCommentDirectory.TAG_COMMENT, new StringValue(segmentBytes, null));
+            directory.setStringValue(JpegCommentDirectory.TAG_COMMENT, new StringValue(segmentBytes, null), filter);
         }
     }
 }

--- a/Source/com/drew/metadata/pcx/PcxReader.java
+++ b/Source/com/drew/metadata/pcx/PcxReader.java
@@ -23,7 +23,9 @@ package com.drew.metadata.pcx;
 import com.drew.imaging.ImageProcessingException;
 import com.drew.lang.SequentialReader;
 import com.drew.lang.annotations.NotNull;
+import com.drew.lang.annotations.Nullable;
 import com.drew.metadata.Metadata;
+import com.drew.metadata.filter.MetadataFilter;
 
 /**
  * Reads PCX image file metadata.
@@ -40,6 +42,14 @@ public class PcxReader
 {
     public void extract(@NotNull final SequentialReader reader, @NotNull final Metadata metadata)
     {
+        extract(reader, metadata, null);
+    }
+
+    public void extract(@NotNull final SequentialReader reader, @NotNull final Metadata metadata, @Nullable final MetadataFilter filter)
+    {
+        if (filter != null && !filter.directoryFilter(PcxDirectory.class))
+            return;
+
         reader.setMotorolaByteOrder(false);
 
         PcxDirectory directory = new PcxDirectory();
@@ -50,35 +60,35 @@ public class PcxReader
             if (identifier != 0x0A)
                 throw new ImageProcessingException("Invalid PCX identifier byte");
 
-            directory.setInt(PcxDirectory.TAG_VERSION, reader.getInt8());
+            directory.setInt(PcxDirectory.TAG_VERSION, reader.getInt8(), filter);
 
             byte encoding = reader.getInt8();
             if (encoding != 0x01)
                 throw new ImageProcessingException("Invalid PCX encoding byte");
 
-            directory.setInt(PcxDirectory.TAG_BITS_PER_PIXEL, reader.getUInt8());
-            directory.setInt(PcxDirectory.TAG_XMIN,           reader.getUInt16());
-            directory.setInt(PcxDirectory.TAG_YMIN,           reader.getUInt16());
-            directory.setInt(PcxDirectory.TAG_XMAX,           reader.getUInt16());
-            directory.setInt(PcxDirectory.TAG_YMAX,           reader.getUInt16());
-            directory.setInt(PcxDirectory.TAG_HORIZONTAL_DPI, reader.getUInt16());
-            directory.setInt(PcxDirectory.TAG_VERTICAL_DPI,   reader.getUInt16());
-            directory.setByteArray(PcxDirectory.TAG_PALETTE,  reader.getBytes(48));
+            directory.setInt(PcxDirectory.TAG_BITS_PER_PIXEL, reader.getUInt8(), filter);
+            directory.setInt(PcxDirectory.TAG_XMIN,           reader.getUInt16(), filter);
+            directory.setInt(PcxDirectory.TAG_YMIN,           reader.getUInt16(), filter);
+            directory.setInt(PcxDirectory.TAG_XMAX,           reader.getUInt16(), filter);
+            directory.setInt(PcxDirectory.TAG_YMAX,           reader.getUInt16(), filter);
+            directory.setInt(PcxDirectory.TAG_HORIZONTAL_DPI, reader.getUInt16(), filter);
+            directory.setInt(PcxDirectory.TAG_VERTICAL_DPI,   reader.getUInt16(), filter);
+            directory.setByteArray(PcxDirectory.TAG_PALETTE,  reader.getBytes(48), filter);
             reader.skip(1);
-            directory.setInt(PcxDirectory.TAG_COLOR_PLANES,   reader.getUInt8());
-            directory.setInt(PcxDirectory.TAG_BYTES_PER_LINE, reader.getUInt16());
+            directory.setInt(PcxDirectory.TAG_COLOR_PLANES,   reader.getUInt8(), filter);
+            directory.setInt(PcxDirectory.TAG_BYTES_PER_LINE, reader.getUInt16(), filter);
 
             int paletteType = reader.getUInt16();
             if (paletteType != 0)
-                directory.setInt(PcxDirectory.TAG_PALETTE_TYPE, paletteType);
+                directory.setInt(PcxDirectory.TAG_PALETTE_TYPE, paletteType, filter);
 
             int hScrSize = reader.getUInt16();
             if (hScrSize != 0)
-                directory.setInt(PcxDirectory.TAG_HSCR_SIZE, hScrSize);
+                directory.setInt(PcxDirectory.TAG_HSCR_SIZE, hScrSize, filter);
 
             int vScrSize = reader.getUInt16();
             if (vScrSize != 0)
-                directory.setInt(PcxDirectory.TAG_VSCR_SIZE, vScrSize);
+                directory.setInt(PcxDirectory.TAG_VSCR_SIZE, vScrSize, filter);
 
         } catch (Exception ex) {
             directory.addError("Exception reading PCX file metadata: " + ex.getMessage());

--- a/Source/com/drew/metadata/tiff/DirectoryTiffHandler.java
+++ b/Source/com/drew/metadata/tiff/DirectoryTiffHandler.java
@@ -23,9 +23,12 @@ package com.drew.metadata.tiff;
 import com.drew.imaging.tiff.TiffHandler;
 import com.drew.lang.Rational;
 import com.drew.lang.annotations.NotNull;
+import com.drew.lang.annotations.Nullable;
 import com.drew.metadata.Directory;
 import com.drew.metadata.Metadata;
 import com.drew.metadata.StringValue;
+import com.drew.metadata.filter.FilteredDirectory;
+import com.drew.metadata.filter.MetadataFilter;
 
 import java.util.Stack;
 
@@ -46,21 +49,35 @@ public abstract class DirectoryTiffHandler implements TiffHandler
         _metadata = metadata;
     }
 
+    protected boolean isCurrentInstanceOf(@Nullable Class<? extends Directory> directoryClass) {
+        if (directoryClass == null)
+            return false;
+        if (_currentDirectory instanceof FilteredDirectory) {
+            return (((FilteredDirectory) _currentDirectory).getSubstituteFor().isAssignableFrom(directoryClass));
+        }
+        return (directoryClass.isInstance(_currentDirectory));
+    }
+
     public void endingIFD()
     {
         _currentDirectory = _directoryStack.empty() ? null : _directoryStack.pop();
     }
 
-    protected void pushDirectory(@NotNull Class<? extends Directory> directoryClass)
+    protected void pushDirectory(@NotNull Class<? extends Directory> directoryClass, @Nullable final MetadataFilter filter)
     {
+        boolean filtered = filter != null && !filter.directoryFilter(directoryClass);
         Directory newDirectory = null;
 
-        try {
-            newDirectory = directoryClass.newInstance();
-        } catch (InstantiationException e) {
-            throw new RuntimeException(e);
-        } catch (IllegalAccessException e) {
-            throw new RuntimeException(e);
+        if (filtered) {
+            newDirectory = new FilteredDirectory(directoryClass);
+        } else {
+            try {
+                newDirectory = directoryClass.newInstance();
+            } catch (InstantiationException e) {
+                throw new RuntimeException(e);
+            } catch (IllegalAccessException e) {
+                throw new RuntimeException(e);
+            }
         }
 
         if (newDirectory != null)
@@ -69,10 +86,11 @@ public abstract class DirectoryTiffHandler implements TiffHandler
             if (_currentDirectory != null)
             {
                 _directoryStack.push(_currentDirectory);
-                newDirectory.setParent(_currentDirectory);
+                newDirectory.setParent(_currentDirectory instanceof FilteredDirectory ? _currentDirectory.getParent() : _currentDirectory);
             }
             _currentDirectory = newDirectory;
-            _metadata.addDirectory(_currentDirectory);
+            if (!filtered)
+                _metadata.addDirectory(_currentDirectory);
         }
     }
 
@@ -88,110 +106,219 @@ public abstract class DirectoryTiffHandler implements TiffHandler
 
     public void setByteArray(int tagId, @NotNull byte[] bytes)
     {
-        _currentDirectory.setByteArray(tagId, bytes);
+        _currentDirectory.setByteArray(tagId, bytes, null);
+    }
+
+    public void setByteArray(int tagId, @NotNull byte[] bytes, @Nullable final MetadataFilter filter)
+    {
+        _currentDirectory.setByteArray(tagId, bytes, filter);
     }
 
     public void setString(int tagId, @NotNull StringValue string)
     {
-        _currentDirectory.setStringValue(tagId, string);
+        _currentDirectory.setStringValue(tagId, string, null);
+    }
+
+    public void setString(int tagId, @NotNull StringValue string, @Nullable final MetadataFilter filter)
+    {
+        _currentDirectory.setStringValue(tagId, string, filter);
     }
 
     public void setRational(int tagId, @NotNull Rational rational)
     {
-        _currentDirectory.setRational(tagId, rational);
+        _currentDirectory.setRational(tagId, rational, null);
+    }
+
+    public void setRational(int tagId, @NotNull Rational rational, @Nullable final MetadataFilter filter)
+    {
+        _currentDirectory.setRational(tagId, rational, filter);
     }
 
     public void setRationalArray(int tagId, @NotNull Rational[] array)
     {
-        _currentDirectory.setRationalArray(tagId, array);
+        _currentDirectory.setRationalArray(tagId, array, null);
+    }
+
+    public void setRationalArray(int tagId, @NotNull Rational[] array, @Nullable final MetadataFilter filter)
+    {
+        _currentDirectory.setRationalArray(tagId, array, filter);
     }
 
     public void setFloat(int tagId, float float32)
     {
-        _currentDirectory.setFloat(tagId, float32);
+        _currentDirectory.setFloat(tagId, float32, null);
+    }
+
+    public void setFloat(int tagId, float float32, @Nullable final MetadataFilter filter)
+    {
+        _currentDirectory.setFloat(tagId, float32, filter);
     }
 
     public void setFloatArray(int tagId, @NotNull float[] array)
     {
-        _currentDirectory.setFloatArray(tagId, array);
+        _currentDirectory.setFloatArray(tagId, array, null);
+    }
+
+    public void setFloatArray(int tagId, @NotNull float[] array, @Nullable final MetadataFilter filter)
+    {
+        _currentDirectory.setFloatArray(tagId, array, filter);
     }
 
     public void setDouble(int tagId, double double64)
     {
-        _currentDirectory.setDouble(tagId, double64);
+        _currentDirectory.setDouble(tagId, double64, null);
+    }
+
+    public void setDouble(int tagId, double double64, @Nullable final MetadataFilter filter)
+    {
+        _currentDirectory.setDouble(tagId, double64, filter);
     }
 
     public void setDoubleArray(int tagId, @NotNull double[] array)
     {
-        _currentDirectory.setDoubleArray(tagId, array);
+        _currentDirectory.setDoubleArray(tagId, array, null);
+    }
+
+    public void setDoubleArray(int tagId, @NotNull double[] array, @Nullable final MetadataFilter filter)
+    {
+        _currentDirectory.setDoubleArray(tagId, array, filter);
     }
 
     public void setInt8s(int tagId, byte int8s)
     {
         // NOTE Directory stores all integral types as int32s, except for int32u and long
-        _currentDirectory.setInt(tagId, int8s);
+        _currentDirectory.setInt(tagId, int8s, null);
+    }
+
+    public void setInt8s(int tagId, byte int8s, @Nullable final MetadataFilter filter)
+    {
+        // NOTE Directory stores all integral types as int32s, except for int32u and long
+        _currentDirectory.setInt(tagId, int8s, filter);
     }
 
     public void setInt8sArray(int tagId, @NotNull byte[] array)
     {
         // NOTE Directory stores all integral types as int32s, except for int32u and long
-        _currentDirectory.setByteArray(tagId, array);
+        _currentDirectory.setByteArray(tagId, array, null);
+    }
+
+    public void setInt8sArray(int tagId, @NotNull byte[] array, @Nullable final MetadataFilter filter)
+    {
+        // NOTE Directory stores all integral types as int32s, except for int32u and long
+        _currentDirectory.setByteArray(tagId, array, filter);
     }
 
     public void setInt8u(int tagId, short int8u)
     {
         // NOTE Directory stores all integral types as int32s, except for int32u and long
-        _currentDirectory.setInt(tagId, int8u);
+        _currentDirectory.setInt(tagId, int8u, null);
+    }
+
+    public void setInt8u(int tagId, short int8u, @Nullable final MetadataFilter filter)
+    {
+        // NOTE Directory stores all integral types as int32s, except for int32u and long
+        _currentDirectory.setInt(tagId, int8u, filter);
     }
 
     public void setInt8uArray(int tagId, @NotNull short[] array)
     {
         // TODO create and use a proper setter for short[]
-        _currentDirectory.setObjectArray(tagId, array);
+        _currentDirectory.setObjectArray(tagId, array, null);
+    }
+
+    public void setInt8uArray(int tagId, @NotNull short[] array, @Nullable final MetadataFilter filter)
+    {
+        // TODO create and use a proper setter for short[]
+        _currentDirectory.setObjectArray(tagId, array, filter);
     }
 
     public void setInt16s(int tagId, int int16s)
     {
         // TODO create and use a proper setter for int16u?
-        _currentDirectory.setInt(tagId, int16s);
+        _currentDirectory.setInt(tagId, int16s, null);
+    }
+
+    public void setInt16s(int tagId, int int16s, @Nullable final MetadataFilter filter)
+    {
+        // TODO create and use a proper setter for int16u?
+        _currentDirectory.setInt(tagId, int16s, filter);
     }
 
     public void setInt16sArray(int tagId, @NotNull short[] array)
     {
         // TODO create and use a proper setter for short[]
-        _currentDirectory.setObjectArray(tagId, array);
+        _currentDirectory.setObjectArray(tagId, array, null);
+    }
+
+    public void setInt16sArray(int tagId, @NotNull short[] array, @Nullable final MetadataFilter filter)
+    {
+        // TODO create and use a proper setter for short[]
+        _currentDirectory.setObjectArray(tagId, array, filter);
     }
 
     public void setInt16u(int tagId, int int16u)
     {
         // TODO create and use a proper setter for
-        _currentDirectory.setInt(tagId, int16u);
+        _currentDirectory.setInt(tagId, int16u, null);
+    }
+
+    public void setInt16u(int tagId, int int16u, @Nullable final MetadataFilter filter)
+    {
+        // TODO create and use a proper setter for
+        _currentDirectory.setInt(tagId, int16u, filter);
     }
 
     public void setInt16uArray(int tagId, @NotNull int[] array)
     {
         // TODO create and use a proper setter for short[]
-        _currentDirectory.setObjectArray(tagId, array);
+        _currentDirectory.setObjectArray(tagId, array, null);
+    }
+
+    public void setInt16uArray(int tagId, @NotNull int[] array, @Nullable final MetadataFilter filter)
+    {
+        // TODO create and use a proper setter for short[]
+        _currentDirectory.setObjectArray(tagId, array, filter);
     }
 
     public void setInt32s(int tagId, int int32s)
     {
-        _currentDirectory.setInt(tagId, int32s);
+        _currentDirectory.setInt(tagId, int32s, null);
+    }
+
+    public void setInt32s(int tagId, int int32s, @Nullable final MetadataFilter filter)
+    {
+        _currentDirectory.setInt(tagId, int32s, filter);
     }
 
     public void setInt32sArray(int tagId, @NotNull int[] array)
     {
-        _currentDirectory.setIntArray(tagId, array);
+        _currentDirectory.setIntArray(tagId, array, null);
+    }
+
+    public void setInt32sArray(int tagId, @NotNull int[] array, @Nullable final MetadataFilter filter)
+    {
+        _currentDirectory.setIntArray(tagId, array, filter);
     }
 
     public void setInt32u(int tagId, long int32u)
     {
-        _currentDirectory.setLong(tagId, int32u);
+        _currentDirectory.setLong(tagId, int32u, null);
+    }
+
+    public void setInt32u(int tagId, long int32u, @Nullable final MetadataFilter filter)
+    {
+        _currentDirectory.setLong(tagId, int32u, filter);
     }
 
     public void setInt32uArray(int tagId, @NotNull long[] array)
     {
         // TODO create and use a proper setter for short[]
-        _currentDirectory.setObjectArray(tagId, array);
+        _currentDirectory.setObjectArray(tagId, array, null);
+    }
+
+    public void setInt32uArray(int tagId, @NotNull long[] array, @Nullable final MetadataFilter filter)
+    {
+        // TODO create and use a proper setter for short[]
+        _currentDirectory.setObjectArray(tagId, array, filter);
     }
 }

--- a/Source/com/drew/metadata/xmp/XmpDirectory.java
+++ b/Source/com/drew/metadata/xmp/XmpDirectory.java
@@ -31,6 +31,7 @@ import com.drew.lang.annotations.NotNull;
 import com.drew.lang.annotations.Nullable;
 import com.drew.metadata.Directory;
 import com.drew.metadata.Schema;
+import com.drew.metadata.filter.MetadataFilter;
 
 import java.util.*;
 
@@ -304,6 +305,11 @@ public class XmpDirectory extends Directory
 
     public void setXMPMeta(@NotNull XMPMeta xmpMeta)
     {
+        setXMPMeta(xmpMeta, null);
+    }
+
+    public void setXMPMeta(@NotNull XMPMeta xmpMeta, @Nullable final MetadataFilter filter)
+    {
         _xmpMeta = xmpMeta;
 
         try {
@@ -315,7 +321,7 @@ public class XmpDirectory extends Directory
                     valueCount++;
                 }
             }
-            setInt(TAG_XMP_VALUE_COUNT, valueCount);
+            setInt(TAG_XMP_VALUE_COUNT, valueCount, filter);
         } catch (XMPException ignored) {
         }
     }
@@ -339,7 +345,12 @@ public class XmpDirectory extends Directory
 
     public void updateInt(int tagType, int value)
     {
-        super.setInt(tagType, value);
+        updateInt(tagType, value, null);
+    }
+
+    public void updateInt(int tagType, int value, @Nullable final MetadataFilter filter)
+    {
+        super.setInt(tagType, value, filter);
         try
         {
             getXMPMeta().setPropertyInteger(_tagSchemaMap.get(tagType), _tagPropNameMap.get(tagType), value);
@@ -352,7 +363,12 @@ public class XmpDirectory extends Directory
 
     public void updateIntArray(int tagType, int[] ints)
     {
-        super.setIntArray(tagType, ints);
+        updateIntArray(tagType, ints, null);
+    }
+
+    public void updateIntArray(int tagType, int[] ints, @Nullable final MetadataFilter filter)
+    {
+        super.setIntArray(tagType, ints, filter);
         try
         {
             String schemaNS = _tagSchemaMap.get(tagType);
@@ -374,7 +390,12 @@ public class XmpDirectory extends Directory
 
     public void updateFloat(int tagType, float value)
     {
-        super.setFloat(tagType, value);
+        updateFloat(tagType, value, null);
+    }
+
+    public void updateFloat(int tagType, float value, @Nullable final MetadataFilter filter)
+    {
+        super.setFloat(tagType, value, filter);
         try
         {
             getXMPMeta().setPropertyDouble(_tagSchemaMap.get(tagType), _tagPropNameMap.get(tagType), value);
@@ -387,7 +408,12 @@ public class XmpDirectory extends Directory
 
     public void updateFloatArray(int tagType, float[] floats)
     {
-        super.setFloatArray(tagType, floats);
+        updateFloatArray(tagType, floats, null);
+    }
+
+    public void updateFloatArray(int tagType, float[] floats, @Nullable final MetadataFilter filter)
+    {
+        super.setFloatArray(tagType, floats, filter);
         try
         {
             String schemaNS = _tagSchemaMap.get(tagType);
@@ -409,7 +435,12 @@ public class XmpDirectory extends Directory
 
     public void updateDouble(int tagType, double value)
     {
-        super.setDouble(tagType, value);
+        updateDouble(tagType, value, null);
+    }
+
+    public void updateDouble(int tagType, double value, @Nullable final MetadataFilter filter)
+    {
+        super.setDouble(tagType, value, filter);
         try
         {
             getXMPMeta().setPropertyDouble(_tagSchemaMap.get(tagType), _tagPropNameMap.get(tagType), value);
@@ -422,7 +453,12 @@ public class XmpDirectory extends Directory
 
     public void updateDoubleArray(int tagType, double[] doubles)
     {
-        super.setDoubleArray(tagType, doubles);
+        updateDoubleArray(tagType, doubles, null);
+    }
+
+    public void updateDoubleArray(int tagType, double[] doubles, @Nullable final MetadataFilter filter)
+    {
+        super.setDoubleArray(tagType, doubles, filter);
         try
         {
             String schemaNS = _tagSchemaMap.get(tagType);
@@ -444,7 +480,12 @@ public class XmpDirectory extends Directory
 
     public void updateString(int tagType, String value)
     {
-        super.setString(tagType, value);
+        updateString(tagType, value, null);
+    }
+
+    public void updateString(int tagType, String value, @Nullable final MetadataFilter filter)
+    {
+        super.setString(tagType, value, filter);
         try
         {
             getXMPMeta().setProperty(_tagSchemaMap.get(tagType), _tagPropNameMap.get(tagType), value);
@@ -462,7 +503,12 @@ public class XmpDirectory extends Directory
 
     public void updateStringArray(int tagType, String[] strings)
     {
-        super.setStringArray(tagType, strings);
+        updateStringArray(tagType, strings, null);
+    }
+
+    public void updateStringArray(int tagType, String[] strings, @Nullable final MetadataFilter filter)
+    {
+        super.setStringArray(tagType, strings, filter);
         try
         {
             String schemaNS = _tagSchemaMap.get(tagType);
@@ -484,7 +530,12 @@ public class XmpDirectory extends Directory
 
     public void updateBoolean(int tagType, boolean value)
     {
-        super.setBoolean(tagType, value);
+        updateBoolean(tagType, value, null);
+    }
+
+    public void updateBoolean(int tagType, boolean value, @Nullable final MetadataFilter filter)
+    {
+        super.setBoolean(tagType, value, filter);
         try
         {
             getXMPMeta().setPropertyBoolean(_tagSchemaMap.get(tagType), _tagPropNameMap.get(tagType), value);
@@ -497,7 +548,12 @@ public class XmpDirectory extends Directory
 
     public void updateLong(int tagType, long value)
     {
-        super.setLong(tagType, value);
+        updateLong(tagType, value, null);
+    }
+
+    public void updateLong(int tagType, long value, @Nullable final MetadataFilter filter)
+    {
+        super.setLong(tagType, value, filter);
         try
         {
             getXMPMeta().setPropertyLong(_tagSchemaMap.get(tagType), _tagPropNameMap.get(tagType), value);
@@ -510,12 +566,22 @@ public class XmpDirectory extends Directory
 
     public void updateDate(int tagType, Date value)
     {
-        updateDate(tagType, value, TimeZone.getDefault());
+        updateDate(tagType, value, TimeZone.getDefault(), null);
+    }
+
+    public void updateDate(int tagType, Date value, @Nullable final MetadataFilter filter)
+    {
+        updateDate(tagType, value, TimeZone.getDefault(), filter);
     }
 
     public void updateDate(int tagType, Date value, TimeZone timeZone)
     {
-        super.setDate(tagType, value);
+        updateDate(tagType, value, timeZone, null);
+    }
+
+    public void updateDate(int tagType, Date value, TimeZone timeZone, @Nullable final MetadataFilter filter)
+    {
+        super.setDate(tagType, value, filter);
         XMPDateTime date = new XMPDateTimeImpl(value, timeZone);
         try
         {

--- a/Tests/com/drew/imaging/jpeg/JpegMetadataReaderTest.java
+++ b/Tests/com/drew/imaging/jpeg/JpegMetadataReaderTest.java
@@ -22,7 +22,11 @@ package com.drew.imaging.jpeg;
 
 import com.drew.metadata.Directory;
 import com.drew.metadata.Metadata;
+import com.drew.metadata.MetadataException;
+import com.drew.metadata.exif.ExifIFD0Directory;
 import com.drew.metadata.exif.ExifSubIFDDirectory;
+import com.drew.metadata.filter.MetadataFilter;
+import com.drew.metadata.jfif.JfifDirectory;
 import com.drew.metadata.xmp.XmpDirectory;
 import org.junit.Test;
 
@@ -31,6 +35,8 @@ import java.io.FileInputStream;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
 
 /**
  * @author Drew Noakes https://drewnoakes.com
@@ -41,12 +47,36 @@ public class JpegMetadataReaderTest
     public void testExtractMetadata() throws Exception
     {
         validate(JpegMetadataReader.readMetadata(new File("Tests/Data/withExif.jpg")));
+        validateFiltered(JpegMetadataReader.readMetadata(new File("Tests/Data/withExif.jpg"), new MetadataFilter() {
+
+            @Override
+            public boolean tagFilter(Directory directory, int tagType) {
+                return directory instanceof JfifDirectory && tagType != JfifDirectory.TAG_UNITS;
+            }
+
+            @Override
+            public boolean directoryFilter(Class<? extends Directory> directory) {
+                return directory == JfifDirectory.class || directory == ExifIFD0Directory.class;
+            }
+        }));
     }
 
     @Test
     public void testExtractMetadataUsingInputStream() throws Exception
     {
         validate(JpegMetadataReader.readMetadata(new FileInputStream((new File("Tests/Data/withExif.jpg")))));
+        validateFiltered(JpegMetadataReader.readMetadata(new FileInputStream((new File("Tests/Data/withExif.jpg"))), new MetadataFilter() {
+
+            @Override
+            public boolean tagFilter(Directory directory, int tagType) {
+                return directory instanceof JfifDirectory && tagType != JfifDirectory.TAG_UNITS;
+            }
+
+            @Override
+            public boolean directoryFilter(Class<? extends Directory> directory) {
+                return directory == JfifDirectory.class || directory == ExifIFD0Directory.class;
+            }
+        }));
     }
 
     @Test
@@ -62,5 +92,17 @@ public class JpegMetadataReaderTest
         Directory directory = metadata.getFirstDirectoryOfType(ExifSubIFDDirectory.class);
         assertNotNull(directory);
         assertEquals("80", directory.getString(ExifSubIFDDirectory.TAG_ISO_EQUIVALENT));
+    }
+
+    private void validateFiltered(Metadata metadata) throws MetadataException
+    {
+        assertTrue(metadata.getDirectoriesOfType(ExifSubIFDDirectory.class).isEmpty());
+        Directory directory = metadata.getFirstDirectoryOfType(JfifDirectory.class);
+        assertNotNull(directory);
+        assertEquals(0x0102, ((JfifDirectory) directory).getVersion());
+        assertFalse(directory.containsTag(JfifDirectory.TAG_UNITS));
+        directory = metadata.getFirstDirectoryOfType(ExifIFD0Directory.class);
+        assertNotNull(directory);
+        assertEquals(0, directory.getTagCount());
     }
 }

--- a/Tests/com/drew/metadata/exif/ExifDirectoryTest.java
+++ b/Tests/com/drew/metadata/exif/ExifDirectoryTest.java
@@ -66,7 +66,7 @@ public class ExifDirectoryTest
     @Test
     public void testDateTime() throws JpegProcessingException, IOException, MetadataException
     {
-        Metadata metadata = ExifReaderTest.processBytes("Tests/Data/nikonMakernoteType2a.jpg.app1");
+        Metadata metadata = ExifReaderTest.processBytes(null, "Tests/Data/nikonMakernoteType2a.jpg.app1");
 
         ExifIFD0Directory exifIFD0Directory = metadata.getFirstDirectoryOfType(ExifIFD0Directory.class);
         ExifSubIFDDirectory exifSubIFDDirectory = metadata.getFirstDirectoryOfType(ExifSubIFDDirectory.class);
@@ -146,7 +146,7 @@ public class ExifDirectoryTest
     @Test
     public void testResolution() throws JpegProcessingException, IOException, MetadataException
     {
-        Metadata metadata = ExifReaderTest.processBytes("Tests/Data/withUncompressedRGBThumbnail.jpg.app1");
+        Metadata metadata = ExifReaderTest.processBytes(null, "Tests/Data/withUncompressedRGBThumbnail.jpg.app1");
 
         ExifThumbnailDirectory thumbnailDirectory = metadata.getFirstDirectoryOfType(ExifThumbnailDirectory.class);
         assertNotNull(thumbnailDirectory);
@@ -160,7 +160,7 @@ public class ExifDirectoryTest
     @Test
     public void testGeoLocation() throws IOException, MetadataException
     {
-        Metadata metadata = ExifReaderTest.processBytes("Tests/Data/withExifAndIptc.jpg.app1.0");
+        Metadata metadata = ExifReaderTest.processBytes(null, "Tests/Data/withExifAndIptc.jpg.app1.0");
 
         GpsDirectory gpsDirectory = metadata.getFirstDirectoryOfType(GpsDirectory.class);
         assertNotNull(gpsDirectory);
@@ -172,7 +172,7 @@ public class ExifDirectoryTest
     @Test
     public void testGpsDate() throws IOException, MetadataException
     {
-        Metadata metadata = ExifReaderTest.processBytes("Tests/Data/withPanasonicFaces.jpg.app1");
+        Metadata metadata = ExifReaderTest.processBytes(null, "Tests/Data/withPanasonicFaces.jpg.app1");
 
         GpsDirectory gpsDirectory = metadata.getFirstDirectoryOfType(GpsDirectory.class);
         assertNotNull(gpsDirectory);

--- a/Tests/com/drew/metadata/exif/NikonType1MakernoteTest.java
+++ b/Tests/com/drew/metadata/exif/NikonType1MakernoteTest.java
@@ -53,7 +53,7 @@ public class NikonType1MakernoteTest
     @Before
     public void setUp() throws Exception
     {
-        Metadata metadata = ExifReaderTest.processBytes("Tests/Data/nikonMakernoteType1.jpg.app1");
+        Metadata metadata = ExifReaderTest.processBytes(null, "Tests/Data/nikonMakernoteType1.jpg.app1");
 
         _nikonDirectory = metadata.getFirstDirectoryOfType(NikonType1MakernoteDirectory.class);
         _exifSubIFDDirectory = metadata.getFirstDirectoryOfType(ExifSubIFDDirectory.class);

--- a/Tests/com/drew/metadata/exif/NikonType2MakernoteTest2.java
+++ b/Tests/com/drew/metadata/exif/NikonType2MakernoteTest2.java
@@ -45,7 +45,7 @@ public class NikonType2MakernoteTest2
     @Before
     public void setUp() throws Exception
     {
-        _metadata = ExifReaderTest.processBytes("Tests/Data/nikonMakernoteType2b.jpg.app1");
+        _metadata = ExifReaderTest.processBytes(null, "Tests/Data/nikonMakernoteType2b.jpg.app1");
 
         _nikonDirectory = _metadata.getFirstDirectoryOfType(NikonType2MakernoteDirectory.class);
         _exifIFD0Directory = _metadata.getFirstDirectoryOfType(ExifIFD0Directory.class);

--- a/Tests/com/drew/metadata/gif/GifReaderTest.java
+++ b/Tests/com/drew/metadata/gif/GifReaderTest.java
@@ -23,7 +23,11 @@ package com.drew.metadata.gif;
 
 import com.drew.lang.StreamReader;
 import com.drew.lang.annotations.NotNull;
+import com.drew.lang.annotations.Nullable;
+import com.drew.metadata.Directory;
 import com.drew.metadata.Metadata;
+import com.drew.metadata.filter.MetadataFilter;
+import com.drew.metadata.xmp.XmpDirectory;
 import org.junit.Test;
 
 import java.io.FileInputStream;
@@ -37,23 +41,27 @@ import static org.junit.Assert.*;
 public class GifReaderTest
 {
     @NotNull
-    public static GifHeaderDirectory processBytes(@NotNull String file) throws Exception
+    public static Metadata processBytes(@NotNull String file, @Nullable MetadataFilter filter) throws Exception
     {
         Metadata metadata = new Metadata();
         InputStream stream = new FileInputStream(file);
-        new GifReader().extract(new StreamReader(stream), metadata);
+        if (filter == null) {
+            new GifReader().extract(new StreamReader(stream), metadata);
+        } else {
+            new GifReader().extract(new StreamReader(stream), metadata, filter);
+        }
         stream.close();
 
-        GifHeaderDirectory directory = metadata.getFirstDirectoryOfType(GifHeaderDirectory.class);
-        assertNotNull(directory);
-        return directory;
+        return metadata;
     }
 
     @Test
     public void testMsPaintGif() throws Exception
     {
-        GifHeaderDirectory directory = processBytes("Tests/Data/mspaint-10x10.gif");
+        Metadata metadata = processBytes("Tests/Data/mspaint-10x10.gif", null);
+        GifHeaderDirectory directory = metadata.getFirstDirectoryOfType(GifHeaderDirectory.class);
 
+        assertNotNull(directory);
         assertFalse(directory.hasErrors());
 
         assertEquals("89a", directory.getString(GifHeaderDirectory.TAG_GIF_FORMAT_VERSION));
@@ -69,8 +77,10 @@ public class GifReaderTest
     @Test
     public void testPhotoshopGif() throws Exception
     {
-        GifHeaderDirectory directory = processBytes("Tests/Data/photoshop-8x12-32colors-alpha.gif");
+        Metadata metadata = processBytes("Tests/Data/photoshop-8x12-32colors-alpha.gif", null);
+        GifHeaderDirectory directory = metadata.getFirstDirectoryOfType(GifHeaderDirectory.class);
 
+        assertNotNull(directory);
         assertFalse(directory.hasErrors());
 
         assertEquals("89a", directory.getString(GifHeaderDirectory.TAG_GIF_FORMAT_VERSION));
@@ -82,4 +92,80 @@ public class GifReaderTest
         assertTrue(directory.getBoolean(GifHeaderDirectory.TAG_HAS_GLOBAL_COLOR_TABLE));
         assertEquals(8, directory.getInt(GifHeaderDirectory.TAG_BACKGROUND_COLOR_INDEX));
     }
+
+    @Test
+    public void testExtractFilteredMetadata() throws Exception {
+        Metadata metadata = processBytes("Tests/Data/photoshop-8x12-32colors-alpha.gif", new MetadataFilter() {
+
+            @Override
+            public boolean tagFilter(Directory directory, int tagType) {
+                return
+                    directory instanceof GifHeaderDirectory && tagType != GifHeaderDirectory.TAG_GIF_FORMAT_VERSION ||
+                    directory instanceof XmpDirectory && tagType != XmpDirectory.TAG_XMP_VALUE_COUNT ||
+                    directory instanceof GifImageDirectory && tagType == GifImageDirectory.TAG_HEIGHT;
+            }
+
+            @Override
+            public boolean directoryFilter(Class<? extends Directory> directory) {
+                return directory != GifControlDirectory.class;
+            }
+        });
+
+        assertEquals(3, metadata.getDirectoryCount());
+        Directory directory = metadata.getFirstDirectoryOfType(GifHeaderDirectory.class);
+        assertNotNull(directory);
+        assertEquals(7, directory.getTagCount());
+        assertFalse(directory.containsTag(GifHeaderDirectory.TAG_GIF_FORMAT_VERSION));
+        assertTrue(directory.containsTag(GifHeaderDirectory.TAG_BACKGROUND_COLOR_INDEX));
+        assertEquals(8, directory.getInt(GifHeaderDirectory.TAG_BACKGROUND_COLOR_INDEX));
+
+        directory = metadata.getFirstDirectoryOfType(XmpDirectory.class);
+        assertNotNull(directory);
+        assertEquals(1, directory.getTagCount());
+        assertFalse(directory.containsTag(XmpDirectory.TAG_XMP_VALUE_COUNT));
+        assertTrue(directory.containsTag(XmpDirectory.TAG_CREATOR_TOOL));
+        assertEquals("Adobe Photoshop CS6 (Windows)", directory.getString(XmpDirectory.TAG_CREATOR_TOOL));
+
+        directory = metadata.getFirstDirectoryOfType(GifImageDirectory.class);
+        assertNotNull(directory);
+        assertEquals(1, directory.getTagCount());
+        assertTrue(directory.containsTag(GifImageDirectory.TAG_HEIGHT));
+        assertEquals(12, directory.getInt(GifImageDirectory.TAG_HEIGHT));
+
+        assertNull(metadata.getFirstDirectoryOfType(GifControlDirectory.class));
+
+        metadata = processBytes("Tests/Data/photoshop-8x12-32colors-alpha.gif", new MetadataFilter() {
+
+            @Override
+            public boolean tagFilter(Directory directory, int tagType) {
+                return false;
+            }
+
+            @Override
+            public boolean directoryFilter(Class<? extends Directory> directory) {
+                return true;
+            }
+
+        });
+        assertEquals(3, metadata.getDirectoryCount());
+        for (Directory dir : metadata.getDirectories()) {
+            assertEquals(0, dir.getTagCount());
+        }
+
+        metadata = processBytes("Tests/Data/photoshop-8x12-32colors-alpha.gif", new MetadataFilter() {
+
+            @Override
+            public boolean tagFilter(Directory directory, int tagType) {
+                return true;
+            }
+
+            @Override
+            public boolean directoryFilter(Class<? extends Directory> directory) {
+                return false;
+            }
+
+        });
+        assertEquals(0, metadata.getDirectoryCount());
+    }
+
 }


### PR DESCRIPTION
@drewnoakes You mentioned creating a whitelist in #216. I figured that would be worth a shot, but I wanted to keep the filtered directories and tags from being created in the first place. This turned out to require changes in many places, so it will be preferrable not to have to keep this "in sync" manually.

As a result, I've created this pull request hoping that you'd consider taking it into the library itself. I've made it as general as possible. All changes to public methods are done with overloads, so it is API compatible. Most of the changes are very straight forward, but I had some challenges with ```TiffHandler``` and its implementing classes due to it's recursiveness and ```DirectoryTiffHandler``` class global ```_currentDirectory```. I created ```FilteredDirectory``` that simply doesn't store anything, and had to redirect ```setParent()``` to the first non-filtered parent.

It is implemented as an interface ```MetadataFilter``` that can easily be implemented as an anonymous class for easy use. It can be used as either a blacklist or a whitelist.

I've tried to keep the formatting as close to the existing code as I can, but I've been very uncertain about how to handle line wrapping many places. The existing practice seems to vary some, so I'm pretty sure you'll want some changes to that.

As a side note, I think I might have found a bug in the new GIF reader. I don't have intricate knowledge of the format, but the reader always skips the size of the color table without checking if there is a global color table. It looks to me like that won't work if the GIF doesn't have a global color table.
