### PR TITLE
Fix "signed byte" bug introduced in #234

### DIFF
--- a/Source/com/drew/metadata/jpeg/JpegDhtReader.java
+++ b/Source/com/drew/metadata/jpeg/JpegDhtReader.java
@@ -88,7 +88,7 @@ public class JpegDhtReader implements JpegSegmentMetadataReader
         byte[] bytes = new byte[count];
         for (int i = 0; i < count; i++) {
             byte b = reader.getByte();
-            if (b == 0xFF) {
+            if ((b & 0xFF) == 0xFF) {
                 byte stuffing = reader.getByte();
                 if (stuffing != 0x00) {
                     throw new IOException("Marker " + JpegSegmentType.fromByte(stuffing) + " found inside DHT segment");


### PR DESCRIPTION
I made a serious error in e9daa3df94e820af8885f78f3404ef8d814f59d5. I must admit that I didn't know that Java defined byte as "signed" - to me that is such a strange concept that I've never even considered it. I've seen the negative "byte" values in the debugger, but I've assumed it was simply a display issue.

It seems ```short``` is the way to go when comparing "byte" values in Java, but I've kept it as a byte here since it's being put into a byte array after comparison. I've run regressions tests and there is no diff, as this code only makes a difference if a Huffman table entry has a ```xFF``` value - which I haven't seen yet.