### PR TITLE
Make number formatting locale independent

### DIFF
--- a/Source/com/drew/lang/GeoLocation.java
+++ b/Source/com/drew/lang/GeoLocation.java
@@ -25,6 +25,8 @@ import com.drew.lang.annotations.NotNull;
 import com.drew.lang.annotations.Nullable;
 
 import java.text.DecimalFormat;
+import java.text.DecimalFormatSymbols;
+import java.util.Locale;
 
 /**
  * Represents a latitude and longitude pair, giving a position on earth in spherical coordinates.
@@ -82,7 +84,7 @@ public final class GeoLocation
     public static String decimalToDegreesMinutesSecondsString(double decimal)
     {
         double[] dms = decimalToDegreesMinutesSeconds(decimal);
-        DecimalFormat format = new DecimalFormat("0.##");
+        DecimalFormat format = new DecimalFormat("0.##", new DecimalFormatSymbols(Locale.ROOT));
         return String.format("%s\u00B0 %s' %s\"", format.format(dms[0]), format.format(dms[1]), format.format(dms[2]));
     }
 

--- a/Source/com/drew/metadata/Directory.java
+++ b/Source/com/drew/metadata/Directory.java
@@ -29,6 +29,7 @@ import java.io.UnsupportedEncodingException;
 import java.lang.reflect.Array;
 import java.text.DateFormat;
 import java.text.DecimalFormat;
+import java.text.DecimalFormatSymbols;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.*;
@@ -43,7 +44,7 @@ import java.util.regex.Pattern;
  */
 public abstract class Directory
 {
-    private static final DecimalFormat _floatFormat = new DecimalFormat("0.###");
+    private static final DecimalFormat _floatFormat = new DecimalFormat("0.###", new DecimalFormatSymbols(Locale.ROOT));
 
     /** Map of values hashed by type identifiers. */
     @NotNull

--- a/Source/com/drew/metadata/TagDescriptor.java
+++ b/Source/com/drew/metadata/TagDescriptor.java
@@ -30,10 +30,12 @@ import java.lang.reflect.Array;
 import java.math.RoundingMode;
 import java.nio.charset.Charset;
 import java.text.DecimalFormat;
+import java.text.DecimalFormatSymbols;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
+import java.util.Locale;
 
 /**
  * Base class for all tag descriptor classes.  Implementations are responsible for
@@ -44,6 +46,8 @@ import java.util.List;
  */
 public class TagDescriptor<T extends Directory>
 {
+    protected static DecimalFormatSymbols formatSymbols = new DecimalFormatSymbols(Locale.ROOT);
+
     @NotNull
     protected final T _directory;
 
@@ -293,7 +297,7 @@ public class TagDescriptor<T extends Directory>
         Double d = _directory.getDoubleObject(tagType);
         if (d != null)
         {
-            DecimalFormat format = new DecimalFormat("0.###");
+            DecimalFormat format = new DecimalFormat("0.###", formatSymbols);
             return format.format(d);
         }
 
@@ -303,7 +307,7 @@ public class TagDescriptor<T extends Directory>
     @Nullable
     protected static String getFStopDescription(double fStop)
     {
-        DecimalFormat format = new DecimalFormat("0.0");
+        DecimalFormat format = new DecimalFormat("0.0", formatSymbols);
         format.setRoundingMode(RoundingMode.HALF_UP);
         return "f/" + format.format(fStop);
     }
@@ -311,7 +315,7 @@ public class TagDescriptor<T extends Directory>
     @Nullable
     protected static String getFocalLengthDescription(double mm)
     {
-        DecimalFormat format = new DecimalFormat("0.#");
+        DecimalFormat format = new DecimalFormat("0.#", formatSymbols);
         format.setRoundingMode(RoundingMode.HALF_UP);
         return format.format(mm) + " mm";
     }
@@ -334,7 +338,7 @@ public class TagDescriptor<T extends Directory>
         if (!values[2].isZero()) {
             sb.append(' ');
 
-            DecimalFormat format = new DecimalFormat("0.0");
+            DecimalFormat format = new DecimalFormat("0.0", formatSymbols);
             format.setRoundingMode(RoundingMode.HALF_UP);
 
             if (values[2].equals(values[3]))
@@ -380,7 +384,7 @@ public class TagDescriptor<T extends Directory>
             float apexPower = (float)(1 / (Math.exp(apexValue * Math.log(2))));
             long apexPower10 = Math.round((double)apexPower * 10.0);
             float fApexPower = (float)apexPower10 / 10.0f;
-            DecimalFormat format = new DecimalFormat("0.##");
+            DecimalFormat format = new DecimalFormat("0.##", formatSymbols);
             format.setRoundingMode(RoundingMode.HALF_UP);
             return format.format(fApexPower) + " sec";
         } else {

--- a/Source/com/drew/metadata/exif/ExifDescriptorBase.java
+++ b/Source/com/drew/metadata/exif/ExifDescriptorBase.java
@@ -52,7 +52,7 @@ public abstract class ExifDescriptorBase<T extends Directory> extends TagDescrip
     private final boolean _allowDecimalRepresentationOfRationals = true;
 
     @NotNull
-    private static final java.text.DecimalFormat SimpleDecimalFormatter = new DecimalFormat("0.#");
+    private static final java.text.DecimalFormat SimpleDecimalFormatter = new DecimalFormat("0.#", formatSymbols);
 
     // Note for the potential addition of brightness presentation in eV:
     // Brightness of taken subject. To calculate Exposure(Ev) from BrightnessValue(Bv),
@@ -1144,7 +1144,7 @@ public abstract class ExifDescriptorBase<T extends Directory> extends TagDescrip
         Rational value = _directory.getRational(TAG_SUBJECT_DISTANCE);
         if (value == null)
             return null;
-        DecimalFormat formatter = new DecimalFormat("0.0##");
+        DecimalFormat formatter = new DecimalFormat("0.0##", formatSymbols);
         return formatter.format(value.doubleValue()) + " metres";
     }
 

--- a/Source/com/drew/metadata/exif/GpsDescriptor.java
+++ b/Source/com/drew/metadata/exif/GpsDescriptor.java
@@ -110,7 +110,7 @@ public class GpsDescriptor extends TagDescriptor<GpsDirectory>
     {
         // time in hour, min, sec
         Rational[] timeComponents = _directory.getRationalArray(TAG_TIME_STAMP);
-        DecimalFormat df = new DecimalFormat("00.000");
+        DecimalFormat df = new DecimalFormat("00.000", formatSymbols);
         return timeComponents == null
             ? null
             : String.format("%02d:%02d:%s UTC",
@@ -143,7 +143,7 @@ public class GpsDescriptor extends TagDescriptor<GpsDirectory>
         Rational angle = _directory.getRational(tagType);
         // provide a decimal version of rational numbers in the description, to avoid strings like "35334/199 degrees"
         String value = angle != null
-            ? new DecimalFormat("0.##").format(angle.doubleValue())
+            ? new DecimalFormat("0.##", formatSymbols).format(angle.doubleValue())
             : _directory.getString(tagType);
         return value == null || value.trim().length() == 0 ? null : value.trim() + " degrees";
     }

--- a/Source/com/drew/metadata/exif/makernotes/CanonMakernoteDescriptor.java
+++ b/Source/com/drew/metadata/exif/makernotes/CanonMakernoteDescriptor.java
@@ -747,7 +747,7 @@ public class CanonMakernoteDescriptor extends TagDescriptor<CanonMakernoteDirect
         if (value == 0) {
             return "Self timer not used";
         } else {
-            DecimalFormat format = new DecimalFormat("0.##");
+            DecimalFormat format = new DecimalFormat("0.##", formatSymbols);
             return format.format((double)value * 0.1d) + " sec";
         }
     }

--- a/Source/com/drew/metadata/exif/makernotes/NikonType2MakernoteDescriptor.java
+++ b/Source/com/drew/metadata/exif/makernotes/NikonType2MakernoteDescriptor.java
@@ -310,7 +310,7 @@ public class NikonType2MakernoteDescriptor extends TagDescriptor<NikonType2Maker
             return null;
         if (values.length < 3 || values[2] == 0)
             return null;
-        final DecimalFormat decimalFormat = new DecimalFormat("0.##");
+        final DecimalFormat decimalFormat = new DecimalFormat("0.##", formatSymbols);
         double ev = values[0] * values[1] / (double)values[2];
         return decimalFormat.format(ev) + " EV";
     }

--- a/Source/com/drew/metadata/exif/makernotes/OlympusCameraSettingsMakernoteDescriptor.java
+++ b/Source/com/drew/metadata/exif/makernotes/OlympusCameraSettingsMakernoteDescriptor.java
@@ -1253,7 +1253,7 @@ public class OlympusCameraSettingsMakernoteDescriptor extends TagDescriptor<Olym
         if (value == null)
             return null;
 
-        return String.format("%s kPa", new DecimalFormat("#.##").format(value / 10.0));
+        return String.format("%s kPa", new DecimalFormat("#.##", formatSymbols).format(value / 10.0));
     }
 
     /// <remarks>
