### PR TITLE
PNG zTXt, ExifImage directory, multipage TIFF

### DIFF
--- a/Source/com/drew/metadata/exif/ExifDescriptorBase.java
+++ b/Source/com/drew/metadata/exif/ExifDescriptorBase.java
@@ -457,9 +457,10 @@ public abstract class ExifDescriptorBase<T extends Directory> extends TagDescrip
     @Nullable
     public String getNewSubfileTypeDescription()
     {
-        return getIndexedDescription(TAG_NEW_SUBFILE_TYPE, 1,
+        return getIndexedDescription(TAG_NEW_SUBFILE_TYPE, 0,
             "Full-resolution image",
             "Reduced-resolution image",
+            "Single page of multi-page image",
             "Single page of multi-page reduced-resolution image",
             "Transparency mask",
             "Transparency mask of reduced-resolution image",

--- a/Source/com/drew/metadata/exif/ExifDirectoryBase.java
+++ b/Source/com/drew/metadata/exif/ExifDirectoryBase.java
@@ -126,6 +126,8 @@ public abstract class ExifDirectoryBase extends Directory
     public static final int TAG_PAGE_NAME                         = 0x011D;
 
     public static final int TAG_RESOLUTION_UNIT                   = 0x0128;
+    public static final int TAG_PAGE_NUMBER                       = 0x0129;
+
     public static final int TAG_TRANSFER_FUNCTION                 = 0x012D;
     public static final int TAG_SOFTWARE                          = 0x0131;
     public static final int TAG_DATETIME                          = 0x0132;
@@ -149,6 +151,15 @@ public abstract class ExifDirectoryBase extends Directory
     public static final int TAG_TRANSFER_RANGE                    = 0x0156;
     public static final int TAG_JPEG_TABLES                       = 0x015B;
     public static final int TAG_JPEG_PROC                         = 0x0200;
+
+    // 0x0201 can have all kinds of descriptions for thumbnail starting index
+    // 0x0202 can have all kinds of descriptions for thumbnail length
+    public static final int TAG_JPEG_RESTART_INTERVAL = 0x0203;
+    public static final int TAG_JPEG_LOSSLESS_PREDICTORS = 0x0205;
+    public static final int TAG_JPEG_POINT_TRANSFORMS = 0x0206;
+    public static final int TAG_JPEG_Q_TABLES = 0x0207;
+    public static final int TAG_JPEG_DC_TABLES = 0x0208;
+    public static final int TAG_JPEG_AC_TABLES = 0x0209;
 
     public static final int TAG_YCBCR_COEFFICIENTS                = 0x0211;
     public static final int TAG_YCBCR_SUBSAMPLING                 = 0x0212;
@@ -617,6 +628,7 @@ public abstract class ExifDirectoryBase extends Directory
         map.put(TAG_PLANAR_CONFIGURATION, "Planar Configuration");
         map.put(TAG_PAGE_NAME, "Page Name");
         map.put(TAG_RESOLUTION_UNIT, "Resolution Unit");
+        map.put(TAG_PAGE_NUMBER, "Page Number");
         map.put(TAG_TRANSFER_FUNCTION, "Transfer Function");
         map.put(TAG_SOFTWARE, "Software");
         map.put(TAG_DATETIME, "Date/Time");
@@ -633,6 +645,14 @@ public abstract class ExifDirectoryBase extends Directory
         map.put(TAG_TRANSFER_RANGE, "Transfer Range");
         map.put(TAG_JPEG_TABLES, "JPEG Tables");
         map.put(TAG_JPEG_PROC, "JPEG Proc");
+
+        map.put(TAG_JPEG_RESTART_INTERVAL, "JPEG Restart Interval");
+        map.put(TAG_JPEG_LOSSLESS_PREDICTORS, "JPEG Lossless Predictors");
+        map.put(TAG_JPEG_POINT_TRANSFORMS, "JPEG Point Transforms");
+        map.put(TAG_JPEG_Q_TABLES, "JPEGQ Tables");
+        map.put(TAG_JPEG_DC_TABLES, "JPEGDC Tables");
+        map.put(TAG_JPEG_AC_TABLES, "JPEGAC Tables");
+
         map.put(TAG_YCBCR_COEFFICIENTS, "YCbCr Coefficients");
         map.put(TAG_YCBCR_SUBSAMPLING, "YCbCr Sub-Sampling");
         map.put(TAG_YCBCR_POSITIONING, "YCbCr Positioning");

--- a/Source/com/drew/metadata/exif/ExifImageDescriptor.java
+++ b/Source/com/drew/metadata/exif/ExifImageDescriptor.java
@@ -18,36 +18,20 @@
  *    https://drewnoakes.com/code/exif/
  *    https://github.com/drewnoakes/metadata-extractor
  */
-package com.drew.lang;
+package com.drew.metadata.exif;
 
 import com.drew.lang.annotations.NotNull;
-import com.drew.metadata.StringValue;
 
 /**
- * Models a key/value pair, where both are non-null {@link StringValue} objects.
+ * Provides human-readable string representations of tag values stored in a {@link ExifImageDirectory}.
  *
  * @author Drew Noakes https://drewnoakes.com
  */
-public class KeyValuePair
+@SuppressWarnings("WeakerAccess")
+public class ExifImageDescriptor extends ExifDescriptorBase<ExifImageDirectory>
 {
-    private final String _key;
-    private final StringValue _value;
-
-    public KeyValuePair(@NotNull String key, @NotNull StringValue value)
+    public ExifImageDescriptor(@NotNull ExifImageDirectory directory)
     {
-        _key = key;
-        _value = value;
-    }
-
-    @NotNull
-    public String getKey()
-    {
-        return _key;
-    }
-
-    @NotNull
-    public StringValue getValue()
-    {
-        return _value;
+        super(directory);
     }
 }

--- a/Source/com/drew/metadata/exif/ExifImageDirectory.java
+++ b/Source/com/drew/metadata/exif/ExifImageDirectory.java
@@ -18,36 +18,47 @@
  *    https://drewnoakes.com/code/exif/
  *    https://github.com/drewnoakes/metadata-extractor
  */
-package com.drew.lang;
+package com.drew.metadata.exif;
 
 import com.drew.lang.annotations.NotNull;
-import com.drew.metadata.StringValue;
+
+import java.util.HashMap;
 
 /**
- * Models a key/value pair, where both are non-null {@link StringValue} objects.
+ * Describes One of several Exif directories.
+ *
+ * Holds information about image IFD's in a chain after the first. The first page is stored in IFD0.
+ * Currently, this only applied to multi-page TIFF images
  *
  * @author Drew Noakes https://drewnoakes.com
  */
-public class KeyValuePair
+@SuppressWarnings("WeakerAccess")
+public class ExifImageDirectory extends ExifDirectoryBase
 {
-    private final String _key;
-    private final StringValue _value;
+    @NotNull
+    protected static final HashMap<Integer, String> _tagNameMap = new HashMap<Integer, String>();
 
-    public KeyValuePair(@NotNull String key, @NotNull StringValue value)
+    static
     {
-        _key = key;
-        _value = value;
+        addExifTagNames(_tagNameMap);
     }
 
-    @NotNull
-    public String getKey()
+    public ExifImageDirectory()
     {
-        return _key;
+        this.setDescriptor(new ExifImageDescriptor(this));
     }
 
+    @Override
     @NotNull
-    public StringValue getValue()
+    public String getName()
     {
-        return _value;
+        return "Exif Image";
+    }
+
+    @Override
+    @NotNull
+    protected HashMap<Integer, String> getTagNameMap()
+    {
+        return _tagNameMap;
     }
 }

--- a/Source/com/drew/metadata/exif/ExifTiffHandler.java
+++ b/Source/com/drew/metadata/exif/ExifTiffHandler.java
@@ -150,8 +150,14 @@ public class ExifTiffHandler extends DirectoryTiffHandler
     public boolean hasFollowerIfd()
     {
         // In Exif, the only known 'follower' IFD is the thumbnail one, however this may not be the case.
-        if (_currentDirectory instanceof ExifIFD0Directory) {
-            pushDirectory(ExifThumbnailDirectory.class);
+        // UPDATE: In multipage TIFFs, the 'follower' IFD points to the next image in the set
+        if (_currentDirectory instanceof ExifIFD0Directory || _currentDirectory instanceof ExifImageDirectory) {
+            // If the PageNumber tag is defined, assume this is a multipage TIFF or similar
+            // TODO: Find better ways to know which follower Directory should be used
+            if (_currentDirectory.containsTag(ExifDirectoryBase.TAG_PAGE_NUMBER))
+                pushDirectory(ExifImageDirectory.class);
+            else
+                pushDirectory(ExifThumbnailDirectory.class);
             return true;
         }
 

--- a/Source/com/drew/metadata/jpeg/JpegReader.java
+++ b/Source/com/drew/metadata/jpeg/JpegReader.java
@@ -62,6 +62,7 @@ public class JpegReader implements JpegSegmentMetadataReader
         );
     }
 
+    @NotNull
     public void readJpegSegments(@NotNull Iterable<byte[]> segments, @NotNull Metadata metadata, @NotNull JpegSegmentType segmentType)
     {
         for (byte[] segmentBytes : segments) {


### PR DESCRIPTION
Ports from .NET:
- drewnoakes/metadata-extractor-dotnet@6752a7d
- drewnoakes/metadata-extractor-dotnet@c9693ed
- drewnoakes/metadata-extractor-dotnet@a15147b

There is an InflaterInputStream change that should be reviewed. It's documented in the code.

PNG zTXt seems to work with what's in the image repo, but eyes peeled in the future.

KeyValuePair was implemented differently in Java - the 'key' was a StringValue. This change makes it match .NET where the key is a string. A StringValue doesn't really give us any advantages as a key (I think).