### PR TITLE
Extend BMP support

### DIFF
--- a/Source/com/drew/imaging/FileTypeDetector.java
+++ b/Source/com/drew/imaging/FileTypeDetector.java
@@ -45,7 +45,12 @@ public class FileTypeDetector
         _root.addPath(FileType.Tiff, "MM".getBytes(), new byte[]{0x00, 0x2a});
         _root.addPath(FileType.Psd, "8BPS".getBytes());
         _root.addPath(FileType.Png, new byte[]{(byte)0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, 0x00, 0x00, 0x00, 0x0D, 0x49, 0x48, 0x44, 0x52});
-        _root.addPath(FileType.Bmp, "BM".getBytes()); // TODO technically there are other very rare magic numbers for OS/2 BMP files...
+        _root.addPath(FileType.Bmp, "BM".getBytes()); // Standard Bitmap Windows and OS/2
+        _root.addPath(FileType.Bmp, "BA".getBytes()); // OS/2 Bitmap Array
+        _root.addPath(FileType.Bmp, "CI".getBytes()); // OS/2 Color Icon
+        _root.addPath(FileType.Bmp, "CP".getBytes()); // OS/2 Color Pointer
+        _root.addPath(FileType.Bmp, "IC".getBytes()); // OS/2 Icon
+        _root.addPath(FileType.Bmp, "PT".getBytes()); // OS/2 Pointer
         _root.addPath(FileType.Gif, "GIF87a".getBytes());
         _root.addPath(FileType.Gif, "GIF89a".getBytes());
         _root.addPath(FileType.Ico, new byte[]{0x00, 0x00, 0x01, 0x00});

--- a/Source/com/drew/lang/Charsets.java
+++ b/Source/com/drew/lang/Charsets.java
@@ -37,4 +37,5 @@ public final class Charsets
     public static final Charset ASCII = Charset.forName("US-ASCII");
     public static final Charset UTF_16BE = Charset.forName("UTF-16BE");
     public static final Charset UTF_16LE = Charset.forName("UTF-16LE");
+    public static final Charset WINDOWS_1252 = Charset.forName("Cp1252");
 }

--- a/Source/com/drew/metadata/bmp/BmpHeaderDescriptor.java
+++ b/Source/com/drew/metadata/bmp/BmpHeaderDescriptor.java
@@ -24,10 +24,13 @@ import com.drew.lang.annotations.NotNull;
 import com.drew.lang.annotations.Nullable;
 import com.drew.metadata.TagDescriptor;
 
+import java.text.DecimalFormat;
+
 import static com.drew.metadata.bmp.BmpHeaderDirectory.*;
 
 /**
  * @author Drew Noakes https://drewnoakes.com
+ * @author Nadahar
  */
 @SuppressWarnings("WeakerAccess")
 public class BmpHeaderDescriptor extends TagDescriptor<BmpHeaderDirectory>
@@ -41,44 +44,127 @@ public class BmpHeaderDescriptor extends TagDescriptor<BmpHeaderDirectory>
     public String getDescription(int tagType)
     {
         switch (tagType) {
+            case TAG_BITMAP_TYPE:
+                return getBitmapTypeDescription();
             case TAG_COMPRESSION:
                 return getCompressionDescription();
+            case TAG_RENDERING:
+                return getRenderingDescription();
+            case TAG_COLOR_ENCODING:
+                return getColorEncodingDescription();
+            case TAG_RED_MASK:
+            case TAG_GREEN_MASK:
+            case TAG_BLUE_MASK:
+            case TAG_ALPHA_MASK:
+                return formatHex(_directory.getLongObject(tagType), 8);
+            case TAG_COLOR_SPACE_TYPE:
+                return getColorSpaceTypeDescription();
+            case TAG_GAMMA_RED:
+            case TAG_GAMMA_GREEN:
+            case TAG_GAMMA_BLUE:
+                return formatFixed1616(_directory.getLongObject(tagType));
+            case TAG_INTENT:
+                return getRenderingIntentDescription();
             default:
                 return super.getDescription(tagType);
         }
     }
 
     @Nullable
