### PR TITLE
Fix another "signed byte" bug introduced in #234

### DIFF
--- a/Source/com/drew/metadata/jpeg/JpegDhtReader.java
+++ b/Source/com/drew/metadata/jpeg/JpegDhtReader.java
@@ -72,7 +72,7 @@ public class JpegDhtReader implements JpegSegmentMetadataReader
                 byte[] lBytes = getBytes(reader, 16);
                 int vCount = 0;
                 for (byte b : lBytes) {
-                    vCount += b;
+                    vCount += (b & 0xFF);
                 }
                 byte[] vBytes = getBytes(reader, vCount);
                 directory.getTables().add(new HuffmanTable(tableClass, tableDestinationId, lBytes, vBytes));


### PR DESCRIPTION
This fixes the bug reported in #242. I've tested it against the [submitted image](https://cloud.githubusercontent.com/assets/8233283/22927412/14b497d2-f2ec-11e6-80ea-605318beaa16.jpg) and it now parses correctly. I've also tested it with no diffs against the images repository.

I'm really sorry for this, I've looked through it and I can't see any more of these now. It's extra bad that a release took place with this bug in it.

