### PR TITLE
support Reconyx Hyper and UltraFire makernotes

### DIFF
--- a/Source/com/drew/lang/Charsets.java
+++ b/Source/com/drew/lang/Charsets.java
@@ -32,7 +32,9 @@ import java.nio.charset.Charset;
 public final class Charsets
 {
     public static final Charset UTF_8 = Charset.forName("UTF-8");
+    public static final Charset UTF_16 = Charset.forName("UTF-16");
     public static final Charset ISO_8859_1 = Charset.forName("ISO-8859-1");
     public static final Charset ASCII = Charset.forName("US-ASCII");
     public static final Charset UTF_16BE = Charset.forName("UTF-16BE");
+    public static final Charset UTF_16LE = Charset.forName("UTF-16LE");
 }

--- a/Source/com/drew/metadata/exif/makernotes/ReconyxHyperFireMakernoteDescriptor.java
+++ b/Source/com/drew/metadata/exif/makernotes/ReconyxHyperFireMakernoteDescriptor.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2002-2016 Drew Noakes
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ * More information about this project is available at:
+ *
+ *    https://drewnoakes.com/code/exif/
+ *    https://github.com/drewnoakes/metadata-extractor
+ */
+
+package com.drew.metadata.exif.makernotes;
+
+import com.drew.lang.annotations.NotNull;
+import com.drew.lang.annotations.Nullable;
+import com.drew.metadata.StringValue;
+import com.drew.metadata.TagDescriptor;
+
+import java.text.DateFormat;
+import java.text.DecimalFormat;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+
+import static com.drew.metadata.exif.makernotes.ReconyxHyperFireMakernoteDirectory.*;
+
+/**
+ * Provides human-readable string representations of tag values stored in a {@link ReconyxHyperFireMakernoteDirectory}.
+ *
+ * @author Todd West http://cascadescarnivoreproject.blogspot.com
+ */
+@SuppressWarnings("WeakerAccess")
+public class ReconyxHyperFireMakernoteDescriptor extends TagDescriptor<ReconyxHyperFireMakernoteDirectory>
+{
+    public ReconyxHyperFireMakernoteDescriptor(@NotNull ReconyxHyperFireMakernoteDirectory directory)
+    {
+        super(directory);
+    }
+
+    @Override
+    @Nullable
+    public String getDescription(int tagType)
+    {
+        switch (tagType) {
+            case TAG_MAKERNOTE_VERSION:
+                return String.format("%d", _directory.getInteger(tagType));
+            case TAG_FIRMWARE_VERSION:
+                return _directory.getString(tagType);
+            case TAG_TRIGGER_MODE:
+                return _directory.getString(tagType);
+            case TAG_SEQUENCE:
+                int[] sequence = _directory.getIntArray(tagType);
+                return String.format("%d/%d", sequence[0], sequence[1]);
+            case TAG_EVENT_NUMBER:
+                return String.format("%d", _directory.getInteger(tagType));
+            case TAG_MOTION_SENSITIVITY:
+                return String.format("%d", _directory.getInteger(tagType));
+            case TAG_BATTERY_VOLTAGE:
+                Double value = _directory.getDoubleObject(tagType);
+                DecimalFormat formatter = new DecimalFormat("0.000");
+                return value == null ? null : formatter.format(value);
+            case TAG_DATE_TIME_ORIGINAL:
+                String date = _directory.getString(tagType);                
+                try {
+                    DateFormat parser = new SimpleDateFormat("yyyy:MM:dd HH:mm:ss");
+                    return parser.format(parser.parse(date));
+                } catch (ParseException e) {
+                    return null;
+                }
+            case TAG_MOON_PHASE:
+                return getIndexedDescription(tagType, "New", "Waxing Crescent", "First Quarter", "Waxing Gibbous", "Full", "Waning Gibbous", "Last Quarter", "Waning Crescent");
+            case TAG_AMBIENT_TEMPERATURE_FAHRENHEIT:
+            case TAG_AMBIENT_TEMPERATURE:
+                return String.format("%d", _directory.getInteger(tagType));
+            case TAG_SERIAL_NUMBER:
+                // default is UTF_16LE
+                StringValue svalue = _directory.getStringValue(tagType);
+                if(svalue == null)
+                    return null;
+                return svalue.toString();
+            case TAG_CONTRAST:
+            case TAG_BRIGHTNESS:
+            case TAG_SHARPNESS:
+            case TAG_SATURATION:
+                return String.format("%d", _directory.getInteger(tagType));
+            case TAG_INFRARED_ILLUMINATOR:
+                return getIndexedDescription(tagType, "Off", "On");
+            case TAG_USER_LABEL:
+                return _directory.getString(tagType);
+            default:
+                return super.getDescription(tagType);
+        }
+    }
+}