+    public String getBitmapTypeDescription()
+    {
+        BitmapType bitmapType = _directory.getBitmapType();
+        return bitmapType == null ? null : bitmapType.toString();
+    }
+
+    @Nullable
     public String getCompressionDescription()
     {
-        // 0 = None
-        // 1 = RLE 8-bit/pixel
-        // 2 = RLE 4-bit/pixel
-        // 3 = Bit field (or Huffman 1D if BITMAPCOREHEADER2 (size 64))
-        // 4 = JPEG (or RLE-24 if BITMAPCOREHEADER2 (size 64))
-        // 5 = PNG
-        // 6 = Bit field
-        try {
-            Integer value = _directory.getInteger(TAG_COMPRESSION);
-            if (value == null)
-                return null;
-            Integer headerSize = _directory.getInteger(TAG_HEADER_SIZE);
-            if (headerSize == null)
-                return null;
+        //  0 = None
+        //  1 = RLE 8-bit/pixel
+        //  2 = RLE 4-bit/pixel
+        //  3 = Bit fields (or Huffman 1D if OS22XBITMAPHEADER (size 64))
+        //  4 = JPEG (or RLE 24-bit/pixel if OS22XBITMAPHEADER (size 64))
+        //  5 = PNG
+        // 11 = CMYK
+        // 12 = CMYK RLE-8
+        // 13 = CMYK RLE-4
 
-            switch (value) {
-                case 0: return "None";
-                case 1: return "RLE 8-bit/pixel";
-                case 2: return "RLE 4-bit/pixel";
-                case 3: return headerSize == 64 ? "Bit field" : "Huffman 1D";
-                case 4: return headerSize == 64 ? "JPEG" : "RLE-24";
-                case 5: return "PNG";
-                case 6: return "Bit field";
-                default:
-                    return super.getDescription(TAG_COMPRESSION);
-            }
-        } catch (Exception e) {
-            return null;
+        Compression compression = _directory.getCompression();
+        if (compression != null) {
+            return compression.toString();
         }
+        Integer value = _directory.getInteger(TAG_COMPRESSION);
+        return value == null ? null : "Illegal value 0x" + Integer.toHexString(value.intValue());
+    }
+
+    @Nullable
+    public String getRenderingDescription()
+    {
+        RenderingHalftoningAlgorithm renderingHalftoningAlgorithm = _directory.getRendering();
+        return renderingHalftoningAlgorithm == null ? null : renderingHalftoningAlgorithm.toString();
+    }
+
+    @Nullable
+    public String getColorEncodingDescription()
+    {
+        ColorEncoding colorEncoding = _directory.getColorEncoding();
+        return colorEncoding == null ? null : colorEncoding.toString();
+    }
+
+    @Nullable
+    public String getColorSpaceTypeDescription()
+    {
+        ColorSpaceType colorSpaceType = _directory.getColorSpaceType();
+        return colorSpaceType == null ? null : colorSpaceType.toString();
+    }
+
+    @Nullable
+    public String getRenderingIntentDescription()
+    {
+        RenderingIntent renderingIntent = _directory.getRenderingIntent();
+        return renderingIntent == null ? null : renderingIntent.toString();
+    }
+
+    @Nullable
+    public static String formatHex(@Nullable Integer value, int digits) {
+        return value == null ? null : formatHex(value.intValue() & 0xFFFFFFFFL, digits);
+    }
+
+    @NotNull
+    public static String formatHex(int value, int digits) {
+        return formatHex(value & 0xFFFFFFFFL, digits);
+    }
+
+    @Nullable
+    public static String formatHex(@Nullable Long value, int digits) {
+        return value == null ? null : formatHex(value.longValue(), digits);
+    }
+
+    @NotNull
+    public static String formatHex(long value, int digits) {
+        return String.format("0x%0"+ digits + "X", value);
+    }
+
+    @Nullable
+    public static String formatFixed1616(Integer value) {
+        return value == null ? null : formatFixed1616(value.intValue() & 0xFFFFFFFFL);
+    }
+
+    @NotNull
+    public static String formatFixed1616(int value) {
+        return formatFixed1616(value & 0xFFFFFFFFL);
+    }
+
+    @Nullable
+    public static String formatFixed1616(Long value) {
+        return value == null ? null : formatFixed1616(value.longValue());
+    }
+
+    @NotNull
+    public static String formatFixed1616(long value) {
+        Double d = (double) value / 0x10000;
+        DecimalFormat format = new DecimalFormat("0.###");
+        return format.format(d);
     }
 }

--- a/Source/com/drew/metadata/bmp/BmpHeaderDirectory.java
+++ b/Source/com/drew/metadata/bmp/BmpHeaderDirectory.java
@@ -21,16 +21,19 @@
 package com.drew.metadata.bmp;
 
 import com.drew.lang.annotations.NotNull;
