### PR TITLE
Full parsing of GIF Graphics Control Extension

### DIFF
--- a/Source/com/drew/metadata/gif/GifControlDirectory.java
+++ b/Source/com/drew/metadata/gif/GifControlDirectory.java
@@ -33,6 +33,10 @@ import java.util.HashMap;
 public class GifControlDirectory extends Directory
 {
     public static final int TAG_DELAY = 1;
+    public static final int TAG_DISPOSAL_METHOD = 2;
+    public static final int TAG_USER_INPUT_FLAG = 3;
+    public static final int TAG_TRANSPARENT_COLOR_FLAG = 4;
+    public static final int TAG_TRANSPARENT_COLOR_INDEX = 5;
 
     @NotNull
     protected static final HashMap<Integer, String> _tagNameMap = new HashMap<Integer, String>();
@@ -40,6 +44,10 @@ public class GifControlDirectory extends Directory
     static
     {
         _tagNameMap.put(TAG_DELAY, "Delay");
+        _tagNameMap.put(TAG_DISPOSAL_METHOD, "Disposal Method");
+        _tagNameMap.put(TAG_USER_INPUT_FLAG, "User Input Flag");
+        _tagNameMap.put(TAG_TRANSPARENT_COLOR_FLAG, "Transparent Color Flag");
+        _tagNameMap.put(TAG_TRANSPARENT_COLOR_INDEX, "Transparent Color Index");
     }
 
     public GifControlDirectory()
@@ -54,10 +62,73 @@ public class GifControlDirectory extends Directory
         return "GIF Control";
     }
 
+    /**
+     * @return The {@link DisposalMethod}.
+     */
+    @NotNull
+    public DisposalMethod getDisposalMethod() {
+        return (DisposalMethod) getObject(TAG_DISPOSAL_METHOD);
+    }
+
+    /**
+     * @return Whether the GIF has transparency.
+     */
+    public boolean isTransparent() {
+        Boolean transparent = getBooleanObject(TAG_TRANSPARENT_COLOR_FLAG);
+        return transparent != null ? transparent.booleanValue() : false;
+    }
+
     @Override
     @NotNull
     protected HashMap<Integer, String> getTagNameMap()
     {
         return _tagNameMap;
+    }
+
+    /**
+     * Disposal method indicates the way in which the graphic is to be treated
+     * after being displayed.
+     */
+    public enum DisposalMethod {
+        NOT_SPECIFIED,
+        DO_NOT_DISPOSE,
+        RESTORE_TO_BACKGROUND_COLOR,
+        RESTORE_TO_PREVIOUS,
+        TO_BE_DEFINED,
+        INVALID;
+
+        public static DisposalMethod typeOf(int value) {
+            switch (value) {
+                case 0: return NOT_SPECIFIED;
+                case 1: return DO_NOT_DISPOSE;
+                case 2: return RESTORE_TO_BACKGROUND_COLOR;
+                case 3: return RESTORE_TO_PREVIOUS;
+                case 4:
+                case 5:
+                case 6:
+                case 7: return TO_BE_DEFINED;
+                default: return INVALID;
+            }
+        }
+
+        @Override
+        public String toString() {
+            switch (this) {
+                case DO_NOT_DISPOSE:
+                    return "Don't Dispose";
+                case INVALID:
+                    return "Invalid value";
+                case NOT_SPECIFIED:
+                    return "Not Specified";
+                case RESTORE_TO_BACKGROUND_COLOR:
+                    return "Restore to Background Color";
+                case RESTORE_TO_PREVIOUS:
+                    return "Restore to Previous";
+                case TO_BE_DEFINED:
+                    return "To Be Defined";
+                default:
+                    return super.toString();
+            }
+        }
     }
 }

--- a/Source/com/drew/metadata/gif/GifReader.java
+++ b/Source/com/drew/metadata/gif/GifReader.java
@@ -30,6 +30,7 @@ import com.drew.metadata.Directory;
 import com.drew.metadata.ErrorDirectory;
 import com.drew.metadata.Metadata;
 import com.drew.metadata.StringValue;
+import com.drew.metadata.gif.GifControlDirectory.DisposalMethod;
 import com.drew.metadata.icc.IccReader;
 import com.drew.metadata.xmp.XmpReader;
 
@@ -298,15 +299,15 @@ public class GifReader
 
         GifControlDirectory directory = new GifControlDirectory();
 
-        reader.skip(1);
-
+        short packedFields = reader.getUInt8();
+        directory.setObject(GifControlDirectory.TAG_DISPOSAL_METHOD, DisposalMethod.typeOf((packedFields >> 2) & 7));
+        directory.setBoolean(GifControlDirectory.TAG_USER_INPUT_FLAG, (packedFields & 2) >> 1 == 1 ? true : false);
+        directory.setBoolean(GifControlDirectory.TAG_TRANSPARENT_COLOR_FLAG, (packedFields & 1) == 1 ? true : false);
         directory.setInt(GifControlDirectory.TAG_DELAY, reader.getUInt16());
-
-        if (blockSizeBytes > 3)
-            reader.skip(blockSizeBytes - 3);
+        directory.setInt(GifControlDirectory.TAG_TRANSPARENT_COLOR_INDEX, reader.getUInt8());
 
         // skip 0x0 block terminator
-        reader.getByte();
+        reader.skip(1);
 
         return directory;
     }


### PR DESCRIPTION
I need to check if GIF's have transparency or not, and found that the key to this is in the "Graphics Control Extension". The flag I need isn't parsed though, so I implemented parsing of the rest of the information found in this block.

I've run it against the "images" repo, and the results look reasonable.