--- a/Source/com/drew/metadata/exif/makernotes/ReconyxHyperFireMakernoteDirectory.java
+++ b/Source/com/drew/metadata/exif/makernotes/ReconyxHyperFireMakernoteDirectory.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2002-2016 Drew Noakes
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ * More information about this project is available at:
+ *
+ *    https://drewnoakes.com/code/exif/
+ *    https://github.com/drewnoakes/metadata-extractor
+ */
+
+package com.drew.metadata.exif.makernotes;
+
+import com.drew.lang.annotations.NotNull;
+import com.drew.metadata.Directory;
+
+import java.util.HashMap;
+
+/**
+ * Describes tags specific to Reconyx HyperFire cameras.
+ * 
+ * Reconyx uses a fixed makernote block.  Tag values are the byte index of the tag within the makernote.
+ * @author Todd West http://cascadescarnivoreproject.blogspot.com
+ */
+@SuppressWarnings("WeakerAccess")
+public class ReconyxHyperFireMakernoteDirectory extends Directory
+{
+    /**
+     * Version number used for identifying makernotes from Reconyx HyperFire cameras.
+     */
+    public static final int MAKERNOTE_VERSION = 61697;
+
+    public static final int TAG_MAKERNOTE_VERSION = 0;
+    public static final int TAG_FIRMWARE_VERSION = 2;
+    public static final int TAG_TRIGGER_MODE = 12;
+    public static final int TAG_SEQUENCE = 14;
+    public static final int TAG_EVENT_NUMBER = 18;
+    public static final int TAG_DATE_TIME_ORIGINAL = 22;
+    public static final int TAG_MOON_PHASE = 36;
+    public static final int TAG_AMBIENT_TEMPERATURE_FAHRENHEIT = 38;
+    public static final int TAG_AMBIENT_TEMPERATURE = 40;
+    public static final int TAG_SERIAL_NUMBER = 42;
+    public static final int TAG_CONTRAST = 72;
+    public static final int TAG_BRIGHTNESS = 74;
+    public static final int TAG_SHARPNESS = 76;
+    public static final int TAG_SATURATION = 78;
+    public static final int TAG_INFRARED_ILLUMINATOR = 80;
+    public static final int TAG_MOTION_SENSITIVITY = 82;
+    public static final int TAG_BATTERY_VOLTAGE = 84;
+    public static final int TAG_USER_LABEL = 86;
+
+    @NotNull
+    protected static final HashMap<Integer, String> _tagNameMap = new HashMap<Integer, String>();
+
+    static
+    {
+        _tagNameMap.put(TAG_MAKERNOTE_VERSION, "Makernote Version");
+        _tagNameMap.put(TAG_FIRMWARE_VERSION, "Firmware Version");
+        _tagNameMap.put(TAG_TRIGGER_MODE, "Trigger Mode");
+        _tagNameMap.put(TAG_SEQUENCE, "Sequence");
+        _tagNameMap.put(TAG_EVENT_NUMBER, "Event Number");
+        _tagNameMap.put(TAG_DATE_TIME_ORIGINAL, "Date/Time Original");
+        _tagNameMap.put(TAG_MOON_PHASE, "Moon Phase");
+        _tagNameMap.put(TAG_AMBIENT_TEMPERATURE_FAHRENHEIT, "Ambient Temperature Fahrenheit");
+        _tagNameMap.put(TAG_AMBIENT_TEMPERATURE, "Ambient Temperature");
+        _tagNameMap.put(TAG_SERIAL_NUMBER, "Serial Number");
+        _tagNameMap.put(TAG_CONTRAST, "Contrast");
+        _tagNameMap.put(TAG_BRIGHTNESS, "Brightness");
+        _tagNameMap.put(TAG_SHARPNESS, "Sharpness");
+        _tagNameMap.put(TAG_SATURATION, "Saturation");
+        _tagNameMap.put(TAG_INFRARED_ILLUMINATOR, "Infrared Illuminator");
+        _tagNameMap.put(TAG_MOTION_SENSITIVITY, "Motion Sensitivity");
+        _tagNameMap.put(TAG_BATTERY_VOLTAGE, "Battery Voltage");
+        _tagNameMap.put(TAG_USER_LABEL, "User Label");
+    }
+
+    public ReconyxHyperFireMakernoteDirectory()
+    {
+        this.setDescriptor(new ReconyxHyperFireMakernoteDescriptor(this));
+    }
+
+    @Override
+    @NotNull
+    public String getName()
+    {
+        return "Reconyx HyperFire Makernote";
+    }
+
+    @Override
+    @NotNull
+    protected HashMap<Integer, String> getTagNameMap()
+    {
+        return _tagNameMap;
+    }
+}

