### PR TITLE
Small update/follow up to #231

### DIFF
--- a/Source/com/drew/imaging/jpeg/JpegMetadataReader.java
+++ b/Source/com/drew/imaging/jpeg/JpegMetadataReader.java
@@ -33,6 +33,7 @@ import com.drew.metadata.jfif.JfifReader;
 import com.drew.metadata.jfxx.JfxxReader;
 import com.drew.metadata.jpeg.JpegCommentReader;
 import com.drew.metadata.jpeg.JpegDhtReader;
+import com.drew.metadata.jpeg.JpegDnlReader;
 import com.drew.metadata.jpeg.JpegReader;
 import com.drew.metadata.photoshop.DuckyReader;
 import com.drew.metadata.photoshop.PhotoshopReader;
@@ -65,7 +66,8 @@ public class JpegMetadataReader
             new DuckyReader(),
             new IptcReader(),
             new AdobeJpegReader(),
-            new JpegDhtReader()
+            new JpegDhtReader(),
+            new JpegDnlReader()
     );
 
     @NotNull

--- a/Source/com/drew/imaging/jpeg/JpegSegmentType.java
+++ b/Source/com/drew/imaging/jpeg/JpegSegmentType.java
@@ -92,6 +92,18 @@ public enum JpegSegmentType
     /** Define Quantization Table segment identifier. */
     DQT((byte)0xDB, false),
 
+    /** Define Number of Lines segment identifier. */
+    DNL((byte)0xDC, false),
+
+    /** Define Restart Interval segment identifier. */
+    DRI((byte)0xDD, false),
+
+    /** Define Hierarchical Progression segment identifier. */
+    DHP((byte)0xDE, false),
+
+    /** EXPand reference component(s) segment identifier. */
+    EXP((byte)0xDF, false),
+
     /** Define Huffman Table segment identifier. */
     DHT((byte)0xC4, false),
 