+import com.drew.lang.annotations.Nullable;
 import com.drew.metadata.Directory;
 
 import java.util.HashMap;
 
 /**
  * @author Drew Noakes https://drewnoakes.com
+ * @author Nadahar
  */
 @SuppressWarnings("WeakerAccess")
 public class BmpHeaderDirectory extends Directory
 {
+    public static final int TAG_BITMAP_TYPE = -2;
     public static final int TAG_HEADER_SIZE = -1;
 
     public static final int TAG_IMAGE_HEIGHT = 1;
@@ -42,11 +45,24 @@ public class BmpHeaderDirectory extends Directory
     public static final int TAG_Y_PIXELS_PER_METER = 7;
     public static final int TAG_PALETTE_COLOUR_COUNT = 8;
     public static final int TAG_IMPORTANT_COLOUR_COUNT = 9;
+    public static final int TAG_RENDERING = 10;
+    public static final int TAG_COLOR_ENCODING = 11;
+    public static final int TAG_RED_MASK = 12;
+    public static final int TAG_GREEN_MASK = 13;
+    public static final int TAG_BLUE_MASK = 14;
+    public static final int TAG_ALPHA_MASK = 15;
+    public static final int TAG_COLOR_SPACE_TYPE = 16;
+    public static final int TAG_GAMMA_RED = 17;
+    public static final int TAG_GAMMA_GREEN = 18;
+    public static final int TAG_GAMMA_BLUE = 19;
+    public static final int TAG_INTENT = 20;
+    public static final int TAG_LINKED_PROFILE = 21;
 
     @NotNull
     protected static final HashMap<Integer, String> _tagNameMap = new HashMap<Integer, String>();
 
     static {
+        _tagNameMap.put(TAG_BITMAP_TYPE, "Bitmap type");
         _tagNameMap.put(TAG_HEADER_SIZE, "Header Size");
 
         _tagNameMap.put(TAG_IMAGE_HEIGHT, "Image Height");
@@ -58,11 +74,58 @@ public class BmpHeaderDirectory extends Directory
         _tagNameMap.put(TAG_Y_PIXELS_PER_METER, "Y Pixels per Meter");
         _tagNameMap.put(TAG_PALETTE_COLOUR_COUNT, "Palette Colour Count");
         _tagNameMap.put(TAG_IMPORTANT_COLOUR_COUNT, "Important Colour Count");
+        _tagNameMap.put(TAG_RENDERING, "Rendering");
+        _tagNameMap.put(TAG_COLOR_ENCODING, "Color Encoding");
+        _tagNameMap.put(TAG_RED_MASK, "Red Mask");
+        _tagNameMap.put(TAG_GREEN_MASK, "Green Mask");
+        _tagNameMap.put(TAG_BLUE_MASK, "Blue Mask");
+        _tagNameMap.put(TAG_ALPHA_MASK, "Alpha Mask");
+        _tagNameMap.put(TAG_COLOR_SPACE_TYPE, "Color Space Type");
+        _tagNameMap.put(TAG_GAMMA_RED, "Red Gamma Curve");
+        _tagNameMap.put(TAG_GAMMA_GREEN, "Green Gamma Curve");
+        _tagNameMap.put(TAG_GAMMA_BLUE, "Blue Gamma Curve");
+        _tagNameMap.put(TAG_INTENT, "Rendering Intent");
+        _tagNameMap.put(TAG_LINKED_PROFILE, "Linked Profile File Name");
     }
 
     public BmpHeaderDirectory()
     {
         this.setDescriptor(new BmpHeaderDescriptor(this));
+    }
+
+    @Nullable
+    public BitmapType getBitmapType() {
+        Integer value = getInteger(TAG_BITMAP_TYPE);
+        return value == null ? null : BitmapType.typeOf(value.intValue());
+    }
+
+    @Nullable
+    public Compression getCompression() {
+        return Compression.typeOf(this);
+    }
+
+    @Nullable
+    public RenderingHalftoningAlgorithm getRendering() {
+        Integer value = getInteger(TAG_RENDERING);
+        return value == null ? null : RenderingHalftoningAlgorithm.typeOf(value.intValue());
+    }
+
+    @Nullable
+    public ColorEncoding getColorEncoding() {
+        Integer value = getInteger(TAG_COLOR_ENCODING);
+        return value == null ? null : ColorEncoding.typeOf(value.intValue());
+    }
+
+    @Nullable
+    public ColorSpaceType getColorSpaceType() {
+        Long value = getLongObject(TAG_COLOR_SPACE_TYPE);
+        return value == null ? null : ColorSpaceType.typeOf(value.longValue());
+    }
+
+    @Nullable
+    public RenderingIntent getRenderingIntent() {
+        Integer value = getInteger(TAG_INTENT);
+        return value == null ? null : RenderingIntent.typeOf(value.intValue());
     }
 
     @Override
@@ -77,5 +140,348 @@ public class BmpHeaderDirectory extends Directory
     protected HashMap<Integer, String> getTagNameMap()
     {
         return _tagNameMap;
+    }
+
+    public enum BitmapType {
+
+           /** "BM" - Windows or OS/2 bitmap */
+        BITMAP(0x4D42),
+
+        /** "BA" - OS/2 Bitmap array (multiple bitmaps) */
+        OS2_BITMAP_ARRAY(0x4142),
+
+            /** "IC" - OS/2 Icon */
+        OS2_ICON(0x4349),
+
+            /** "CI" - OS/2 Color icon */
+        OS2_COLOR_ICON(0x4943),
+
+        /** "CP" - OS/2 Color pointer */
+        OS2_COLOR_POINTER(0x5043),
+
+            /** "PT" - OS/2 Pointer */
+        OS2_POINTER(0x5450);
+
+        private final int value;
+
+        private BitmapType(int value) {
+            this.value = value;
+        }
+
+        public int getValue() {
+            return value;
+        }
+
+        @Nullable
+        public static BitmapType typeOf(int value) {
+            for (BitmapType bitmapType : BitmapType.values())
+            {
+                if (bitmapType.value == value)
+                {
+                    return bitmapType;
+                }
+            }
+            return null;
+        }
+
+        @Override
+        @NotNull
+        public String toString() {
+            switch (this) {
+                case BITMAP: return "Standard";
+                case OS2_BITMAP_ARRAY: return "Bitmap Array";
+                case OS2_COLOR_ICON: return "Color Icon";
+                case OS2_COLOR_POINTER: return "Color Pointer";
+                case OS2_ICON: return "Monochrome Icon";
+                case OS2_POINTER: return "Monochrome Pointer";
+                default:
+                    throw new IllegalStateException("Unimplemented bitmap type " + super.toString());
+            }
+        }
+    }
+
+    public enum Compression {
+
+        /** 0 = None */
+        BI_RGB(0),
+
+        /** 1 = RLE 8-bit/pixel */
+        BI_RLE8(1),
+
+        /** 2 = RLE 4-bit/pixel */
+        BI_RLE4(2),
+
+        /** 3 = Bit fields (not OS22XBITMAPHEADER (size 64)) */
+        BI_BITFIELDS(3),
+
+        /** 3 = Huffman 1D (if OS22XBITMAPHEADER (size 64)) */
+        BI_HUFFMAN_1D(3),
+
+        /** 4 = JPEG (not OS22XBITMAPHEADER (size 64)) */
+        BI_JPEG(4),
+
+        /** 4 = RLE 24-bit/pixel (if OS22XBITMAPHEADER (size 64)) */
+        BI_RLE24(4),
+
+        /** 5 = PNG */
+        BI_PNG(5),
+
+        /** 6 = RGBA bit fields */
+        BI_ALPHABITFIELDS(6),
+
+        /** 11 = CMYK */
+        BI_CMYK(11),
+
+        /** 12 = CMYK RLE-8 */
+        BI_CMYKRLE8(12),
+
+        /** 13 = CMYK RLE-4 */
+        BI_CMYKRLE4(13);
+
+        private final int value;
+
+        private Compression(int value) {
+            this.value = value;
+        }
+
+        public int getValue() {
+            return value;
+        }
+
+        @Nullable
+        public static Compression typeOf(@NotNull BmpHeaderDirectory directory) {
+            Integer value = directory.getInteger(TAG_COMPRESSION);
+            if (value == null)
+                return null;
+            Integer headerSize = directory.getInteger(TAG_HEADER_SIZE);
+            if (headerSize == null)
+                return null;
+
+            return typeOf(value, headerSize);
+        }
+
+        @Nullable
+        public static Compression typeOf(int value, int headerSize) {
+            switch (value) {
+                case 0:  return BI_RGB;
+                case 1:  return BI_RLE8;
+                case 2:  return BI_RLE4;
+                case 3:  return headerSize == 64 ? BI_HUFFMAN_1D : BI_BITFIELDS;
+                case 4:  return headerSize == 64 ? BI_RLE24 : BI_JPEG;
+                case 5:  return BI_PNG;
+                case 6:  return BI_ALPHABITFIELDS;
+                case 11: return BI_CMYK;
+                case 12: return BI_CMYKRLE8;
+                case 13: return BI_CMYKRLE4;
+                default: return null;
+            }
+        }
+
+        @Override
+        @NotNull
+        public String toString() {
+            switch (this) {
+                case BI_RGB:            return "None";
+                case BI_RLE8:           return "RLE 8-bit/pixel";
+                case BI_RLE4:           return "RLE 4-bit/pixel";
+                case BI_BITFIELDS:      return "Bit Fields";
+                case BI_HUFFMAN_1D:     return "Huffman 1D";
+                case BI_JPEG:           return "JPEG";
+                case BI_RLE24:          return "RLE 24-bit/pixel";
+                case BI_PNG:            return "PNG";
+                case BI_ALPHABITFIELDS: return "RGBA Bit Fields";
+                case BI_CMYK:           return "CMYK Uncompressed";
+                case BI_CMYKRLE8:       return "CMYK RLE-8";
+                case BI_CMYKRLE4:       return "CMYK RLE-4";
+                default:
+                    throw new IllegalStateException("Unimplemented compression type " + super.toString());
+            }
+        }
+    }
+
+    public enum RenderingHalftoningAlgorithm {
+
+        /** No halftoning algorithm */
+        NONE(0),
+
+        /** Error Diffusion Halftoning */
+        ERROR_DIFFUSION(1),
+
+        /** Processing Algorithm for Noncoded Document Acquisition */
+        PANDA(2),
+
+        /** Super-circle Halftoning */
+        SUPER_CIRCLE(3);
+
+        private final int value;
+
+        private RenderingHalftoningAlgorithm(int value) {
+            this.value = value;
+        }
+
+        public int getValue() {
+            return value;
+        }
+
+        @Nullable
+        public static RenderingHalftoningAlgorithm typeOf(int value) {
+            for (RenderingHalftoningAlgorithm renderingHalftoningAlgorithm : RenderingHalftoningAlgorithm.values())
+            {
+                if (renderingHalftoningAlgorithm.value == value)
+                {
+                    return renderingHalftoningAlgorithm;
+                }
+            }
+            return null;
+        }
+
+        @Override
+        @NotNull
+        public String toString() {
+            switch (this) {
+                case NONE:
+                    return "No Halftoning Algorithm";
+                case ERROR_DIFFUSION:
+                    return "Error Diffusion Halftoning";
+                case PANDA:
+                    return "Processing Algorithm for Noncoded Document Acquisition";
+                case SUPER_CIRCLE:
+                    return "Super-circle Halftoning";
+                default:
+                    throw new IllegalStateException("Unimplemented rendering halftoning algorithm type " + super.toString());
+            }
+        }
+    }
+
+    public enum ColorEncoding {
+        RGB(0);
+
+        private final int value;
+
+        private ColorEncoding(int value) {
+            this.value = value;
+        }
+
+        public int getValue() {
+            return value;
+        }
+
+        @Nullable
+        public static ColorEncoding typeOf(int value) {
+            return value == 0 ? RGB : null;
+        }
+    }
+
+    public enum ColorSpaceType {
+
+        /** 0 = Calibrated RGB */
+        LCS_CALIBRATED_RGB(0L),
+
+        /** "sRGB" = sRGB Color Space */
+        LCS_sRGB(0x73524742L),
+
+        /** "Win " = System Default Color Space, sRGB */
+        LCS_WINDOWS_COLOR_SPACE(0x57696E20L),
+
+        /** "LINK" = Linked Profile */
+        PROFILE_LINKED(0x4C494E4BL),
+
+        /** "MBED" = Embedded Profile */
+        PROFILE_EMBEDDED(0x4D424544L);
+
+        private final long value;
+
+        private ColorSpaceType(long value) {
+            this.value = value;
+        }
+
+        public long getValue() {
+            return value;
+        }
+
+        @Nullable
+        public static ColorSpaceType typeOf(long value) {
+            for (ColorSpaceType colorSpaceType : ColorSpaceType.values())
+            {
+                if (colorSpaceType.value == value)
+                {
+                    return colorSpaceType;
+                }
+            }
+            return null;
+        }
+
+        @Override
+        @NotNull
+        public String toString() {
+            switch (this) {
+                case LCS_CALIBRATED_RGB:
+                    return "Calibrated RGB";
+                case LCS_sRGB:
+                    return "sRGB Color Space";
+                case LCS_WINDOWS_COLOR_SPACE:
+                    return "System Default Color Space, sRGB";
+                case PROFILE_LINKED:
+                    return "Linked Profile";
+                case PROFILE_EMBEDDED:
+                    return "Embedded Profile";
+                default:
+                    throw new IllegalStateException("Unimplemented color space type " + super.toString());
+            }
+        }
+    }
+
+    public enum RenderingIntent {
+
+        /** Graphic, Saturation */
+        LCS_GM_BUSINESS(1),
+
+        /** Proof, Relative Colorimetric */
+        LCS_GM_GRAPHICS(2),
+
+        /** Picture, Perceptual */
+        LCS_GM_IMAGES(4),
+
+        /** Match, Absolute Colorimetric */
+        LCS_GM_ABS_COLORIMETRIC(8);
+
+        private final int value;
+
+        private RenderingIntent(int value) {
+            this.value = value;
+        }
+
+        public int getValue() {
+            return value;
+        }
+
+        @Nullable
+        public static RenderingIntent typeOf(long value) {
+            for (RenderingIntent renderingIntent : RenderingIntent.values())
+            {
+                if (renderingIntent.value == value)
+                {
+                    return renderingIntent;
+                }
+            }
+            return null;
+        }
+
+        @Override
+        @NotNull
+        public String toString() {
+            switch (this) {
+                case LCS_GM_BUSINESS:
+                    return "Graphic, Saturation";
+                case LCS_GM_GRAPHICS:
+                    return "Proof, Relative Colorimetric";
+                case LCS_GM_IMAGES:
+                    return "Picture, Perceptual";
+                case LCS_GM_ABS_COLORIMETRIC:
+                    return "Match, Absolute Colorimetric";
+                default:
+                    throw new IllegalStateException("Unimplemented rendering intent " + super.toString());
+            }
+        }
     }
 }

