### PR TITLE
BugFix - convert to unsigned value.

### DIFF
--- a/Source/com/drew/metadata/gif/GifReader.java
+++ b/Source/com/drew/metadata/gif/GifReader.java
@@ -270,7 +270,7 @@ public class GifReader
         else if (extensionType.equals("ICCRGBG1012"))
         {
             // ICC profile extension
-            byte[] iccBytes = gatherBytes(reader, reader.getByte());
+            byte[] iccBytes = gatherBytes(reader, ((int) reader.getByte()) & 0xff);
             if (iccBytes.length != 0)
                 new IccReader().extract(new ByteArrayReader(iccBytes), metadata);
         }
@@ -375,7 +375,7 @@ public class GifReader
         {
             buffer.write(reader.getBytes(length), 0, length);
 
-            length = reader.getByte();
+            length = reader.getByte() & 0xff;
         }
 
         return buffer.toByteArray();


### PR DESCRIPTION
This pr fixes cast of unsigned value of 255 to signed -1 when reading length of ICC profile in GIF blocks.