@@ -1267,7 +1267,7 @@ public class OlympusCameraSettingsMakernoteDescriptor extends TagDescriptor<Olym
         if (values == null || values.length < 2)
             return null;
 
-        DecimalFormat format = new DecimalFormat("#.##");
+        DecimalFormat format = new DecimalFormat("#.##", formatSymbols);
         return String.format("%s m, %s ft",
             format.format(values[0] / 10.0),
             format.format(values[1] / 10.0));

--- a/Source/com/drew/metadata/exif/makernotes/OlympusEquipmentMakernoteDescriptor.java
+++ b/Source/com/drew/metadata/exif/makernotes/OlympusEquipmentMakernoteDescriptor.java
@@ -174,7 +174,7 @@ public class OlympusEquipmentMakernoteDescriptor extends TagDescriptor<OlympusEq
         if (value == null)
             return null;
 
-        DecimalFormat format = new DecimalFormat("0.#");
+        DecimalFormat format = new DecimalFormat("0.#", formatSymbols);
         return format.format(CalcMaxAperture(value));
     }
 
@@ -185,7 +185,7 @@ public class OlympusEquipmentMakernoteDescriptor extends TagDescriptor<OlympusEq
         if (value == null)
             return null;
 
-        DecimalFormat format = new DecimalFormat("0.#");
+        DecimalFormat format = new DecimalFormat("0.#", formatSymbols);
         return format.format(CalcMaxAperture(value));
     }
 