--- a/Source/com/drew/metadata/exif/makernotes/ReconyxUltraFireMakernoteDescriptor.java
+++ b/Source/com/drew/metadata/exif/makernotes/ReconyxUltraFireMakernoteDescriptor.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2002-2016 Drew Noakes
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ * More information about this project is available at:
+ *
+ *    https://drewnoakes.com/code/exif/
+ *    https://github.com/drewnoakes/metadata-extractor
+ */
+
+package com.drew.metadata.exif.makernotes;
+
+import com.drew.lang.annotations.NotNull;
+import com.drew.lang.annotations.Nullable;
+import com.drew.metadata.StringValue;
+import com.drew.metadata.TagDescriptor;
+
+import java.text.DateFormat;
+import java.text.DecimalFormat;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+
+import static com.drew.metadata.exif.makernotes.ReconyxUltraFireMakernoteDirectory.*;
+
+/**
+ * Provides human-readable string representations of tag values stored in a {@link ReconyxUltraFireMakernoteDirectory}.
+ *
+ * @author Todd West http://cascadescarnivoreproject.blogspot.com
+ */
+@SuppressWarnings("WeakerAccess")
+public class ReconyxUltraFireMakernoteDescriptor extends TagDescriptor<ReconyxUltraFireMakernoteDirectory>
+{
+    public ReconyxUltraFireMakernoteDescriptor(@NotNull ReconyxUltraFireMakernoteDirectory directory)
+    {
+        super(directory);
+    }
+
+    @Override
+    @Nullable
+    public String getDescription(int tagType)
+    {
+        switch (tagType) {
+            case TAG_LABEL:
+                return _directory.getString(tagType);
+            case TAG_MAKERNOTE_ID:
+                return String.format("0x%08X", _directory.getInteger(tagType));
+            case TAG_MAKERNOTE_SIZE:
+                return String.format("%d", _directory.getInteger(tagType));
+            case TAG_MAKERNOTE_PUBLIC_ID:
+                return String.format("0x%08X", _directory.getInteger(tagType));
+            case TAG_MAKERNOTE_PUBLIC_SIZE:
+                return String.format("%d", _directory.getInteger(tagType));
+            case TAG_CAMERA_VERSION:
+            case TAG_UIB_VERSION:
+            case TAG_BTL_VERSION:
+            case TAG_PEX_VERSION:
+            case TAG_EVENT_TYPE:
+                return _directory.getString(tagType);
+            case TAG_SEQUENCE:
+                int[] sequence = _directory.getIntArray(tagType);
+                return String.format("%d/%d", sequence[0], sequence[1]);
+            case TAG_EVENT_NUMBER:
+                return String.format("%d", _directory.getInteger(tagType));
+            case TAG_DATE_TIME_ORIGINAL:
+                String date = _directory.getString(tagType);                
+                try {
+                    DateFormat parser = new SimpleDateFormat("yyyy:MM:dd HH:mm:ss");
+                    return parser.format(parser.parse(date));
+                } catch (ParseException e) {
+                    return null;
+                }
+            /*case TAG_DAY_OF_WEEK:
+                return getIndexedDescription(tagType, CultureInfo.CurrentCulture.DateTimeFormat.DayNames);*/
+            case TAG_MOON_PHASE:
+                return getIndexedDescription(tagType, "New", "Waxing Crescent", "First Quarter", "Waxing Gibbous", "Full", "Waning Gibbous", "Last Quarter", "Waning Crescent");
+            case TAG_AMBIENT_TEMPERATURE_FAHRENHEIT:
+            case TAG_AMBIENT_TEMPERATURE:
+                return String.format("%d", _directory.getInteger(tagType));
+            case TAG_FLASH:
+                return getIndexedDescription(tagType, "Off", "On");
+            case TAG_BATTERY_VOLTAGE:
+                Double value = _directory.getDoubleObject(tagType);
+                DecimalFormat formatter = new DecimalFormat("0.000");
+                return value == null ? null : formatter.format(value);
+            case TAG_SERIAL_NUMBER:
+                // default is UTF_8
+                StringValue svalue = _directory.getStringValue(tagType);
+                if(svalue == null)
+                    return null;
+                return svalue.toString();
+            case TAG_USER_LABEL:
+                return _directory.getString(tagType);
+            default:
+                return super.getDescription(tagType);
+        }
+    }
+}