--- a/Source/com/drew/metadata/jpeg/HuffmanTablesDirectory.java
+++ b/Source/com/drew/metadata/jpeg/HuffmanTablesDirectory.java
@@ -200,7 +200,7 @@ public class HuffmanTablesDirectory extends Directory {
      *         Huffman tables.
      */
     public boolean isTypical() {
-        if (tables.size() != 4) {
+        if (tables.size() == 0) {
             return false;
         }
         for (HuffmanTable table : tables) {

--- a/Source/com/drew/metadata/jpeg/JpegDnlReader.java
+++ b/Source/com/drew/metadata/jpeg/JpegDnlReader.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2002-2017 Drew Noakes
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ * More information about this project is available at:
+ *
+ *    https://drewnoakes.com/code/exif/
+ *    https://github.com/drewnoakes/metadata-extractor
+ */
+package com.drew.metadata.jpeg;
+
+import com.drew.imaging.jpeg.JpegSegmentMetadataReader;
+import com.drew.imaging.jpeg.JpegSegmentType;
+import com.drew.lang.SequentialByteArrayReader;
+import com.drew.lang.SequentialReader;
+import com.drew.lang.annotations.NotNull;
+import com.drew.metadata.ErrorDirectory;
+import com.drew.metadata.Metadata;
+
+import java.io.IOException;
+import java.util.Arrays;
+
+/**
+ * Decodes JPEG DNL data, adjusting the image height with information missing from the JPEG SOFx segment.
+ *
+ * @author Nadahar
+ */
+public class JpegDnlReader implements JpegSegmentMetadataReader
+{
+    @NotNull
+    public Iterable<JpegSegmentType> getSegmentTypes()
+    {
+        return Arrays.asList(JpegSegmentType.DNL);
+    }
+
+    @NotNull
+    public void readJpegSegments(@NotNull Iterable<byte[]> segments, @NotNull Metadata metadata, @NotNull JpegSegmentType segmentType)
+    {
+        for (byte[] segmentBytes : segments) {
+            extract(segmentBytes, metadata, segmentType);
+        }
+    }
+
+    public void extract(byte[] segmentBytes, Metadata metadata, JpegSegmentType segmentType)
+    {
+        JpegDirectory directory = metadata.getFirstDirectoryOfType(JpegDirectory.class);
+        if (directory == null) {
+            ErrorDirectory errorDirectory = new ErrorDirectory();
+            metadata.addDirectory(errorDirectory);
+            errorDirectory.addError("DNL segment found without SOFx - illegal JPEG format");
+        }
+
+        SequentialReader reader = new SequentialByteArrayReader(segmentBytes);
+
+        try {
+            // Only set height from DNL if it's not already defined
+            Integer i = directory.getInteger(JpegDirectory.TAG_IMAGE_HEIGHT);
+            if (i == null || i.intValue() == 0) {
+                directory.setInt(JpegDirectory.TAG_IMAGE_HEIGHT, reader.getUInt16());
+            }
+        } catch (IOException ex) {
+            directory.addError(ex.getMessage());
+        }
+    }
+}

--- a/Tests/com/drew/metadata/jpeg/HuffmanTablesDirectoryTest.java
+++ b/Tests/com/drew/metadata/jpeg/HuffmanTablesDirectoryTest.java
@@ -25,6 +25,9 @@ import org.junit.Test;
 
 import static org.junit.Assert.*;
 
+import com.drew.metadata.jpeg.HuffmanTablesDirectory.HuffmanTable;
+import com.drew.metadata.jpeg.HuffmanTablesDirectory.HuffmanTable.HuffmanTableClass;
+
 /**
  * @author Nadahar
  */
@@ -62,5 +65,30 @@ public class HuffmanTablesDirectoryTest
         _directory.setInt(HuffmanTablesDirectory.TAG_NUMBER_OF_TABLES, 9);
         assertEquals(9,_directory.getNumberOfTables());
         assertEquals("9 Huffman tables", _directory.getDescription(HuffmanTablesDirectory.TAG_NUMBER_OF_TABLES));
+    }
+
+    @Test
+    public void testIsTypical() throws Exception
+    {
+        _directory.tables.add(new HuffmanTable(
+            HuffmanTableClass.AC,
+            0,
+            HuffmanTablesDirectory.TYPICAL_CHROMINANCE_AC_LENGTHS,
+            HuffmanTablesDirectory.TYPICAL_CHROMINANCE_AC_VALUES
+        ));
+        _directory.tables.add(new HuffmanTable(
+            HuffmanTableClass.DC,
+            0,
+            HuffmanTablesDirectory.TYPICAL_LUMINANCE_DC_LENGTHS,
+            HuffmanTablesDirectory.TYPICAL_LUMINANCE_DC_VALUES
+        ));
+
+        assertTrue(_directory.getTable(0).isTypical());
+        assertFalse(_directory.getTable(0).isOptimized());
+        assertTrue(_directory.getTable(1).isTypical());
+        assertFalse(_directory.getTable(1).isOptimized());
+
+        assertTrue(_directory.isTypical());
+        assertFalse(_directory.isOptimized());
     }
 }


### PR DESCRIPTION
I realized I'd made a couple of mistakes in #231:
* I didn't take into account the stuffing bytes (x00 following a xFF) when reading Huffman tables.
* The requirement for ```isTypical()``` that there had to be 4 Huffman tables is invalid for progressive JPEGs.

I added support for stuffing bytes in ```JpegDhtReader```. I still haven't seen this being used in a Huffman table in any of my tests which is why I didn't think of it earlier.

The requirement for 4 Huffman tables became evident that was wrong when the progressive JPEGs came up - my initial idea was that there the typical tables are 4, thus require the total number to be 4. I still think this might technically be a correct requirement even for progressive, as I can't see why they would need to redefine any of the already defined tables if they are the same. But, I can't say 100% sure that this logic holds water. In any case, the way the current ```JpegSegmentReader``` works it is wrong, as only some of the total number of Huffman tables will be read for progressive JPEGs. I've therefore come to the conclusion that the correct thing to do is to remove this requirement.

While I was at it studying the standard, I added some additional JPEG segment definitions: DNL, DRI, DHP and EXP. I guess it doesn't hurt to have  them defined. In addition I've implemented support for DNL in ```JpegReader```. The diff seems like there's a lot of changes there, but that's just due to indentation. The change is really quite minor.

The way DNL works is that it is allowed as per the standard to give an image height of ```0``` in the SOFx header. If the height is 0 however, a DNL segment is required after the first SOS block. The DNL segment simply defines the image height. This doesn't seem like a very widely used feature, I had to do some searching to find a JPEG featuring this, and neither Windows image preview not Photoshop will open the file (Photoshop states that DNL isn't supported). It is still a part of the standard though, so I figured it couldn't hurt to parse it correctly. 

With the current  ```JpegSegmentReader``` the DNL segment will never be found. To be able to test this, and reading of Huffman tables in progressive JPEGs I temporarily replaced 
```java
            if (segmentType == SEGMENT_SOS) {
                // The 'Start-Of-Scan' segment's length doesn't include the image data, instead would
                // have to search for the two bytes: 0xFF 0xD9 (EOI).
                // It comes last so simply return at this point
                return segmentData;
            }
```
with
```java
            if (segmentType == SEGMENT_SOS) {
                // The 'Start-Of-Scan' segment's length doesn't include the image data, instead would
                // have to search for the two bytes: 0xFF 0xD9 (EOI).
                // It comes last so simply return at this point
                continue;
            }
```
That's all it takes to make the current segment reader read the whole file, but I haven't committed that change because of the performance impact it will have. But, it allwed me to test that this code works correctly when all segments are read, and it does. The code should therefore need no changes if the segment reader is replaced.

I have the image featuring DNL that I managed to dig up. I didn't include it in this PR as it's not possible to test DNL with the current segment reader. I still feel that this image should be kept somehow. Manybe I should upload it to the images repo? If so, how do I name it?

This code is tested with the images repo and there's no difference from the current master in the output.