@@ -196,7 +196,7 @@ public class OlympusEquipmentMakernoteDescriptor extends TagDescriptor<OlympusEq
         if (value == null)
             return null;
 
-        DecimalFormat format = new DecimalFormat("0.#");
+        DecimalFormat format = new DecimalFormat("0.#", formatSymbols);
         return format.format(CalcMaxAperture(value));
     }
 

--- a/Source/com/drew/metadata/exif/makernotes/OlympusMakernoteDescriptor.java
+++ b/Source/com/drew/metadata/exif/makernotes/OlympusMakernoteDescriptor.java
@@ -286,7 +286,7 @@ public class OlympusMakernoteDescriptor extends TagDescriptor<OlympusMakernoteDi
             return null;
 
         double iso = Math.pow((value / 8d) - 1, 2) * 3.125;
-        DecimalFormat format = new DecimalFormat("0.##");
+        DecimalFormat format = new DecimalFormat("0.##", formatSymbols);
         format.setRoundingMode(RoundingMode.HALF_UP);
         return format.format(iso);
     }
@@ -304,7 +304,7 @@ public class OlympusMakernoteDescriptor extends TagDescriptor<OlympusMakernoteDi
             return null;
 
         double shutterSpeed = Math.pow((49-value) / 8d, 2);
-        DecimalFormat format = new DecimalFormat("0.###");
+        DecimalFormat format = new DecimalFormat("0.###", formatSymbols);
         format.setRoundingMode(RoundingMode.HALF_UP);
         return format.format(shutterSpeed) + " sec";
     }