--- a/Source/com/drew/metadata/exif/makernotes/ReconyxUltraFireMakernoteDirectory.java
+++ b/Source/com/drew/metadata/exif/makernotes/ReconyxUltraFireMakernoteDirectory.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2002-2016 Drew Noakes
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ * More information about this project is available at:
+ *
+ *    https://drewnoakes.com/code/exif/
+ *    https://github.com/drewnoakes/metadata-extractor
+ */
+
+package com.drew.metadata.exif.makernotes;
+
+import com.drew.lang.annotations.NotNull;
+import com.drew.metadata.Directory;
+
+import java.util.HashMap;
+
+/**
+ * Describes tags specific to Reconyx UltraFire cameras.
+ * 
+ * Reconyx uses a fixed makernote block.  Tag values are the byte index of the tag within the makernote.
+ * @author Todd West http://cascadescarnivoreproject.blogspot.com
+ */
+@SuppressWarnings("WeakerAccess")
+public class ReconyxUltraFireMakernoteDirectory extends Directory
+{
+    /**
+     * Version number used for identifying makernotes from Reconyx UltraFire cameras.
+     */
+    public static final int MAKERNOTE_ID = 0x00010000;
+    
+    /**
+     * Version number used for identifying the public portion of makernotes from Reconyx UltraFire cameras.
+     */
+    public static final int MAKERNOTE_PUBLIC_ID = 0x07f10001;
+
+    public static final int TAG_LABEL = 0;
+    public static final int TAG_MAKERNOTE_ID = 10;
+    public static final int TAG_MAKERNOTE_SIZE = 14;
+    public static final int TAG_MAKERNOTE_PUBLIC_ID = 18;
+    public static final int TAG_MAKERNOTE_PUBLIC_SIZE = 22;
+    public static final int TAG_CAMERA_VERSION = 24;
+    public static final int TAG_UIB_VERSION = 31;
+    public static final int TAG_BTL_VERSION = 38;
+    public static final int TAG_PEX_VERSION = 45;
+    public static final int TAG_EVENT_TYPE = 52;
+    public static final int TAG_SEQUENCE = 53;
+    public static final int TAG_EVENT_NUMBER = 55;
+    public static final int TAG_DATE_TIME_ORIGINAL = 59;
+    public static final int TAG_DAY_OF_WEEK = 66;
+    public static final int TAG_MOON_PHASE = 67;
+    public static final int TAG_AMBIENT_TEMPERATURE_FAHRENHEIT = 68;
+    public static final int TAG_AMBIENT_TEMPERATURE = 70;
+    public static final int TAG_FLASH = 72;
+    public static final int TAG_BATTERY_VOLTAGE = 73;
+    public static final int TAG_SERIAL_NUMBER = 75;
+    public static final int TAG_USER_LABEL = 80;
+
+    @NotNull
+    protected static final HashMap<Integer, String> _tagNameMap = new HashMap<Integer, String>();
+
+    static
+    {
+        _tagNameMap.put(TAG_LABEL, "Makernote Label");
+        _tagNameMap.put(TAG_MAKERNOTE_ID, "Makernote ID");
+        _tagNameMap.put(TAG_MAKERNOTE_SIZE, "Makernote Size");
+        _tagNameMap.put(TAG_MAKERNOTE_PUBLIC_ID, "Makernote Public ID");
+        _tagNameMap.put(TAG_MAKERNOTE_PUBLIC_SIZE, "Makernote Public Size");
+        _tagNameMap.put(TAG_CAMERA_VERSION, "Camera Version");
+        _tagNameMap.put(TAG_UIB_VERSION, "Uib Version");
+        _tagNameMap.put(TAG_BTL_VERSION, "Btl Version");
+        _tagNameMap.put(TAG_PEX_VERSION, "Pex Version");
+        _tagNameMap.put(TAG_EVENT_TYPE, "Event Type");
+        _tagNameMap.put(TAG_SEQUENCE, "Sequence");
+        _tagNameMap.put(TAG_EVENT_NUMBER, "Event Number");
+        _tagNameMap.put(TAG_DATE_TIME_ORIGINAL, "Date/Time Original");
+        _tagNameMap.put(TAG_DAY_OF_WEEK, "Day of Week");
+        _tagNameMap.put(TAG_MOON_PHASE, "Moon Phase");
+        _tagNameMap.put(TAG_AMBIENT_TEMPERATURE_FAHRENHEIT, "Ambient Temperature Fahrenheit");
+        _tagNameMap.put(TAG_AMBIENT_TEMPERATURE, "Ambient Temperature");
+        _tagNameMap.put(TAG_FLASH, "Flash");
+        _tagNameMap.put(TAG_BATTERY_VOLTAGE, "Battery Voltage");
+        _tagNameMap.put(TAG_SERIAL_NUMBER, "Serial Number");
+        _tagNameMap.put(TAG_USER_LABEL, "User Label");
+    }
+
+    public ReconyxUltraFireMakernoteDirectory()
+    {
+        this.setDescriptor(new ReconyxUltraFireMakernoteDescriptor(this));
+    }
+
+    @Override
+    @NotNull
+    public String getName()
+    {
+        return "Reconyx UltraFire Makernote";
+    }
+
+    @Override
+    @NotNull
+    protected HashMap<Integer, String> getTagNameMap()
+    {
+        return _tagNameMap;
+    }
+}


### PR DESCRIPTION
Port of .NET commit drewnoakes/metadata-extractor-dotnet@1542a7d

This is complete for Hyper, but incomplete for Ultra; none of the DirectoryExtensions or ByteConvert changes were ported. Some of the obvious Ultra tags are implemented, but I don't have a test image to finish it off. Maybe @twest820 is interested in finishing it.