### PR TITLE
Move JpegComponent description

### DIFF
--- a/Source/com/drew/metadata/jpeg/JpegComponent.java
+++ b/Source/com/drew/metadata/jpeg/JpegComponent.java
@@ -88,4 +88,15 @@ public class JpegComponent implements Serializable
     {
         return _samplingFactorByte & 0x0F;
     }
+
+    @NotNull
+    @Override
+    public String toString() {
+        return String.format(
+            "Quantization table %d, Sampling factors %d horiz/%d vert",
+            _quantizationTableNumber,
+            getHorizontalSamplingFactor(),
+            getVerticalSamplingFactor()
+        );
+    }
 }

--- a/Source/com/drew/metadata/jpeg/JpegDescriptor.java
+++ b/Source/com/drew/metadata/jpeg/JpegDescriptor.java
@@ -124,8 +124,6 @@ public class JpegDescriptor extends TagDescriptor<JpegDirectory>
         if (value==null)
             return null;
 
-        return value.getComponentName() + " component: Quantization table " + value.getQuantizationTableNumber()
-            + ", Sampling factors " + value.getHorizontalSamplingFactor()
-            + " horiz/" + value.getVerticalSamplingFactor() + " vert";
+        return value.getComponentName() + " component: " + value;
     }
 }


### PR DESCRIPTION
This is really minor, but every time I run a test against the images repo, I get a diff on ```eddea4ef9629be031f750a8ff0b7497c.jpg``` because ```JpegComponent``` is printed in the form ```com.drew.metadata.jpeg.JpegComponent@25586e1e```. The array address is always different for obvious reasons, and thus the diff. 

By moving the "textual representation generation" to ```JpegComponent.toString()``` it will work in this instance as well, eliminating that pesky diff.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/drewnoakes/metadata-extractor/235)
<!-- Reviewable:end -->