@@ -340,7 +340,7 @@ public class OlympusMakernoteDescriptor extends TagDescriptor<OlympusMakernoteDi
     public String getExposureCompensationDescription()
     {
         Long value = _directory.getLongObject(CameraSettings.TAG_EXPOSURE_COMPENSATION);
-        DecimalFormat format = new DecimalFormat("0.##");
+        DecimalFormat format = new DecimalFormat("0.##", formatSymbols);
         return value == null ? null : format.format((value / 3d) - 2) + " EV";
     }
 
@@ -466,7 +466,7 @@ public class OlympusMakernoteDescriptor extends TagDescriptor<OlympusMakernoteDi
     public String getWhiteBalanceRedDescription()
     {
         Long value = _directory.getLongObject(CameraSettings.TAG_WHITE_BALANCE_RED);
-        DecimalFormat format = new DecimalFormat("0.##");
+        DecimalFormat format = new DecimalFormat("0.##", formatSymbols);
         return value == null ? null : format.format(value/256d);
     }
 
@@ -474,7 +474,7 @@ public class OlympusMakernoteDescriptor extends TagDescriptor<OlympusMakernoteDi
     public String getWhiteBalanceGreenDescription()
     {
         Long value = _directory.getLongObject(CameraSettings.TAG_WHITE_BALANCE_GREEN);
-        DecimalFormat format = new DecimalFormat("0.##");
+        DecimalFormat format = new DecimalFormat("0.##", formatSymbols);
         return value == null ? null : format.format(value/256d);
     }
 
@@ -482,7 +482,7 @@ public class OlympusMakernoteDescriptor extends TagDescriptor<OlympusMakernoteDi
     public String getWhiteBalanceBlueDescription()
     {
         Long value = _directory.getLongObject(CameraSettings.TAG_WHITE_BALANCE_BLUE);
-        DecimalFormat format = new DecimalFormat("0.##");
+        DecimalFormat format = new DecimalFormat("0.##", formatSymbols);
         return value == null ? null : format.format(value / 256d);
     }
 
@@ -516,7 +516,7 @@ public class OlympusMakernoteDescriptor extends TagDescriptor<OlympusMakernoteDi
     public String getFlashCompensationDescription()
     {
         Long value = _directory.getLongObject(CameraSettings.TAG_FLASH_COMPENSATION);
-        DecimalFormat format = new DecimalFormat("0.##");
+        DecimalFormat format = new DecimalFormat("0.##", formatSymbols);
         return value == null ? null : format.format((value-6)/3d) + " EV";
     }
 
@@ -581,7 +581,7 @@ public class OlympusMakernoteDescriptor extends TagDescriptor<OlympusMakernoteDi
     public String getApexBrightnessDescription()
     {
         Long value = _directory.getLongObject(CameraSettings.TAG_APEX_BRIGHTNESS_VALUE);
-        DecimalFormat format = new DecimalFormat("0.##");
+        DecimalFormat format = new DecimalFormat("0.##", formatSymbols);
         return value == null ? null : format.format((value/8d)-6);
     }
 
@@ -793,7 +793,7 @@ public class OlympusMakernoteDescriptor extends TagDescriptor<OlympusMakernoteDi
         if (value == null)
             return null;
 
-        DecimalFormat format = new DecimalFormat("0.###");
+        DecimalFormat format = new DecimalFormat("0.###", formatSymbols);
         return format.format(value.doubleValue()) + " mm";
     }
 

--- a/Source/com/drew/metadata/exif/makernotes/PanasonicMakernoteDescriptor.java
+++ b/Source/com/drew/metadata/exif/makernotes/PanasonicMakernoteDescriptor.java
@@ -465,7 +465,7 @@ public class PanasonicMakernoteDescriptor extends TagDescriptor<PanasonicMakerno
         if (value == null)
             return null;
 
-        DecimalFormat format = new DecimalFormat("0.#");
+        DecimalFormat format = new DecimalFormat("0.#", formatSymbols);
         // converted to degrees of clockwise camera rotation
         return format.format(value.shortValue() / 10.0);
     }
@@ -477,7 +477,7 @@ public class PanasonicMakernoteDescriptor extends TagDescriptor<PanasonicMakerno
         if (value == null)
             return null;
 
-        DecimalFormat format = new DecimalFormat("0.#");
+        DecimalFormat format = new DecimalFormat("0.#", formatSymbols);
         // converted to degrees of upward camera tilt
         return format.format(-value.shortValue() / 10.0);
     }