--- a/Source/com/drew/metadata/bmp/BmpReader.java
+++ b/Source/com/drew/metadata/bmp/BmpReader.java
@@ -20,92 +20,315 @@
  */
 package com.drew.metadata.bmp;
 
+import com.drew.lang.ByteArrayReader;
+import com.drew.lang.Charsets;
 import com.drew.lang.SequentialReader;
 import com.drew.lang.annotations.NotNull;
+import com.drew.metadata.Directory;
+import com.drew.metadata.ErrorDirectory;
 import com.drew.metadata.Metadata;
+import com.drew.metadata.MetadataException;
+import com.drew.metadata.bmp.BmpHeaderDirectory.ColorSpaceType;
+import com.drew.metadata.icc.IccReader;
 
 import java.io.IOException;
 
 /**
+ * Reader for Windows and OS/2 bitmap files.
+ * <p>
+ * References:
+ * <ul>
+ *   <li><a href="https://web.archive.org/web/20170302205626/http://fileformats.archiveteam.org/wiki/BMP">Fileformats Wiki BMP overview</a></li>
+ *   <li><a href="http://web.archive.org/web/20170303000822/http://netghost.narod.ru/gff/graphics/summary/micbmp.htm">Graphics File Formats encyclopedia Windows bitmap description</a></li>
+ *   <li><a href="https://web.archive.org/web/20170302205330/http://netghost.narod.ru/gff/graphics/summary/os2bmp.htm">Graphics File Formats encyclopedia OS/2 bitmap description</a></li>
+ *   <li><a href="https://web.archive.org/web/20170302205457/http://www.fileformat.info/format/os2bmp/spec/902d5c253f2a43ada39c2b81034f27fd/view.htm">OS/2 bitmap specification</a></li>
+ *   <li><a href="https://msdn.microsoft.com/en-us/library/dd183392(v=vs.85).aspx">Microsoft Bitmap Structures</a></li>
+ * </ul>
+ *
  * @author Drew Noakes https://drewnoakes.com
+ * @author Nadahar
  */
 public class BmpReader
 {
+    // Possible "magic bytes" indicating bitmap type:
+    /**
+     * "BM" - Windows or OS/2 bitmap
+     */
+    public static final int BITMAP = 0x4D42;
+    /**
+     * "BA" - OS/2 Bitmap array (multiple bitmaps)
+     */
+    public static final int OS2_BITMAP_ARRAY = 0x4142;
+    /**
+     * "IC" - OS/2 Icon
+     */
+    public static final int OS2_ICON = 0x4349;
+    /**
+     * "CI" - OS/2 Color icon
+     */
+    public static final int OS2_COLOR_ICON = 0x4943;
+    /**
+     * "CP" - OS/2 Color pointer
+     */
+    public static final int OS2_COLOR_POINTER = 0x5043;
+    /**
+     * "PT" - OS/2 Pointer
+     */
+    public static final int OS2_POINTER = 0x5450;
+
     public void extract(@NotNull final SequentialReader reader, final @NotNull Metadata metadata)
     {
-        BmpHeaderDirectory directory = new BmpHeaderDirectory();
-        metadata.addDirectory(directory);
+        reader.setMotorolaByteOrder(false);
 
-        // FILE HEADER
-        //
-        // 2 - magic number (0x42 0x4D = "BM")
-        // 4 - size of BMP file in bytes
-        // 2 - reserved
-        // 2 - reserved
-        // 4 - the offset of the pixel array
-        //
         // BITMAP INFORMATION HEADER
         //
         // The first four bytes of the header give the size, which is a discriminator of the actual header format.
         // See this for more information http://en.wikipedia.org/wiki/BMP_file_format
-        //
-        // BITMAPINFOHEADER (size = 40)
-        //
-        // 4 - size of header
-        // 4 - pixel width (signed)
-        // 4 - pixel height (signed)
-        // 2 - number of colour planes (must be set to 1)
-        // 2 - number of bits per pixel
-        // 4 - compression being used (needs decoding)
-        // 4 - pixel data length (not total file size, just pixel array)
-        // 4 - horizontal resolution, pixels/meter (signed)
-        // 4 - vertical resolution, pixels/meter (signed)
-        // 4 - number of colours in the palette (0 means no palette)
-        // 4 - number of important colours (generally ignored)
-        //
-        // BITMAPCOREHEADER (size = 12)
-        //
-        // 4 - size of header
-        // 2 - pixel width
-        // 2 - pixel height
-        // 2 - number of colour planes (must be set to 1)
-        // 2 - number of bits per pixel
-        //
-        // COMPRESSION VALUES
-        //
-        // 0 = None
-        // 1 = RLE 8-bit/pixel
-        // 2 = RLE 4-bit/pixel
-        // 3 = Bit field (or Huffman 1D if BITMAPCOREHEADER2 (size 64))
-        // 4 = JPEG (or RLE-24 if BITMAPCOREHEADER2 (size 64))
-        // 5 = PNG
-        // 6 = Bit field
 
-        reader.setMotorolaByteOrder(false);
+        readFileHeader(reader, metadata, true);
+    }
+
+    protected void readFileHeader(@NotNull final SequentialReader reader, final @NotNull Metadata metadata, boolean allowArray) {
+        /*
+         * There are two possible headers a file can start with. If the magic
+         * number is OS/2 Bitmap Array (0x4142) the OS/2 Bitmap Array Header
+         * will follow. In all other cases the file header will follow, which
+         * is identical for Windows and OS/2.
+         *
+         * File header:
+         *
+         *    WORD   FileType;      - File type identifier
+         *    DWORD  FileSize;      - Size of the file in bytes
+         *    WORD   XHotSpot;      - X coordinate of hotspot for pointers
+         *    WORD   YHotSpot;      - Y coordinate of hotspot for pointers
+         *    DWORD  BitmapOffset;  - Starting position of image data in bytes
+         *
+         * OS/2 Bitmap Array Header:
+         *
+         *     WORD  Type;          - Header type, always 4142h ("BA")
+         *     DWORD Size;          - Size of this header
+         *     DWORD OffsetToNext;  - Offset to next OS2BMPARRAYFILEHEADER
+         *     WORD  ScreenWidth;   - Width of the image display in pixels
+         *     WORD  ScreenHeight;  - Height of the image display in pixels
+         *
+         */
+
+        final int magicNumber;
+        try {
+            magicNumber = reader.getUInt16();
+        } catch (IOException e) {
+            metadata.addDirectory(new ErrorDirectory("Couldn't determine bitmap type: " + e.getMessage()));
+            return;
+        }
+
+        Directory directory = null;
+        try {
+            switch (magicNumber) {
+                case OS2_BITMAP_ARRAY:
+                    if (!allowArray) {
+                        addError("Invalid bitmap file - nested arrays not allowed", metadata);
+                        return;
+                    }
+                    reader.skip(4); // Size
+                    long nextHeaderOffset = reader.getUInt32();
+                    reader.skip(2 + 2); // Screen Resolution
+                    readFileHeader(reader, metadata, false);
+                    if (nextHeaderOffset == 0) {
+                        return; // No more bitmaps
+                    }
+                    if (reader.getPosition() > nextHeaderOffset) {
+                        addError("Invalid next header offset", metadata);
+                        return;
+                    }
+                    reader.skip(nextHeaderOffset - reader.getPosition());
+                    readFileHeader(reader, metadata, true);
+                    break;
+                case BITMAP:
+                case OS2_ICON:
+                case OS2_COLOR_ICON:
+                case OS2_COLOR_POINTER:
+                case OS2_POINTER:
+                    directory = new BmpHeaderDirectory();
+                    metadata.addDirectory(directory);
+                    directory.setInt(BmpHeaderDirectory.TAG_BITMAP_TYPE, magicNumber);
+                    // skip past the rest of the file header
+                    reader.skip(4 + 2 + 2 + 4);
+                    readBitmapHeader(reader, (BmpHeaderDirectory) directory, metadata);
+                    break;
+                default:
+                    metadata.addDirectory(new ErrorDirectory("Invalid BMP magic number 0x" + Integer.toHexString(magicNumber)));
+                    return;
+            }
+        } catch (IOException e) {
+            if (directory == null) {
+                 addError("Unable to read BMP file header", metadata);
+            } else {
+                directory.addError("Unable to read BMP file header");
+            }
+        }
+    }
+
+    protected void readBitmapHeader(@NotNull final SequentialReader reader, final @NotNull BmpHeaderDirectory directory, final @NotNull Metadata metadata) {
+        /*
+         * BITMAPCOREHEADER (12 bytes):
+         *
+         *    DWORD Size              - Size of this header in bytes
+         *    SHORT Width             - Image width in pixels
+         *    SHORT Height            - Image height in pixels
+         *    WORD  Planes            - Number of color planes
+         *    WORD  BitsPerPixel      - Number of bits per pixel
+         *
+         * OS21XBITMAPHEADER (12 bytes):
+         *
+         *    DWORD  Size             - Size of this structure in bytes
+         *    WORD   Width            - Bitmap width in pixels
+         *    WORD   Height           - Bitmap height in pixel
+         *      WORD   NumPlanes        - Number of bit planes (color depth)
+         *    WORD   BitsPerPixel     - Number of bits per pixel per plane
+         *
+         * OS22XBITMAPHEADER (16/64 bytes):
+         *
+         *    DWORD  Size             - Size of this structure in bytes
+         *    DWORD  Width            - Bitmap width in pixels
+         *    DWORD  Height           - Bitmap height in pixel
+         *      WORD   NumPlanes        - Number of bit planes (color depth)
+         *    WORD   BitsPerPixel     - Number of bits per pixel per plane
+         *
+         *    - Short version ends here -
+         *
+         *    DWORD  Compression      - Bitmap compression scheme
+         *    DWORD  ImageDataSize    - Size of bitmap data in bytes
+         *    DWORD  XResolution      - X resolution of display device
+         *    DWORD  YResolution      - Y resolution of display device
+         *    DWORD  ColorsUsed       - Number of color table indices used
+         *    DWORD  ColorsImportant  - Number of important color indices
+         *    WORD   Units            - Type of units used to measure resolution
+         *    WORD   Reserved         - Pad structure to 4-byte boundary
+         *    WORD   Recording        - Recording algorithm
+         *    WORD   Rendering        - Halftoning algorithm used
+         *    DWORD  Size1            - Reserved for halftoning algorithm use
+         *    DWORD  Size2            - Reserved for halftoning algorithm use
+         *    DWORD  ColorEncoding    - Color model used in bitmap
+         *    DWORD  Identifier       - Reserved for application use
+         *
+         * BITMAPINFOHEADER (40 bytes), BITMAPV2INFOHEADER (52 bytes), BITMAPV3INFOHEADER (56 bytes),
+         * BITMAPV4HEADER (108 bytes) and BITMAPV5HEADER (124 bytes):
+         *
+         *    DWORD Size              - Size of this header in bytes
+         *    LONG  Width             - Image width in pixels
+         *    LONG  Height            - Image height in pixels
+         *    WORD  Planes            - Number of color planes
+         *    WORD  BitsPerPixel      - Number of bits per pixel
+         *    DWORD Compression       - Compression methods used
+         *    DWORD SizeOfBitmap      - Size of bitmap in bytes
+         *    LONG  HorzResolution    - Horizontal resolution in pixels per meter
+         *    LONG  VertResolution    - Vertical resolution in pixels per meter
+         *    DWORD ColorsUsed        - Number of colors in the image
+         *    DWORD ColorsImportant   - Minimum number of important colors
+         *
+         *    - BITMAPINFOHEADER ends here -
+         *
+         *    DWORD RedMask           - Mask identifying bits of red component
+         *    DWORD GreenMask         - Mask identifying bits of green component
+         *    DWORD BlueMask          - Mask identifying bits of blue component
+         *
+         *    - BITMAPV2INFOHEADER ends here -
+         *
+         *    DWORD AlphaMask         - Mask identifying bits of alpha component
+         *
+         *    - BITMAPV3INFOHEADER ends here -
+         *
+         *    DWORD CSType            - Color space type
+         *    LONG  RedX              - X coordinate of red endpoint
+         *    LONG  RedY              - Y coordinate of red endpoint
+         *    LONG  RedZ              - Z coordinate of red endpoint
+         *    LONG  GreenX            - X coordinate of green endpoint
+         *    LONG  GreenY            - Y coordinate of green endpoint
+         *    LONG  GreenZ            - Z coordinate of green endpoint
+         *    LONG  BlueX             - X coordinate of blue endpoint
+         *    LONG  BlueY             - Y coordinate of blue endpoint
+         *    LONG  BlueZ             - Z coordinate of blue endpoint
+         *    DWORD GammaRed          - Gamma red coordinate scale value
+         *    DWORD GammaGreen        - Gamma green coordinate scale value
+         *    DWORD GammaBlue         - Gamma blue coordinate scale value
+         *
+         *    - BITMAPV4HEADER ends here -
+         *
+         *    DWORD Intent            - Rendering intent for bitmap
+         *    DWORD ProfileData       - Offset of the profile data relative to BITMAPV5HEADER
+         *    DWORD ProfileSize       - Size, in bytes, of embedded profile data
+         *    DWORD Reserved          - Shall be zero
+         *
+         */
 
         try {
-            final int magicNumber = reader.getUInt16();
-
-            if (magicNumber != 0x4D42)
-            {
-                directory.addError("Invalid BMP magic number");
-                return;
-            }
-
-            // skip past the rest of the file header
-            reader.skip(4 + 2 + 2 + 4);
-
+            int bitmapType = directory.getInt(BmpHeaderDirectory.TAG_BITMAP_TYPE);
+            long headerOffset = reader.getPosition();
             int headerSize = reader.getInt32();
 
             directory.setInt(BmpHeaderDirectory.TAG_HEADER_SIZE, headerSize);
 
-            // We expect the header size to be either 40 (BITMAPINFOHEADER) or 12 (BITMAPCOREHEADER)
-            if (headerSize == 40) {
-                // BITMAPINFOHEADER
+            /*
+             * Known header type sizes:
+             *
+             *  12 - BITMAPCOREHEADER or OS21XBITMAPHEADER
+             *  16 - OS22XBITMAPHEADER (short)
+             *  40 - BITMAPINFOHEADER
+             *  52 - BITMAPV2INFOHEADER
+             *  56 - BITMAPV3INFOHEADER
+             *  64 - OS22XBITMAPHEADER (full)
+             * 108 - BITMAPV4HEADER
+             * 124 - BITMAPV5HEADER
+             *
+             */
+
+            if (headerSize == 12 && bitmapType == BITMAP) { //BITMAPCOREHEADER
+                /*
+                 * There's no way to tell BITMAPCOREHEADER and OS21XBITMAPHEADER
+                 * apart for the "standard" bitmap type. The difference is only
+                 * that BITMAPCOREHEADER has signed width and height while
+                 * in OS21XBITMAPHEADER they are unsigned. Since BITMAPCOREHEADER,
+                 * the Windows version, is most common, read them as signed.
+                 */
+                directory.setInt(BmpHeaderDirectory.TAG_IMAGE_WIDTH, reader.getInt16());
+                directory.setInt(BmpHeaderDirectory.TAG_IMAGE_HEIGHT, reader.getInt16());
+                directory.setInt(BmpHeaderDirectory.TAG_COLOUR_PLANES, reader.getUInt16());
+                directory.setInt(BmpHeaderDirectory.TAG_BITS_PER_PIXEL, reader.getUInt16());
+            } else if (headerSize == 12) { // OS21XBITMAPHEADER
+                directory.setInt(BmpHeaderDirectory.TAG_IMAGE_WIDTH, reader.getUInt16());
+                directory.setInt(BmpHeaderDirectory.TAG_IMAGE_HEIGHT, reader.getUInt16());
+                directory.setInt(BmpHeaderDirectory.TAG_COLOUR_PLANES, reader.getUInt16());
+                directory.setInt(BmpHeaderDirectory.TAG_BITS_PER_PIXEL, reader.getUInt16());
+            } else if (headerSize == 16 || headerSize == 64) { // OS22XBITMAPHEADER
                 directory.setInt(BmpHeaderDirectory.TAG_IMAGE_WIDTH, reader.getInt32());
                 directory.setInt(BmpHeaderDirectory.TAG_IMAGE_HEIGHT, reader.getInt32());
-                directory.setInt(BmpHeaderDirectory.TAG_COLOUR_PLANES, reader.getInt16());
-                directory.setInt(BmpHeaderDirectory.TAG_BITS_PER_PIXEL, reader.getInt16());
+                directory.setInt(BmpHeaderDirectory.TAG_COLOUR_PLANES, reader.getUInt16());
+                directory.setInt(BmpHeaderDirectory.TAG_BITS_PER_PIXEL, reader.getUInt16());
+                if (headerSize > 16) {
+                    directory.setInt(BmpHeaderDirectory.TAG_COMPRESSION, reader.getInt32());
+                    reader.skip(4); // skip the pixel data length
+                    directory.setInt(BmpHeaderDirectory.TAG_X_PIXELS_PER_METER, reader.getInt32());
+                    directory.setInt(BmpHeaderDirectory.TAG_Y_PIXELS_PER_METER, reader.getInt32());
+                    directory.setInt(BmpHeaderDirectory.TAG_PALETTE_COLOUR_COUNT, reader.getInt32());
+                    directory.setInt(BmpHeaderDirectory.TAG_IMPORTANT_COLOUR_COUNT, reader.getInt32());
+                    reader.skip(
+                        2 + // Skip Units, can only be 0 (pixels per meter)
+                        2 + // Skip padding
+                        2   // Skip Recording, can only be 0 (left to right, bottom to top)
+                    );
+                    directory.setInt(BmpHeaderDirectory.TAG_RENDERING, reader.getUInt16());
+                    reader.skip(4 + 4); // Skip Size1 and Size2
+                    directory.setInt(BmpHeaderDirectory.TAG_COLOR_ENCODING, reader.getInt32());
+                    reader.skip(4); // Skip Identifier
+                }
+            } else if (
+                headerSize == 40 || headerSize == 52 || headerSize == 56 ||
+                headerSize == 108 || headerSize == 124
+            ) { // BITMAPINFOHEADER V1-5
+                directory.setInt(BmpHeaderDirectory.TAG_IMAGE_WIDTH, reader.getInt32());
+                directory.setInt(BmpHeaderDirectory.TAG_IMAGE_HEIGHT, reader.getInt32());
+                directory.setInt(BmpHeaderDirectory.TAG_COLOUR_PLANES, reader.getUInt16());
+                directory.setInt(BmpHeaderDirectory.TAG_BITS_PER_PIXEL, reader.getUInt16());
                 directory.setInt(BmpHeaderDirectory.TAG_COMPRESSION, reader.getInt32());
                 // skip the pixel data length
                 reader.skip(4);
@@ -113,16 +336,66 @@ public class BmpReader
                 directory.setInt(BmpHeaderDirectory.TAG_Y_PIXELS_PER_METER, reader.getInt32());
                 directory.setInt(BmpHeaderDirectory.TAG_PALETTE_COLOUR_COUNT, reader.getInt32());
                 directory.setInt(BmpHeaderDirectory.TAG_IMPORTANT_COLOUR_COUNT, reader.getInt32());
-            } else if (headerSize == 12) {
-                directory.setInt(BmpHeaderDirectory.TAG_IMAGE_WIDTH, reader.getInt16());
-                directory.setInt(BmpHeaderDirectory.TAG_IMAGE_HEIGHT, reader.getInt16());
-                directory.setInt(BmpHeaderDirectory.TAG_COLOUR_PLANES, reader.getInt16());
-                directory.setInt(BmpHeaderDirectory.TAG_BITS_PER_PIXEL, reader.getInt16());
+                if (headerSize == 40) { // BITMAPINFOHEADER end
+                    return;
+                }
+                directory.setLong(BmpHeaderDirectory.TAG_RED_MASK, reader.getUInt32());
+                directory.setLong(BmpHeaderDirectory.TAG_GREEN_MASK, reader.getUInt32());
+                directory.setLong(BmpHeaderDirectory.TAG_BLUE_MASK, reader.getUInt32());
+                if (headerSize == 52) { // BITMAPV2INFOHEADER end
+                    return;
+                }
+                directory.setLong(BmpHeaderDirectory.TAG_ALPHA_MASK, reader.getUInt32());
+                if (headerSize == 56) { // BITMAPV3INFOHEADER end
+                    return;
+                }
+                long csType = reader.getUInt32();
+                directory.setLong(BmpHeaderDirectory.TAG_COLOR_SPACE_TYPE, csType);
+                reader.skip(36); // Skip color endpoint coordinates
+                directory.setLong(BmpHeaderDirectory.TAG_GAMMA_RED, reader.getUInt32());
+                directory.setLong(BmpHeaderDirectory.TAG_GAMMA_GREEN, reader.getUInt32());
+                directory.setLong(BmpHeaderDirectory.TAG_GAMMA_BLUE, reader.getUInt32());
+                if (headerSize == 108) { // BITMAPV4HEADER end
+                    return;
+                }
+                directory.setInt(BmpHeaderDirectory.TAG_INTENT, reader.getInt32());
+                if (csType == ColorSpaceType.PROFILE_EMBEDDED.getValue() || csType == ColorSpaceType.PROFILE_LINKED.getValue()) {
+                    long profileOffset = reader.getUInt32();
+                    int profileSize = reader.getInt32();
+                    if (reader.getPosition() > headerOffset + profileOffset) {
+                        directory.addError("Invalid profile data offset 0x" + Long.toHexString(headerOffset + profileOffset));
+                        return;
+                    }
+                    reader.skip(headerOffset + profileOffset - reader.getPosition());
+                    if (csType == ColorSpaceType.PROFILE_LINKED.getValue()) {
+                        directory.setString(BmpHeaderDirectory.TAG_LINKED_PROFILE, reader.getNullTerminatedString(profileSize, Charsets.WINDOWS_1252));
+                    } else {
+                        ByteArrayReader randomAccessReader = new ByteArrayReader(reader.getBytes(profileSize));
+                        new IccReader().extract(randomAccessReader, metadata, directory);
+                    }
+                } else {
+                    reader.skip(
+                        4 + // Skip ProfileData offset
+                        4 + // Skip ProfileSize
+                        4   // Skip Reserved
+                    );
+                }
             } else {
                 directory.addError("Unexpected DIB header size: " + headerSize);
             }
         } catch (IOException e) {
             directory.addError("Unable to read BMP header");
+        } catch (MetadataException e) {
+            directory.addError("Internal error");
+        }
+    }
+
+    protected void addError(@NotNull String errorMessage, final @NotNull Metadata metadata) {
+        ErrorDirectory directory = metadata.getFirstDirectoryOfType(ErrorDirectory.class);
+        if (directory == null) {
+            metadata.addDirectory(new ErrorDirectory(errorMessage));
+        } else {
+            directory.addError(errorMessage);
         }
     }
 }


### PR DESCRIPTION
While testing I found some BMP's that couldn't be parsed. This lead me to thing that it was such an easy file format that I could quickly extend it to cover "everything". I was wrong. This wasn't quick at all, but I think I've covered most of the BMP variants now.

I have some things I'm unsure about. First of all, I've put some ```formatHex()``` and ```formatFixed1616()``` in ```BmpHeaderDescriptor```. They are too general to be there, but I couldn't find where such methods are kept. Please advise.

As usual I'm also unsure about the formatting, line wrapping etc. I've done my best to try to keep the existing style, but please let me know if anything should be changed.

I had to add ```WINDOWS-1252``` to ```Charsets``` because BMP files use this character set by definition. I don't know if that ```Charset``` is available on all platforms, or how Java handles "fallback" if it's missing. I'm assuming it will simply fall back to ```Latin-1``` or similar, which shouldn't pose much of a problem. It's only actually used for one thing, and that is decoding the file name for a "linked" ICC profile. It wouldn't be the end of the world if this failed, I haven't implemented parsing of ICC profiles from external files anyway - as I see it as very unlikely that they will actually be there, so I'm simply storing the file name in a tag.

I've rearranged (and expanded) the documentation in ```BmpReader```. I had to rearrange the whole logic a bit since some BMP files contain multiple images. I've split the reading into methods that makes reading those recursively easy, and I've moved the documentation with the methods. 

I've also created quite a few ```enum```s in ```BmpHeaderDirectory``` and the documentation for those tags are in the enums (if any, some are quite self-explanatory).

I've added a corresponding PR to the images repository drewnoakes/metadata-extractor-images#10.

There's an error with some of the ICC profiles that I haven't looked at:
```logtalk
[ERROR: ICC Profile] ICC data describes an invalid date/time: year=10 month=1998 day=19 hour=30 minute=52 second=42
```
Could this be a ```Locale``` issue as well?

There's a bug in the existing code where ```Bit Fields``` <-> ```Huffman 1D``` and ```JPEG``` <-> ```RLE-24``` is mixed up. This PR fixes that which explains the diffs on these values.

There's probably something I've forgot to mention, but I'll add it as I remember it.