--- a/Source/com/drew/metadata/exif/makernotes/ReconyxHyperFireMakernoteDescriptor.java
+++ b/Source/com/drew/metadata/exif/makernotes/ReconyxHyperFireMakernoteDescriptor.java
@@ -66,7 +66,7 @@ public class ReconyxHyperFireMakernoteDescriptor extends TagDescriptor<ReconyxHy
                 return String.format("%d", _directory.getInteger(tagType));
             case TAG_BATTERY_VOLTAGE:
                 Double value = _directory.getDoubleObject(tagType);
-                DecimalFormat formatter = new DecimalFormat("0.000");
+                DecimalFormat formatter = new DecimalFormat("0.000", formatSymbols);
                 return value == null ? null : formatter.format(value);
             case TAG_DATE_TIME_ORIGINAL:
                 String date = _directory.getString(tagType);

--- a/Source/com/drew/metadata/exif/makernotes/ReconyxUltraFireMakernoteDescriptor.java
+++ b/Source/com/drew/metadata/exif/makernotes/ReconyxUltraFireMakernoteDescriptor.java
@@ -91,7 +91,7 @@ public class ReconyxUltraFireMakernoteDescriptor extends TagDescriptor<ReconyxUl
                 return getIndexedDescription(tagType, "Off", "On");
             case TAG_BATTERY_VOLTAGE:
                 Double value = _directory.getDoubleObject(tagType);
-                DecimalFormat formatter = new DecimalFormat("0.000");
+                DecimalFormat formatter = new DecimalFormat("0.000", formatSymbols);
                 return value == null ? null : formatter.format(value);
             case TAG_SERIAL_NUMBER:
                 // default is UTF_8

--- a/Source/com/drew/metadata/icc/IccDescriptor.java
+++ b/Source/com/drew/metadata/icc/IccDescriptor.java
@@ -163,13 +163,13 @@ public class IccDescriptor extends TagDescriptor<IccDirectory>
                             illuminantString = String.format("Unknown %d", illuminantType);
                             break;
                     }
-                    DecimalFormat format = new DecimalFormat("0.###");
+                    DecimalFormat format = new DecimalFormat("0.###", formatSymbols);
                     return String.format("%s Observer, Backing (%s, %s, %s), Geometry %s, Flare %d%%, Illuminant %s",
                             observerString, format.format(x), format.format(y), format.format(z), geometryString, Math.round(flare * 100), illuminantString);
                 }
                 case ICC_TAG_TYPE_XYZ_ARRAY: {
                     StringBuilder res = new StringBuilder();
-                    DecimalFormat format = new DecimalFormat("0.####");
+                    DecimalFormat format = new DecimalFormat("0.####", formatSymbols);
                     int count = (bytes.length - 8) / 12;
                     for (int i = 0; i < count; i++) {
                         float x = reader.getS15Fixed16(8 + i * 12);

--- a/Source/com/drew/metadata/photoshop/PhotoshopDescriptor.java
+++ b/Source/com/drew/metadata/photoshop/PhotoshopDescriptor.java
@@ -202,7 +202,7 @@ public class PhotoshopDescriptor extends TagDescriptor<PhotoshopDirectory>
             RandomAccessReader reader = new ByteArrayReader(bytes);
             float resX = reader.getS15Fixed16(0);
             float resY = reader.getS15Fixed16(8); // is this the correct offset? it's only reading 4 bytes each time
-            DecimalFormat format = new DecimalFormat("0.##");
+            DecimalFormat format = new DecimalFormat("0.##", formatSymbols);
             return format.format(resX) + "x" + format.format(resY) + " DPI";
         } catch (Exception e) {
             return null;


### PR DESCRIPTION
I'm not sure if this is a good idea, some people might want to use their local decimal separator and others symbols. Take this as a suggestion.

The background is that I took the time to clone ```metadata-extractor-images``` to run some tests. The diffs are however more or less useless, because my locale has different number formatting symbols.

I just threw this together quickly, there are other approaches to this. Relying on the default locale can be tricky in many circumstances though because it can produce very unpredictable results.