### PR TITLE
Riff file support additions: WAV and AVI

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,10 +39,12 @@ The library understands several formats of metadata, many of which may be presen
 * [ICC Profiles](http://en.wikipedia.org/wiki/ICC_profile)
 * [Photoshop](http://en.wikipedia.org/wiki/Photoshop) fields
 * [WebP](http://en.wikipedia.org/wiki/WebP) properties
+* [WAV](http://en.wikipedia.org/wiki/WAV) properties
+* [AVI](http://en.wikipedia.org/wiki/Audio_Video_Interleave) properties
 * [PNG](http://en.wikipedia.org/wiki/Portable_Network_Graphics) properties
 * [BMP](http://en.wikipedia.org/wiki/BMP_file_format) properties
 * [GIF](http://en.wikipedia.org/wiki/Graphics_Interchange_Format) properties
-* [ICO](https://en.wikipedia.org/wiki/ICO_(file_format)) properties
+* [ICO](http://en.wikipedia.org/wiki/ICO_(file_format)) properties
 * [PCX](http://en.wikipedia.org/wiki/PCX) properties
 
 It will process files of type:
@@ -50,6 +52,8 @@ It will process files of type:
 * JPEG
 * TIFF
 * WebP
+* WAV
+* AVI
 * PSD
 * PNG
 * BMP

--- a/Source/com/drew/imaging/FileType.java
+++ b/Source/com/drew/imaging/FileType.java
@@ -31,51 +31,66 @@ import com.drew.lang.annotations.Nullable;
  */
 public enum FileType
 {
-    Unknown("Unknown", null),
-    Jpeg("Jpeg", "image/jpeg"),
-    Tiff("Tiff", "image/tiff"),
-    Psd("Psd", "image/vnd.adobe.photoshop"),
-    Png("Png", "image/png"),
-    Bmp("Bmp", "image/bmp"),
-    Gif("Gif", "image/gif"),
-    Ico("Ico", "image/x-icon"),
-    Pcx("Pcx", "image/x-pcx"),
-    Riff("Riff", null),
+    Unknown(null, false),
+    Jpeg("image/jpeg", false, ".jpg", ".jpeg", ".jpe"),
+    Tiff("image/tiff", true, ".tiff", ".tif"),
+    Psd("image/vnd.adobe.photoshop", false, ".psd"),
+    Png("image/png", false, ".png"),
+    Bmp("image/bmp", false, ".bmp"),
+    Gif("image/gif", false, ".gif"),
+    Ico("image/x-icon", false, ".ico"),
+    Pcx("image/x-pcx", false, ".pcx"),
+    Riff(null, true, null),
 
     /** Sony camera raw. */
-    Arw("Arw", null),
+    Arw(null, false, ".arw"),
     /** Canon camera raw, version 1. */
-    Crw("Crw", null),
+    Crw(null, false, ".crw"),
     /** Canon camera raw, version 2. */
-    Cr2("Cr2", null),
+    Cr2(null, false, ".cr2"),
     /** Nikon camera raw. */
-    Nef("Nef", null),
+    Nef(null, false, ".nef"),
     /** Olympus camera raw. */
-    Orf("Orf", null),
+    Orf(null, false, ".orf"),
     /** FujiFilm camera raw. */
-    Raf("Raf", null),
+    Raf(null, false, ".raf"),
     /** Panasonic camera raw. */
-    Rw2("Rw2", null);
-
-    private final String _name;
+    Rw2(null, false, ".rw2");
 
     private final String _mimeType;
 
-    FileType(String name, String mimeType)
+    private final boolean _isContainer;
+
+    private final String[] _extensions;
+
+    FileType(String mimeType, boolean isContainer, String... extensions)
     {
-        _name = name;
         _mimeType = mimeType;
+        _isContainer = isContainer;
+        _extensions = extensions;
     }
 
     @NotNull
     public String getName()
     {
-        return _name;
+        return this.name();
     }
 
     @Nullable
     public String getMimeType()
     {
         return _mimeType;
+    }
+
+    @NotNull
+    public boolean getIsContainer()
+    {
+        return _isContainer;
+    }
+
+    @Nullable
+    public String[] getExtension()
+    {
+        return _extensions;
     }
 }

--- a/Source/com/drew/imaging/FileType.java
+++ b/Source/com/drew/imaging/FileType.java
@@ -41,6 +41,9 @@ public enum FileType
     Ico("image/x-icon", false, ".ico"),
     Pcx("image/x-pcx", false, ".pcx"),
     Riff(null, true, null),
+    Wav("audio/vnd.wave", false, ".wav", ".wave"),
+    Avi("video/vnd.avi", false, ".avi"),
+    Webp("image/webp", false, ".webp"),
 
     /** Sony camera raw. */
     Arw(null, false, ".arw"),

--- a/Source/com/drew/imaging/FileType.java
+++ b/Source/com/drew/imaging/FileType.java
@@ -20,34 +20,62 @@
  */
 package com.drew.imaging;
 
+import com.drew.lang.annotations.NotNull;
+import com.drew.lang.annotations.Nullable;
+
 /**
  * Enumeration of supported image file formats.
+ *
+ * MIME Type Source: https://www.freeformatter.com/mime-types-list.html
+ *                   https://www.iana.org/assignments/media-types/media-types.xhtml
  */
 public enum FileType
 {
-    Unknown,
-    Jpeg,
-    Tiff,
-    Psd,
-    Png,
-    Bmp,
-    Gif,
-    Ico,
-    Pcx,
-    Riff,
+    Unknown("Unknown", null),
+    Jpeg("Jpeg", "image/jpeg"),
+    Tiff("Tiff", "image/tiff"),
+    Psd("Psd", "image/vnd.adobe.photoshop"),
+    Png("Png", "image/png"),
+    Bmp("Bmp", "image/bmp"),
+    Gif("Gif", "image/gif"),
+    Ico("Ico", "image/x-icon"),
+    Pcx("Pcx", "image/x-pcx"),
+    Riff("Riff", null),
 
     /** Sony camera raw. */
-    Arw,
+    Arw("Arw", null),
     /** Canon camera raw, version 1. */
-    Crw,
+    Crw("Crw", null),
     /** Canon camera raw, version 2. */
-    Cr2,
+    Cr2("Cr2", null),
     /** Nikon camera raw. */
-    Nef,
+    Nef("Nef", null),
     /** Olympus camera raw. */
-    Orf,
+    Orf("Orf", null),
     /** FujiFilm camera raw. */
-    Raf,
+    Raf("Raf", null),
     /** Panasonic camera raw. */
-    Rw2
+    Rw2("Rw2", null);
+
+    private final String _name;
+
+    private final String _mimeType;
+
+    FileType(String name, String mimeType)
+    {
+        _name = name;
+        _mimeType = mimeType;
+    }
+
+    @NotNull
+    public String getName()
+    {
+        return _name;
+    }
+
+    @Nullable
+    public String getMimeType()
+    {
+        return _mimeType;
+    }
 }

--- a/Source/com/drew/imaging/FileTypeDetector.java
+++ b/Source/com/drew/imaging/FileTypeDetector.java
@@ -68,6 +68,9 @@ public class FileTypeDetector
         _root.addPath(FileType.Pcx, new byte[]{0x0A, 0x03, 0x01});
         _root.addPath(FileType.Pcx, new byte[]{0x0A, 0x05, 0x01});
         _root.addPath(FileType.Riff, "RIFF".getBytes());
+        _root.addPath(FileType.Wav, "WAVE".getBytes());
+        _root.addPath(FileType.Avi, "AVI ".getBytes());
+        _root.addPath(FileType.Webp, "WEBP".getBytes());
 
         _root.addPath(FileType.Arw, "II".getBytes(), new byte[]{0x2a, 0x00, 0x08, 0x00});
         _root.addPath(FileType.Crw, "II".getBytes(), new byte[]{0x1a, 0x00, 0x00, 0x00}, "HEAPCCDR".getBytes());

--- a/Source/com/drew/imaging/FileTypeDetector.java
+++ b/Source/com/drew/imaging/FileTypeDetector.java
@@ -104,7 +104,33 @@ public class FileTypeDetector
 
         inputStream.reset();
 
+        FileType fileType = _root.find(bytes);
+
+        if (fileType.getIsContainer()) {
+            fileType = handleContainer(inputStream, fileType);
+        }
+
         //noinspection ConstantConditions
-        return _root.find(bytes);
+        return fileType;
+    }
+
+    /**
+     * Skips to identifier location for potential container file types and calls detectFileType on new inputStream
+     * location.  In the case of fileTypes without magic bytes to identify with (Zip), the fileType will be
+     * found within this method alone.
+     *
+     * @throws IOException if an IO error occurred or the input stream ended unexpectedly.
+     */
+    @NotNull
+    public static FileType handleContainer(@NotNull final BufferedInputStream inputStream, @NotNull FileType fileType) throws IOException
+    {
+        switch (fileType) {
+            case Riff:
+                inputStream.skip(8);
+                return detectFileType(inputStream);
+            case Tiff:
+            default:
+                return fileType;
+        }
     }
 }

--- a/Source/com/drew/imaging/FileTypeDetector.java
+++ b/Source/com/drew/imaging/FileTypeDetector.java
@@ -21,10 +21,12 @@
 package com.drew.imaging;
 
 import com.drew.lang.ByteTrie;
+import com.drew.lang.RandomAccessStreamReader;
 import com.drew.lang.annotations.NotNull;
 
 import java.io.BufferedInputStream;
 import java.io.IOException;
+import java.io.InputStream;
 
 /**
  * Examines the a file's first bytes and estimates the file's type.
@@ -102,9 +104,9 @@ public class FileTypeDetector
 
         FileType fileType = _root.find(bytes);
 
-        //noinspection ConstantConditions
+    //noinspection ConstantConditions
         return fileType;
-    }
+}
 
     /**
      * Examines the file's bytes and estimates the file's type.

--- a/Source/com/drew/imaging/FileTypeDetector.java
+++ b/Source/com/drew/imaging/FileTypeDetector.java
@@ -23,6 +23,9 @@ package com.drew.imaging;
 import com.drew.lang.ByteTrie;
 import com.drew.lang.RandomAccessStreamReader;
 import com.drew.lang.annotations.NotNull;
+import com.drew.metadata.avi.AviDirectory;
+import com.drew.metadata.wav.WavDirectory;
+import com.drew.metadata.webp.WebpDirectory;
 
 import java.io.BufferedInputStream;
 import java.io.IOException;

--- a/Source/com/drew/imaging/ImageMetadataReader.java
+++ b/Source/com/drew/imaging/ImageMetadataReader.java
@@ -107,7 +107,11 @@ public class ImageMetadataReader
 
         FileType fileType = FileTypeDetector.detectFileType(bufferedInputStream);
 
-        return readMetadata(bufferedInputStream, streamLength, fileType);
+        Metadata metadata = readMetadata(bufferedInputStream, streamLength, fileType);
+
+        new FileMetadataReader().read(metadata, fileType);
+
+        return metadata;
     }
 
     /**

--- a/Source/com/drew/imaging/ImageMetadataReader.java
+++ b/Source/com/drew/imaging/ImageMetadataReader.java
@@ -20,6 +20,7 @@
  */
 package com.drew.imaging;
 
+import com.drew.imaging.avi.AviMetadataReader;
 import com.drew.imaging.bmp.BmpMetadataReader;
 import com.drew.imaging.gif.GifMetadataReader;
 import com.drew.imaging.ico.IcoMetadataReader;
@@ -29,6 +30,7 @@ import com.drew.imaging.png.PngMetadataReader;
 import com.drew.imaging.psd.PsdMetadataReader;
 import com.drew.imaging.raf.RafMetadataReader;
 import com.drew.imaging.tiff.TiffMetadataReader;
+import com.drew.imaging.wav.WavMetadataReader;
 import com.drew.imaging.webp.WebpMetadataReader;
 import com.drew.lang.RandomAccessStreamReader;
 import com.drew.lang.StringUtil;
@@ -149,10 +151,14 @@ public class ImageMetadataReader
                 return IcoMetadataReader.readMetadata(inputStream);
             case Pcx:
                 return PcxMetadataReader.readMetadata(inputStream);
-            case Riff:
+            case Webp:
                 return WebpMetadataReader.readMetadata(inputStream);
             case Raf:
                 return RafMetadataReader.readMetadata(inputStream);
+            case Avi:
+                return AviMetadataReader.readMetadata(inputStream);
+            case Wav:
+                return WavMetadataReader.readMetadata(inputStream);
             default:
                 throw new ImageProcessingException("File format is not supported");
         }

--- a/Source/com/drew/imaging/avi/AviMetadataReader.java
+++ b/Source/com/drew/imaging/avi/AviMetadataReader.java
@@ -1,7 +1,11 @@
 package com.drew.imaging.avi;
 
+import com.drew.imaging.riff.RiffProcessingException;
+import com.drew.imaging.riff.RiffReader;
+import com.drew.lang.StreamReader;
 import com.drew.lang.annotations.NotNull;
 import com.drew.metadata.Metadata;
+import com.drew.metadata.avi.AviRiffHandler;
 import com.drew.metadata.file.FileMetadataReader;
 
 import java.io.File;
@@ -24,9 +28,10 @@ public class AviMetadataReader
     }
 
     @NotNull
-    public static Metadata readMetadata(@NotNull InputStream inputStream)
+    public static Metadata readMetadata(@NotNull InputStream inputStream) throws IOException, RiffProcessingException
     {
         Metadata metadata = new Metadata();
+        new RiffReader().processRiff(new StreamReader(inputStream), new AviRiffHandler(metadata));
         return metadata;
     }
 }

--- a/Source/com/drew/imaging/avi/AviMetadataReader.java
+++ b/Source/com/drew/imaging/avi/AviMetadataReader.java
@@ -1,0 +1,32 @@
+package com.drew.imaging.avi;
+
+import com.drew.lang.annotations.NotNull;
+import com.drew.metadata.Metadata;
+import com.drew.metadata.file.FileMetadataReader;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+
+/**
+ * Obtains metadata from AVI files.
+ *
+ * @author Payton Garland
+ */
+public class AviMetadataReader
+{
+    @NotNull
+    public static Metadata readMetadata(@NotNull File file) throws IOException
+    {
+        Metadata metadata = new Metadata();
+        new FileMetadataReader().read(file, metadata);
+        return metadata;
+    }
+
+    @NotNull
+    public static Metadata readMetadata(@NotNull InputStream inputStream)
+    {
+        Metadata metadata = new Metadata();
+        return metadata;
+    }
+}

--- a/Source/com/drew/imaging/avi/package-info.java
+++ b/Source/com/drew/imaging/avi/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Contains classes for working with AVI files.
+ */
+package com.drew.imaging.avi;

--- a/Source/com/drew/imaging/riff/RiffHandler.java
+++ b/Source/com/drew/imaging/riff/RiffHandler.java
@@ -52,6 +52,16 @@ public interface RiffHandler
     boolean shouldAcceptChunk(@NotNull String fourCC);
 
     /**
+     * Gets whether this handler is interested in the specific list type.
+     * Returns <code>true</code> if the chunks should continue being processed,
+     * or <code>false</code> to avoid any unknown chunks within the list.
+     *
+     * @param fourCC the four character code of this chunk
+     * @return true if {@link RiffHandler#processChunk(String, byte[])} should be called, otherwise false
+     */
+    boolean shouldAcceptList(@NotNull String fourCC);
+
+    /**
      * Perform whatever processing is necessary for the type of chunk with its
      * payload.
      *

--- a/Source/com/drew/imaging/riff/RiffReader.java
+++ b/Source/com/drew/imaging/riff/RiffReader.java
@@ -22,6 +22,7 @@ package com.drew.imaging.riff;
 
 import com.drew.lang.SequentialReader;
 import com.drew.lang.annotations.NotNull;
+import org.apache.pdfbox.io.SequentialRead;
 
 import java.io.IOException;
 
@@ -60,7 +61,7 @@ public class RiffReader
         if (!fileFourCC.equals("RIFF"))
             throw new RiffProcessingException("Invalid RIFF header: " + fileFourCC);
 
-        // The total size of the chunks that follow plus 4 bytes for the 'WEBP' FourCC
+        // The total size of the chunks that follow plus 4 bytes for the FourCC
         final int fileSize = reader.getInt32();
         int sizeLeft = fileSize;
 
@@ -71,30 +72,53 @@ public class RiffReader
             return;
 
         // PROCESS CHUNKS
+        processChunks(reader, sizeLeft, handler);
 
-        while (sizeLeft != 0) {
-            final String chunkFourCC = reader.getString(4);
-            final int chunkSize = reader.getInt32();
-            sizeLeft -= 8;
+//        while (sizeLeft != 0) {
+//            final String chunkFourCC = reader.getString(4);
+//            final int chunkSize = reader.getInt32();
+//            sizeLeft -= 8;
+//
+//            // NOTE we fail a negative chunk size here (greater than 0x7FFFFFFF) as Java cannot
+//            // allocate arrays larger than this.
+//            if (chunkSize < 0 || sizeLeft < chunkSize)
+//                throw new RiffProcessingException("Invalid RIFF chunk size");
+//
+//            if (handler.shouldAcceptChunk(chunkFourCC)) {
+//                // TODO is it feasible to avoid copying the chunk here, and to pass the sequential reader to the handler?
+//                handler.processChunk(chunkFourCC, reader.getBytes(chunkSize));
+//            } else {
+//                reader.skip(chunkSize);
+//            }
+//
+//            sizeLeft -= chunkSize;
+//
+//            // Skip any padding byte added to keep chunks aligned to even numbers of bytes
+//            if (chunkSize % 2 == 1) {
+//                reader.getInt8();
+//                sizeLeft--;
+//            }
 
-            // NOTE we fail a negative chunk size here (greater than 0x7FFFFFFF) as Java cannot
-            // allocate arrays larger than this.
-            if (chunkSize < 0 || sizeLeft < chunkSize)
-                throw new RiffProcessingException("Invalid RIFF chunk size");
-
-            if (handler.shouldAcceptChunk(chunkFourCC)) {
-                // TODO is it feasible to avoid copying the chunk here, and to pass the sequential reader to the handler?
-                handler.processChunk(chunkFourCC, reader.getBytes(chunkSize));
+    }
+    public void processChunks(SequentialReader reader, int sectionSize, RiffHandler handler) throws IOException
+    {
+        while (reader.getPosition() < sectionSize) {
+            String fourCC = new String(reader.getBytes(4));
+            int size = reader.getInt32();
+            if (fourCC.equals("LIST")) {
+                String listName = new String(reader.getBytes(4));
+                if (handler.shouldAcceptList(listName)) {
+                    processChunks(reader, size - 4, handler);
+                } else {
+                    reader.skip(size - 4);
+                }
             } else {
-                reader.skip(chunkSize);
-            }
-
-            sizeLeft -= chunkSize;
-
-            // Skip any padding byte added to keep chunks aligned to even numbers of bytes
-            if (chunkSize % 2 == 1) {
-                reader.getInt8();
-                sizeLeft--;
+                if (handler.shouldAcceptChunk(fourCC)) {
+                    // TODO is it feasible to avoid copying the chunk here, and to pass the sequential reader to the handler?
+                    handler.processChunk(fourCC, reader.getBytes(size));
+                } else {
+                    reader.skip(size);
+                }
             }
         }
     }

--- a/Source/com/drew/imaging/wav/WavMetadataReader.java
+++ b/Source/com/drew/imaging/wav/WavMetadataReader.java
@@ -1,0 +1,37 @@
+package com.drew.imaging.wav;
+
+import com.drew.imaging.riff.RiffProcessingException;
+import com.drew.imaging.riff.RiffReader;
+import com.drew.lang.StreamReader;
+import com.drew.lang.annotations.NotNull;
+import com.drew.metadata.Metadata;
+import com.drew.metadata.file.FileMetadataReader;
+import com.drew.metadata.wav.WavRiffHandler;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+
+/**
+ * Obtains metadata from WAV files.
+ *
+ * @author Payton Garland
+ */
+public class WavMetadataReader
+{
+    @NotNull
+    public static Metadata readMetadata(@NotNull File file) throws IOException
+    {
+        Metadata metadata = new Metadata();
+        new FileMetadataReader().read(file, metadata);
+        return metadata;
+    }
+
+    @NotNull
+    public static Metadata readMetadata(@NotNull InputStream inputStream) throws IOException, RiffProcessingException
+    {
+        Metadata metadata = new Metadata();
+        new RiffReader().processRiff(new StreamReader(inputStream), new WavRiffHandler(metadata));
+        return metadata;
+    }
+}

--- a/Source/com/drew/imaging/wav/package-info.java
+++ b/Source/com/drew/imaging/wav/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Contains classes for working with WAV files.
+ */
+package com.drew.imaging.wav;

--- a/Source/com/drew/metadata/avi/AviDescriptor.java
+++ b/Source/com/drew/metadata/avi/AviDescriptor.java
@@ -19,8 +19,15 @@ public class AviDescriptor extends TagDescriptor<AviDirectory>
     public String getDescription(int tagType)
     {
         switch (tagType) {
-            default:
-                return super.getDescription(tagType);
+            case (AviDirectory.TAG_WIDTH):
+            case (AviDirectory.TAG_HEIGHT):
+                return getSizeDescription(tagType);
         }
+        return super.getDescription(tagType);
+    }
+
+    public String getSizeDescription(int tagType)
+    {
+        return _directory.getString(tagType) + " pixels";
     }
 }

--- a/Source/com/drew/metadata/avi/AviDescriptor.java
+++ b/Source/com/drew/metadata/avi/AviDescriptor.java
@@ -1,0 +1,26 @@
+package com.drew.metadata.avi;
+
+import com.drew.lang.annotations.NotNull;
+import com.drew.lang.annotations.Nullable;
+import com.drew.metadata.TagDescriptor;
+
+/**
+ * @author Payton Garland
+ */
+public class AviDescriptor extends TagDescriptor<AviDirectory>
+{
+    public AviDescriptor(@NotNull AviDirectory directory)
+    {
+        super(directory);
+    }
+
+    @Override
+    @Nullable
+    public String getDescription(int tagType)
+    {
+        switch (tagType) {
+            default:
+                return super.getDescription(tagType);
+        }
+    }
+}

--- a/Source/com/drew/metadata/avi/AviDirectory.java
+++ b/Source/com/drew/metadata/avi/AviDirectory.java
@@ -1,0 +1,39 @@
+package com.drew.metadata.avi;
+
+import com.drew.lang.annotations.NotNull;
+import com.drew.metadata.Directory;
+
+import java.util.HashMap;
+
+/**
+ * @author Payton Garland
+ */
+public class AviDirectory extends Directory
+{
+
+    public static final int TAG_FRAMES_PER_SECOND = 1;
+    public static final int TAG_SAMPLES_PER_SECOND = 2;
+
+    @NotNull
+    protected static final HashMap<Integer, String> _tagNameMap = new HashMap<Integer, String>();
+
+    static {
+        _tagNameMap.put(TAG_FRAMES_PER_SECOND, "Frames Per Second");
+        _tagNameMap.put(TAG_SAMPLES_PER_SECOND, "Samples Per Second");
+    }
+
+    public AviDirectory()
+    {
+        this.setDescriptor(new AviDescriptor(this));
+    }
+
+    @Override
+    public String getName() {
+        return "AVI";
+    }
+
+    @Override
+    protected HashMap<Integer, String> getTagNameMap() {
+        return _tagNameMap;
+    }
+}

--- a/Source/com/drew/metadata/avi/AviDirectory.java
+++ b/Source/com/drew/metadata/avi/AviDirectory.java
@@ -6,6 +6,8 @@ import com.drew.metadata.Directory;
 import java.util.HashMap;
 
 /**
+ * Holds basic metadata from Avi files
+ *
  * @author Payton Garland
  */
 public class AviDirectory extends Directory
@@ -13,6 +15,20 @@ public class AviDirectory extends Directory
 
     public static final int TAG_FRAMES_PER_SECOND = 1;
     public static final int TAG_SAMPLES_PER_SECOND = 2;
+    public static final int TAG_DURATION = 3;
+    public static final int TAG_VIDEO_CODEC = 4;
+    public static final int TAG_AUDIO_CODEC = 5;
+    public static final int TAG_WIDTH = 6;
+    public static final int TAG_HEIGHT = 7;
+    public static final int TAG_STREAMS = 8;
+
+    public static final String CHUNK_STREAM_HEADER = "strh";
+    public static final String CHUNK_MAIN_HEADER = "avih";
+
+    public static final String LIST_HEADER = "hdrl";
+    public static final String LIST_STREAM_HEADER = "strl";
+
+    public static final String FORMAT = "AVI ";
 
     @NotNull
     protected static final HashMap<Integer, String> _tagNameMap = new HashMap<Integer, String>();
@@ -20,6 +36,12 @@ public class AviDirectory extends Directory
     static {
         _tagNameMap.put(TAG_FRAMES_PER_SECOND, "Frames Per Second");
         _tagNameMap.put(TAG_SAMPLES_PER_SECOND, "Samples Per Second");
+        _tagNameMap.put(TAG_DURATION, "Duration");
+        _tagNameMap.put(TAG_VIDEO_CODEC, "Video Codec");
+        _tagNameMap.put(TAG_AUDIO_CODEC, "Audio Codec");
+        _tagNameMap.put(TAG_WIDTH, "Width");
+        _tagNameMap.put(TAG_HEIGHT, "Height");
+        _tagNameMap.put(TAG_STREAMS, "Stream Count");
     }
 
     public AviDirectory()

--- a/Source/com/drew/metadata/avi/AviRiffHandler.java
+++ b/Source/com/drew/metadata/avi/AviRiffHandler.java
@@ -1,0 +1,81 @@
+package com.drew.metadata.avi;
+
+import com.drew.imaging.riff.RiffHandler;
+import com.drew.lang.SequentialByteArrayReader;
+import com.drew.lang.annotations.NotNull;
+import com.drew.metadata.Metadata;
+
+import java.io.IOException;
+
+/**
+ * Source: http://www.alexander-noe.com/video/documentation/avi.pdf
+ *
+ * @author Payton Garland
+ */
+public class AviRiffHandler implements RiffHandler
+{
+    @NotNull
+    private final Metadata _metadata;
+
+    public AviRiffHandler(@NotNull Metadata metadata)
+    {
+        _metadata = metadata;
+    }
+
+    public boolean shouldAcceptRiffIdentifier(@NotNull String identifier)
+    {
+        return identifier.equals("AVI ");
+    }
+
+    public boolean shouldAcceptChunk(@NotNull String fourCC)
+    {
+        return fourCC.equals("strh");
+    }
+
+    public boolean shouldAcceptList(@NotNull String fourCC)
+    {
+        return fourCC.equals("hdrl")
+            || fourCC.equals("strl");
+    }
+
+    public void processChunk(@NotNull String fourCC, @NotNull byte[] payload)
+    {
+        System.out.println(fourCC);
+        AviDirectory directory = new AviDirectory();
+        _metadata.addDirectory(directory);
+
+//        System.out.println("Chunk " + fourCC + " " + payload.length + " bytes");
+        try {
+            if (fourCC.equals("strh")) {
+                SequentialByteArrayReader reader = new SequentialByteArrayReader(payload);
+                reader.setMotorolaByteOrder(false);
+
+                String fccType = new String(reader.getBytes(4));
+                String fccHandler = new String(reader.getBytes(4));
+                int dwFlags = reader.getInt32();
+                int wPriority = reader.getInt16();
+                int wLanguage = reader.getInt16();
+                int dwInitialFrames = reader.getInt32();
+                float dwScale = reader.getFloat32();
+                float dwRate = reader.getFloat32();
+                int dwStart = reader.getInt32();
+                int dwLength = reader.getInt32();
+                int dwSuggestedBufferSize = reader.getInt32();
+                int dwQuality = reader.getInt32();
+                int dwSampleSize = reader.getInt32();
+                int rcFrame = reader.getInt16();
+
+                if (fccType.equals("vids")) {
+                    directory.setDouble(AviDirectory.TAG_FRAMES_PER_SECOND, (dwRate/dwScale));
+                } else if (fccType.equals("auds")) {
+                    directory.setDouble(AviDirectory.TAG_SAMPLES_PER_SECOND, (dwRate/dwScale));
+                }
+
+                System.out.println(dwRate/dwScale);
+            }
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+
+    }
+}

--- a/Source/com/drew/metadata/avi/AviRiffHandler.java
+++ b/Source/com/drew/metadata/avi/AviRiffHandler.java
@@ -1,6 +1,7 @@
 package com.drew.metadata.avi;
 
 import com.drew.imaging.riff.RiffHandler;
+import com.drew.lang.ByteArrayReader;
 import com.drew.lang.SequentialByteArrayReader;
 import com.drew.lang.annotations.NotNull;
 import com.drew.metadata.Metadata;
@@ -8,74 +9,120 @@ import com.drew.metadata.Metadata;
 import java.io.IOException;
 
 /**
- * Source: http://www.alexander-noe.com/video/documentation/avi.pdf
+ * Implementation of {@link RiffHandler} specialising in Wav support.
+ *
+ * Extracts data from chunk/list types:
+ *
+ * <ul>
+ *     <li><code>"avih"</code>: width, height, streams</li>
+ *     <li><code>"strh"</code>: frames/second, samples/second, duration, video codec</li>
+ * </ul>
+ *
+ * Sources: http://www.alexander-noe.com/video/documentation/avi.pdf
+ *          https://msdn.microsoft.com/en-us/library/ms899422.aspx
+ *          https://www.loc.gov/preservation/digital/formats/fdd/fdd000025.shtml
  *
  * @author Payton Garland
  */
 public class AviRiffHandler implements RiffHandler
 {
     @NotNull
-    private final Metadata _metadata;
+    private final AviDirectory _directory;
+
+    @NotNull
+    private String _currentList = "";
 
     public AviRiffHandler(@NotNull Metadata metadata)
     {
-        _metadata = metadata;
+        _directory = new AviDirectory();
+        metadata.addDirectory(_directory);
     }
 
     public boolean shouldAcceptRiffIdentifier(@NotNull String identifier)
     {
-        return identifier.equals("AVI ");
+        return identifier.equals(AviDirectory.FORMAT);
     }
 
     public boolean shouldAcceptChunk(@NotNull String fourCC)
     {
-        return fourCC.equals("strh");
+        return fourCC.equals(AviDirectory.CHUNK_STREAM_HEADER)
+            || fourCC.equals(AviDirectory.CHUNK_MAIN_HEADER);
     }
 
     public boolean shouldAcceptList(@NotNull String fourCC)
     {
-        return fourCC.equals("hdrl")
-            || fourCC.equals("strl");
+        if (fourCC.equals(AviDirectory.LIST_HEADER) || fourCC.equals(AviDirectory.LIST_STREAM_HEADER) || fourCC.equals(AviDirectory.FORMAT)) {
+            _currentList = fourCC;
+        } else {
+            _currentList = "";
+        }
+        return fourCC.equals(AviDirectory.LIST_HEADER)
+            || fourCC.equals(AviDirectory.LIST_STREAM_HEADER)
+            || fourCC.equals(AviDirectory.FORMAT);
     }
 
     public void processChunk(@NotNull String fourCC, @NotNull byte[] payload)
     {
-        System.out.println(fourCC);
-        AviDirectory directory = new AviDirectory();
-        _metadata.addDirectory(directory);
-
-//        System.out.println("Chunk " + fourCC + " " + payload.length + " bytes");
         try {
-            if (fourCC.equals("strh")) {
-                SequentialByteArrayReader reader = new SequentialByteArrayReader(payload);
+            if (fourCC.equals(AviDirectory.CHUNK_STREAM_HEADER)) {
+                ByteArrayReader reader = new ByteArrayReader(payload);
                 reader.setMotorolaByteOrder(false);
 
-                String fccType = new String(reader.getBytes(4));
-                String fccHandler = new String(reader.getBytes(4));
-                int dwFlags = reader.getInt32();
-                int wPriority = reader.getInt16();
-                int wLanguage = reader.getInt16();
-                int dwInitialFrames = reader.getInt32();
-                float dwScale = reader.getFloat32();
-                float dwRate = reader.getFloat32();
-                int dwStart = reader.getInt32();
-                int dwLength = reader.getInt32();
-                int dwSuggestedBufferSize = reader.getInt32();
-                int dwQuality = reader.getInt32();
-                int dwSampleSize = reader.getInt32();
-                int rcFrame = reader.getInt16();
+                String fccType = new String(reader.getBytes(0, 4));
+                String fccHandler = new String(reader.getBytes(4, 4));
+//                int dwFlags = reader.getInt32(8);
+//                int wPriority = reader.getInt16(12);
+//                int wLanguage = reader.getInt16(14);
+//                int dwInitialFrames = reader.getInt32(16);
+                float dwScale = reader.getFloat32(20);
+                float dwRate = reader.getFloat32(24);
+//                int dwStart = reader.getInt32(28);
+                int dwLength = reader.getInt32(32);
+//                int dwSuggestedBufferSize = reader.getInt32(36);
+//                int dwQuality = reader.getInt32(40);
+//                int dwSampleSize = reader.getInt32(44);
+//                byte[] rcFrame = reader.getBytes(48, 2);
 
                 if (fccType.equals("vids")) {
-                    directory.setDouble(AviDirectory.TAG_FRAMES_PER_SECOND, (dwRate/dwScale));
+                    if (!_directory.containsTag(AviDirectory.TAG_FRAMES_PER_SECOND)) {
+                        _directory.setDouble(AviDirectory.TAG_FRAMES_PER_SECOND, (dwRate / dwScale));
+
+                        double duration = dwLength / (dwRate / dwScale);
+                        Integer hours = (int) duration / (int) (Math.pow(60, 2));
+                        Integer minutes = ((int) duration / (int) (Math.pow(60, 1))) - (hours * 60);
+                        Integer seconds = (int) Math.round((duration / (Math.pow(60, 0))) - (minutes * 60));
+                        String time = String.format("%1$02d:%2$02d:%3$02d", hours, minutes, seconds);
+
+                        _directory.setString(AviDirectory.TAG_DURATION, time);
+                        _directory.setString(AviDirectory.TAG_VIDEO_CODEC, fccHandler);
+                    }
                 } else if (fccType.equals("auds")) {
-                    directory.setDouble(AviDirectory.TAG_SAMPLES_PER_SECOND, (dwRate/dwScale));
+                    if (!_directory.containsTag(AviDirectory.TAG_SAMPLES_PER_SECOND)) {
+                        _directory.setDouble(AviDirectory.TAG_SAMPLES_PER_SECOND, (dwRate / dwScale));
+                    }
                 }
+            } else if (fourCC.equals(AviDirectory.CHUNK_MAIN_HEADER)) {
+                ByteArrayReader reader = new ByteArrayReader(payload);
+                reader.setMotorolaByteOrder(false);
 
-                System.out.println(dwRate/dwScale);
+//                int dwMicroSecPerFrame = reader.getInt32(0);
+//                int dwMaxBytesPerSec = reader.getInt32(4);
+//                int dwPaddingGranularity = reader.getInt32(8);
+//                int dwFlags = reader.getInt32(12);
+//                int dwTotalFrames = reader.getInt32(16);
+//                int dwInitialFrames = reader.getInt32(20);
+                int dwStreams = reader.getInt32(24);
+//                int dwSuggestedBufferSize = reader.getInt32(28);
+                int dwWidth = reader.getInt32(32);
+                int dwHeight = reader.getInt32(36);
+//                byte[] dwReserved = reader.getBytes(40, 4);
+
+                _directory.setInt(AviDirectory.TAG_WIDTH, dwWidth);
+                _directory.setInt(AviDirectory.TAG_HEIGHT, dwHeight);
+                _directory.setInt(AviDirectory.TAG_STREAMS, dwStreams);
             }
-        } catch (IOException e) {
-            e.printStackTrace();
+        } catch (IOException ex) {
+            _directory.addError(ex.getMessage());
         }
-
     }
 }

--- a/Source/com/drew/metadata/avi/package-info.java
+++ b/Source/com/drew/metadata/avi/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Contains classes for the extraction and modelling of AVI file metadata.
+ */
+package com.drew.metadata.avi;

--- a/Source/com/drew/metadata/file/FileMetadataDirectory.java
+++ b/Source/com/drew/metadata/file/FileMetadataDirectory.java
@@ -36,6 +36,7 @@ public class FileMetadataDirectory extends Directory
     public static final int TAG_FILE_MODIFIED_DATE = 3;
     public static final int TAG_FILE_TYPE = 4;
     public static final int TAG_FILE_MIME_TYPE = 5;
+    public static final int TAG_FILE_EXTENSION = 6;
 
     @NotNull
     protected static final HashMap<Integer, String> _tagNameMap = new HashMap<Integer, String>();
@@ -46,6 +47,7 @@ public class FileMetadataDirectory extends Directory
         _tagNameMap.put(TAG_FILE_MODIFIED_DATE, "File Modified Date");
         _tagNameMap.put(TAG_FILE_TYPE, "File Type");
         _tagNameMap.put(TAG_FILE_MIME_TYPE, "MIME Type");
+        _tagNameMap.put(TAG_FILE_EXTENSION, "File Extensions");
     }
 
     public FileMetadataDirectory()

--- a/Source/com/drew/metadata/file/FileMetadataDirectory.java
+++ b/Source/com/drew/metadata/file/FileMetadataDirectory.java
@@ -34,6 +34,8 @@ public class FileMetadataDirectory extends Directory
     public static final int TAG_FILE_NAME = 1;
     public static final int TAG_FILE_SIZE = 2;
     public static final int TAG_FILE_MODIFIED_DATE = 3;
+    public static final int TAG_FILE_TYPE = 4;
+    public static final int TAG_FILE_MIME_TYPE = 5;
 
     @NotNull
     protected static final HashMap<Integer, String> _tagNameMap = new HashMap<Integer, String>();
@@ -42,6 +44,8 @@ public class FileMetadataDirectory extends Directory
         _tagNameMap.put(TAG_FILE_NAME, "File Name");
         _tagNameMap.put(TAG_FILE_SIZE, "File Size");
         _tagNameMap.put(TAG_FILE_MODIFIED_DATE, "File Modified Date");
+        _tagNameMap.put(TAG_FILE_TYPE, "File Type");
+        _tagNameMap.put(TAG_FILE_MIME_TYPE, "MIME Type");
     }
 
     public FileMetadataDirectory()

--- a/Source/com/drew/metadata/file/FileMetadataReader.java
+++ b/Source/com/drew/metadata/file/FileMetadataReader.java
@@ -60,6 +60,10 @@ public class FileMetadataReader
             directory.setString(FileMetadataDirectory.TAG_FILE_MIME_TYPE, fileType.getMimeType());
         }
 
+        if (fileType.getExtension() != null) {
+            directory.setStringArray(FileMetadataDirectory.TAG_FILE_EXTENSION, fileType.getExtension());
+        }
+
         metadata.addDirectory(directory);
     }
 }

--- a/Source/com/drew/metadata/file/FileMetadataReader.java
+++ b/Source/com/drew/metadata/file/FileMetadataReader.java
@@ -25,10 +25,7 @@ import com.drew.imaging.FileTypeDetector;
 import com.drew.lang.annotations.NotNull;
 import com.drew.metadata.Metadata;
 
-import java.io.BufferedInputStream;
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.IOException;
+import java.io.*;
 import java.util.Date;
 
 public class FileMetadataReader
@@ -42,14 +39,22 @@ public class FileMetadataReader
         if (!file.canRead())
             throw new IOException("File is not readable");
 
-        FileMetadataDirectory directory = new FileMetadataDirectory();
-        FileInputStream inputStream = new FileInputStream(file);
-        FileType fileType = FileTypeDetector.detectFileType(new BufferedInputStream(inputStream));
-        inputStream.close();
+        FileMetadataDirectory directory = metadata.getFirstDirectoryOfType(FileMetadataDirectory.class);
+
+        if (directory == null) {
+            directory = new FileMetadataDirectory();
+            metadata.addDirectory(directory);
+        }
 
         directory.setString(FileMetadataDirectory.TAG_FILE_NAME, file.getName());
         directory.setLong(FileMetadataDirectory.TAG_FILE_SIZE, file.length());
         directory.setDate(FileMetadataDirectory.TAG_FILE_MODIFIED_DATE, new Date(file.lastModified()));
+    }
+
+    public void read(@NotNull Metadata metadata, @NotNull FileType fileType) throws IOException
+    {
+        FileMetadataDirectory directory = new FileMetadataDirectory();
+
         directory.setString(FileMetadataDirectory.TAG_FILE_TYPE, fileType.getName());
         if (fileType.getMimeType() != null) {
             directory.setString(FileMetadataDirectory.TAG_FILE_MIME_TYPE, fileType.getMimeType());

--- a/Source/com/drew/metadata/file/FileMetadataReader.java
+++ b/Source/com/drew/metadata/file/FileMetadataReader.java
@@ -20,10 +20,14 @@
  */
 package com.drew.metadata.file;
 
+import com.drew.imaging.FileType;
+import com.drew.imaging.FileTypeDetector;
 import com.drew.lang.annotations.NotNull;
 import com.drew.metadata.Metadata;
 
+import java.io.BufferedInputStream;
 import java.io.File;
+import java.io.FileInputStream;
 import java.io.IOException;
 import java.util.Date;
 
@@ -39,10 +43,17 @@ public class FileMetadataReader
             throw new IOException("File is not readable");
 
         FileMetadataDirectory directory = new FileMetadataDirectory();
+        FileInputStream inputStream = new FileInputStream(file);
+        FileType fileType = FileTypeDetector.detectFileType(new BufferedInputStream(inputStream));
+        inputStream.close();
 
         directory.setString(FileMetadataDirectory.TAG_FILE_NAME, file.getName());
         directory.setLong(FileMetadataDirectory.TAG_FILE_SIZE, file.length());
         directory.setDate(FileMetadataDirectory.TAG_FILE_MODIFIED_DATE, new Date(file.lastModified()));
+        directory.setString(FileMetadataDirectory.TAG_FILE_TYPE, fileType.getName());
+        if (fileType.getMimeType() != null) {
+            directory.setString(FileMetadataDirectory.TAG_FILE_MIME_TYPE, fileType.getMimeType());
+        }
 
         metadata.addDirectory(directory);
     }

--- a/Source/com/drew/metadata/wav/WavDescriptor.java
+++ b/Source/com/drew/metadata/wav/WavDescriptor.java
@@ -1,0 +1,26 @@
+package com.drew.metadata.wav;
+
+import com.drew.lang.annotations.NotNull;
+import com.drew.lang.annotations.Nullable;
+import com.drew.metadata.TagDescriptor;
+
+/**
+ * @author Payton Garland
+ */
+public class WavDescriptor extends TagDescriptor<WavDirectory>
+{
+    public WavDescriptor(@NotNull WavDirectory directory)
+    {
+        super(directory);
+    }
+
+    @Override
+    @Nullable
+    public String getDescription(int tagType)
+    {
+        switch (tagType) {
+            default:
+                return super.getDescription(tagType);
+        }
+    }
+}

--- a/Source/com/drew/metadata/wav/WavDescriptor.java
+++ b/Source/com/drew/metadata/wav/WavDescriptor.java
@@ -18,9 +18,6 @@ public class WavDescriptor extends TagDescriptor<WavDirectory>
     @Nullable
     public String getDescription(int tagType)
     {
-        switch (tagType) {
-            default:
-                return super.getDescription(tagType);
-        }
+        return super.getDescription(tagType);
     }
 }

--- a/Source/com/drew/metadata/wav/WavDirectory.java
+++ b/Source/com/drew/metadata/wav/WavDirectory.java
@@ -6,6 +6,8 @@ import com.drew.metadata.Directory;
 import java.util.HashMap;
 
 /**
+ * Holds basic metadata from Wav files including some ID3 tags
+ *
  * @author Payton Garland
  */
 public class WavDirectory extends Directory
@@ -16,17 +18,305 @@ public class WavDirectory extends Directory
     public static final int TAG_BYTES_PER_SEC = 4;
     public static final int TAG_BLOCK_ALIGNMENT = 5;
     public static final int TAG_BITS_PER_SAMPLE = 6;
+    public static final int TAG_ARTIST = 7;
+    public static final int TAG_TITLE = 8;
+    public static final int TAG_PRODUCT = 9;
+    public static final int TAG_TRACK_NUMBER = 10;
+    public static final int TAG_DATE_CREATED = 11;
+    public static final int TAG_GENRE = 12;
+    public static final int TAG_COMMENTS = 13;
+    public static final int TAG_COPYRIGHT = 14;
+    public static final int TAG_SOFTWARE = 15;
+    public static final int TAG_DURATION = 16;
+
+    public static final String CHUNK_FORMAT = "fmt ";
+    public static final String CHUNK_DATA = "data";
+
+    public static final String LIST_INFO = "INFO";
+
+    public static final String FORMAT = "WAVE";
 
     @NotNull
     protected static final HashMap<Integer, String> _tagNameMap = new HashMap<Integer, String>();
 
+    @NotNull
+    protected transient static final HashMap<String, Integer> _tagIntegerMap = new HashMap<String, Integer>();
+
+    @NotNull
+    protected transient static final HashMap<Integer, String> _audioEncodingMap = new HashMap<Integer, String>();
+
     static {
+        _tagIntegerMap.put("IART", TAG_ARTIST);
+        _tagIntegerMap.put("INAM", TAG_TITLE);
+        _tagIntegerMap.put("IPRD", TAG_PRODUCT);
+        _tagIntegerMap.put("ITRK", TAG_TRACK_NUMBER);
+        _tagIntegerMap.put("ICRD", TAG_DATE_CREATED);
+        _tagIntegerMap.put("IGNR", TAG_GENRE);
+        _tagIntegerMap.put("ICMT", TAG_COMMENTS);
+        _tagIntegerMap.put("ICOP", TAG_COPYRIGHT);
+        _tagIntegerMap.put("ISFT", TAG_SOFTWARE);
+
         _tagNameMap.put(TAG_FORMAT, "Format");
         _tagNameMap.put(TAG_CHANNELS, "Channels");
         _tagNameMap.put(TAG_SAMPLES_PER_SEC, "Samples Per Second");
         _tagNameMap.put(TAG_BYTES_PER_SEC, "Bytes Per Second");
         _tagNameMap.put(TAG_BLOCK_ALIGNMENT, "Block Alignment");
         _tagNameMap.put(TAG_BITS_PER_SAMPLE, "Bits Per Sample");
+        _tagNameMap.put(TAG_ARTIST, "Artist");
+        _tagNameMap.put(TAG_TITLE, "Title");
+        _tagNameMap.put(TAG_PRODUCT, "Product");
+        _tagNameMap.put(TAG_TRACK_NUMBER, "Track Number");
+        _tagNameMap.put(TAG_DATE_CREATED, "Date Created");
+        _tagNameMap.put(TAG_GENRE, "Genre");
+        _tagNameMap.put(TAG_COMMENTS, "Comments");
+        _tagNameMap.put(TAG_COPYRIGHT, "Copyright");
+        _tagNameMap.put(TAG_SOFTWARE, "Software");
+        _tagNameMap.put(TAG_DURATION, "Duration");
+
+        // Audio encoding tags from http://www.sno.phy.queensu.ca/~phil/exiftool/TagNames/RIFF.html#AudioEncoding
+        _audioEncodingMap.put(0x1, "Microsoft PCM");
+        _audioEncodingMap.put(0x2, "Microsoft ADPCM");
+        _audioEncodingMap.put(0x3, "Microsoft IEEE float");
+        _audioEncodingMap.put(0x4, "Compaq VSELP");
+        _audioEncodingMap.put(0x5, "IBM CVSD");
+        _audioEncodingMap.put(0x6, "Microsoft a-Law");
+        _audioEncodingMap.put(0x7, "Microsoft u-Law");
+        _audioEncodingMap.put(0x8, "Microsoft DTS");
+        _audioEncodingMap.put(0x9, "DRM");
+        _audioEncodingMap.put(0xa, "WMA 9 Speech");
+        _audioEncodingMap.put(0xb, "Microsoft Windows Media RT Voice");
+        _audioEncodingMap.put(0x10, "OKI-ADPCM");
+        _audioEncodingMap.put(0x11, "Intel IMA/DVI-ADPCM");
+        _audioEncodingMap.put(0x12, "Videologic Mediaspace ADPCM");
+        _audioEncodingMap.put(0x13, "Sierra ADPCM");
+        _audioEncodingMap.put(0x14, "Antex G.723 ADPCM");
+        _audioEncodingMap.put(0x15, "DSP Solutions DIGISTD");
+        _audioEncodingMap.put(0x16, "DSP Solutions DIGIFIX");
+        _audioEncodingMap.put(0x17, "Dialoic OKI ADPCM");
+        _audioEncodingMap.put(0x18, "Media Vision ADPCM");
+        _audioEncodingMap.put(0x19, "HP CU");
+        _audioEncodingMap.put(0x1a, "HP Dynamic Voice");
+        _audioEncodingMap.put(0x20, "Yamaha ADPCM");
+        _audioEncodingMap.put(0x21, "SONARC Speech Compression");
+        _audioEncodingMap.put(0x22, "DSP Group True Speech");
+        _audioEncodingMap.put(0x23, "Echo Speech Corp.");
+        _audioEncodingMap.put(0x24, "Virtual Music Audiofile AF36");
+        _audioEncodingMap.put(0x25, "Audio Processing Tech.");
+        _audioEncodingMap.put(0x26, "Virtual Music Audiofile AF10");
+        _audioEncodingMap.put(0x27, "Aculab Prosody 1612");
+        _audioEncodingMap.put(0x28, "Merging Tech. LRC");
+        _audioEncodingMap.put(0x30, "Dolby AC2");
+        _audioEncodingMap.put(0x31, "Microsoft GSM610");
+        _audioEncodingMap.put(0x32, "MSN Audio");
+        _audioEncodingMap.put(0x33, "Antex ADPCME");
+        _audioEncodingMap.put(0x34, "Control Resources VQLPC");
+        _audioEncodingMap.put(0x35, "DSP Solutions DIGIREAL");
+        _audioEncodingMap.put(0x36, "DSP Solutions DIGIADPCM");
+        _audioEncodingMap.put(0x37, "Control Resources CR10");
+        _audioEncodingMap.put(0x38, "Natural MicroSystems VBX ADPCM");
+        _audioEncodingMap.put(0x39, "Crystal Semiconductor IMA ADPCM");
+        _audioEncodingMap.put(0x3a, "Echo Speech ECHOSC3");
+        _audioEncodingMap.put(0x3b, "Rockwell ADPCM");
+        _audioEncodingMap.put(0x3c, "Rockwell DIGITALK");
+        _audioEncodingMap.put(0x3d, "Xebec Multimedia");
+        _audioEncodingMap.put(0x40, "Antex G.721 ADPCM");
+        _audioEncodingMap.put(0x41, "Antex G.728 CELP");
+        _audioEncodingMap.put(0x42, "Microsoft MSG723");
+        _audioEncodingMap.put(0x43, "IBM AVC ADPCM");
+        _audioEncodingMap.put(0x45, "ITU-T G.726");
+        _audioEncodingMap.put(0x50, "Microsoft MPEG");
+        _audioEncodingMap.put(0x51, "RT23 or PAC");
+        _audioEncodingMap.put(0x52, "InSoft RT24");
+        _audioEncodingMap.put(0x53, "InSoft PAC");
+        _audioEncodingMap.put(0x55, "MP3");
+        _audioEncodingMap.put(0x59, "Cirrus");
+        _audioEncodingMap.put(0x60, "Cirrus Logic");
+        _audioEncodingMap.put(0x61, "ESS Tech. PCM");
+        _audioEncodingMap.put(0x62, "Voxware Inc.");
+        _audioEncodingMap.put(0x63, "Canopus ATRAC");
+        _audioEncodingMap.put(0x64, "APICOM G.726 ADPCM");
+        _audioEncodingMap.put(0x65, "APICOM G.722 ADPCM");
+        _audioEncodingMap.put(0x66, "Microsoft DSAT");
+        _audioEncodingMap.put(0x67, "Micorsoft DSAT DISPLAY");
+        _audioEncodingMap.put(0x69, "Voxware Byte Aligned");
+        _audioEncodingMap.put(0x70, "Voxware AC8");
+        _audioEncodingMap.put(0x71, "Voxware AC10");
+        _audioEncodingMap.put(0x72, "Voxware AC16");
+        _audioEncodingMap.put(0x73, "Voxware AC20");
+        _audioEncodingMap.put(0x74, "Voxware MetaVoice");
+        _audioEncodingMap.put(0x75, "Voxware MetaSound");
+        _audioEncodingMap.put(0x76, "Voxware RT29HW");
+        _audioEncodingMap.put(0x77, "Voxware VR12");
+        _audioEncodingMap.put(0x78, "Voxware VR18");
+        _audioEncodingMap.put(0x79, "Voxware TQ40");
+        _audioEncodingMap.put(0x7a, "Voxware SC3");
+        _audioEncodingMap.put(0x7b, "Voxware SC3");
+        _audioEncodingMap.put(0x80, "Soundsoft");
+        _audioEncodingMap.put(0x81, "Voxware TQ60");
+        _audioEncodingMap.put(0x82, "Microsoft MSRT24");
+        _audioEncodingMap.put(0x83, "AT&T G.729A");
+        _audioEncodingMap.put(0x84, "Motion Pixels MVI MV12");
+        _audioEncodingMap.put(0x85, "DataFusion G.726");
+        _audioEncodingMap.put(0x86, "DataFusion GSM610");
+        _audioEncodingMap.put(0x88, "Iterated Systems Audio");
+        _audioEncodingMap.put(0x89, "Onlive");
+        _audioEncodingMap.put(0x8a, "Multitude, Inc. FT SX20");
+        _audioEncodingMap.put(0x8b, "Infocom ITS A/S G.721 ADPCM");
+        _audioEncodingMap.put(0x8c, "Convedia G729");
+        _audioEncodingMap.put(0x8d, "Not specified congruency, Inc.");
+        _audioEncodingMap.put(0x91, "Siemens SBC24");
+        _audioEncodingMap.put(0x92, "Sonic Foundry Dolby AC3 APDIF");
+        _audioEncodingMap.put(0x93, "MediaSonic G.723");
+        _audioEncodingMap.put(0x94, "Aculab Prosody 8kbps");
+        _audioEncodingMap.put(0x97, "ZyXEL ADPCM");
+        _audioEncodingMap.put(0x98, "Philips LPCBB");
+        _audioEncodingMap.put(0x99, "Studer Professional Audio Packed");
+        _audioEncodingMap.put(0xa0, "Malden PhonyTalk");
+        _audioEncodingMap.put(0xa1, "Racal Recorder GSM");
+        _audioEncodingMap.put(0xa2, "Racal Recorder G720.a");
+        _audioEncodingMap.put(0xa3, "Racal G723.1");
+        _audioEncodingMap.put(0xa4, "Racal Tetra ACELP");
+        _audioEncodingMap.put(0xb0, "NEC AAC NEC Corporation");
+        _audioEncodingMap.put(0xff, "AAC");
+        _audioEncodingMap.put(0x100, "Rhetorex ADPCM");
+        _audioEncodingMap.put(0x101, "IBM u-Law");
+        _audioEncodingMap.put(0x102, "IBM a-Law");
+        _audioEncodingMap.put(0x103, "IBM ADPCM");
+        _audioEncodingMap.put(0x111, "Vivo G.723");
+        _audioEncodingMap.put(0x112, "Vivo Siren");
+        _audioEncodingMap.put(0x120, "Philips Speech Processing CELP");
+        _audioEncodingMap.put(0x121, "Philips Speech Processing GRUNDIG");
+        _audioEncodingMap.put(0x123, "Digital G.723");
+        _audioEncodingMap.put(0x125, "Sanyo LD ADPCM");
+        _audioEncodingMap.put(0x130, "Sipro Lab ACEPLNET");
+        _audioEncodingMap.put(0x131, "Sipro Lab ACELP4800");
+        _audioEncodingMap.put(0x132, "Sipro Lab ACELP8V3");
+        _audioEncodingMap.put(0x133, "Sipro Lab G.729");
+        _audioEncodingMap.put(0x134, "Sipro Lab G.729A");
+        _audioEncodingMap.put(0x135, "Sipro Lab Kelvin");
+        _audioEncodingMap.put(0x136, "VoiceAge AMR");
+        _audioEncodingMap.put(0x140, "Dictaphone G.726 ADPCM");
+        _audioEncodingMap.put(0x150, "Qualcomm PureVoice");
+        _audioEncodingMap.put(0x151, "Qualcomm HalfRate");
+        _audioEncodingMap.put(0x155, "Ring Zero Systems TUBGSM");
+        _audioEncodingMap.put(0x160, "Microsoft Audio1");
+        _audioEncodingMap.put(0x161, "Windows Media Audio V2 V7 V8 V9 / DivX audio (WMA) / Alex AC3 Audio");
+        _audioEncodingMap.put(0x162, "Windows Media Audio Professional V9");
+        _audioEncodingMap.put(0x163, "Windows Media Audio Lossless V9");
+        _audioEncodingMap.put(0x164, "WMA Pro over S/PDIF");
+        _audioEncodingMap.put(0x170, "UNISYS NAP ADPCM");
+        _audioEncodingMap.put(0x171, "UNISYS NAP ULAW");
+        _audioEncodingMap.put(0x172, "UNISYS NAP ALAW");
+        _audioEncodingMap.put(0x173, "UNISYS NAP 16K");
+        _audioEncodingMap.put(0x174, "MM SYCOM ACM SYC008 SyCom Technologies");
+        _audioEncodingMap.put(0x175, "MM SYCOM ACM SYC701 G726L SyCom Technologies");
+        _audioEncodingMap.put(0x176, "MM SYCOM ACM SYC701 CELP54 SyCom Technologies");
+        _audioEncodingMap.put(0x177, "MM SYCOM ACM SYC701 CELP68 SyCom Technologies");
+        _audioEncodingMap.put(0x178, "Knowledge Adventure ADPCM");
+        _audioEncodingMap.put(0x180, "Fraunhofer IIS MPEG2AAC");
+        _audioEncodingMap.put(0x190, "Digital Theater Systems DTS DS");
+        _audioEncodingMap.put(0x200, "Creative Labs ADPCM");
+        _audioEncodingMap.put(0x202, "Creative Labs FASTSPEECH8");
+        _audioEncodingMap.put(0x203, "Creative Labs FASTSPEECH10");
+        _audioEncodingMap.put(0x210, "UHER ADPCM");
+        _audioEncodingMap.put(0x215, "Ulead DV ACM");
+        _audioEncodingMap.put(0x216, "Ulead DV ACM");
+        _audioEncodingMap.put(0x220, "Quarterdeck Corp.");
+        _audioEncodingMap.put(0x230, "I-Link VC");
+        _audioEncodingMap.put(0x240, "Aureal Semiconductor Raw Sport");
+        _audioEncodingMap.put(0x241, "ESST AC3");
+        _audioEncodingMap.put(0x250, "Interactive Products HSX");
+        _audioEncodingMap.put(0x251, "Interactive Products RPELP");
+        _audioEncodingMap.put(0x260, "Consistent CS2");
+        _audioEncodingMap.put(0x270, "Sony SCX");
+        _audioEncodingMap.put(0x271, "Sony SCY");
+        _audioEncodingMap.put(0x272, "Sony ATRAC3");
+        _audioEncodingMap.put(0x273, "Sony SPC");
+        _audioEncodingMap.put(0x280, "TELUM Telum Inc.");
+        _audioEncodingMap.put(0x281, "TELUMIA Telum Inc.");
+        _audioEncodingMap.put(0x285, "Norcom Voice Systems ADPCM");
+        _audioEncodingMap.put(0x300, "Fujitsu FM TOWNS SND");
+        _audioEncodingMap.put(0x301, "Fujitsu (not specified)");
+        _audioEncodingMap.put(0x302, "Fujitsu (not specified)");
+        _audioEncodingMap.put(0x303, "Fujitsu (not specified)");
+        _audioEncodingMap.put(0x304, "Fujitsu (not specified)");
+        _audioEncodingMap.put(0x305, "Fujitsu (not specified)");
+        _audioEncodingMap.put(0x306, "Fujitsu (not specified)");
+        _audioEncodingMap.put(0x307, "Fujitsu (not specified)");
+        _audioEncodingMap.put(0x308, "Fujitsu (not specified)");
+        _audioEncodingMap.put(0x350, "Micronas Semiconductors, Inc. Development");
+        _audioEncodingMap.put(0x351, "Micronas Semiconductors, Inc. CELP833");
+        _audioEncodingMap.put(0x400, "Brooktree Digital");
+        _audioEncodingMap.put(0x401, "Intel Music Coder (IMC)");
+        _audioEncodingMap.put(0x402, "Ligos Indeo Audio");
+        _audioEncodingMap.put(0x450, "QDesign Music");
+        _audioEncodingMap.put(0x500, "On2 VP7 On2 Technologies");
+        _audioEncodingMap.put(0x501, "On2 VP6 On2 Technologies");
+        _audioEncodingMap.put(0x680, "AT&T VME VMPCM");
+        _audioEncodingMap.put(0x681, "AT&T TCP");
+        _audioEncodingMap.put(0x700, "YMPEG Alpha (dummy for MPEG-2 compressor)");
+        _audioEncodingMap.put(0x8ae, "ClearJump LiteWave (lossless)");
+        _audioEncodingMap.put(0x1000, "Olivetti GSM");
+        _audioEncodingMap.put(0x1001, "Olivetti ADPCM");
+        _audioEncodingMap.put(0x1002, "Olivetti CELP");
+        _audioEncodingMap.put(0x1003, "Olivetti SBC");
+        _audioEncodingMap.put(0x1004, "Olivetti OPR");
+        _audioEncodingMap.put(0x1100, "Lernout & Hauspie");
+        _audioEncodingMap.put(0x1101, "Lernout & Hauspie CELP codec");
+        _audioEncodingMap.put(0x1102, "Lernout & Hauspie SBC codec");
+        _audioEncodingMap.put(0x1103, "Lernout & Hauspie SBC codec");
+        _audioEncodingMap.put(0x1104, "Lernout & Hauspie SBC codec");
+        _audioEncodingMap.put(0x1400, "Norris Comm. Inc.");
+        _audioEncodingMap.put(0x1401, "ISIAudio");
+        _audioEncodingMap.put(0x1500, "AT&T Soundspace Music Compression");
+        _audioEncodingMap.put(0x181c, "VoxWare RT24 speech codec");
+        _audioEncodingMap.put(0x181e, "Lucent elemedia AX24000P Music codec");
+        _audioEncodingMap.put(0x1971, "Sonic Foundry LOSSLESS");
+        _audioEncodingMap.put(0x1979, "Innings Telecom Inc. ADPCM");
+        _audioEncodingMap.put(0x1c07, "Lucent SX8300P speech codec");
+        _audioEncodingMap.put(0x1c0c, "Lucent SX5363S G.723 compliant codec");
+        _audioEncodingMap.put(0x1f03, "CUseeMe DigiTalk (ex-Rocwell)");
+        _audioEncodingMap.put(0x1fc4, "NCT Soft ALF2CD ACM");
+        _audioEncodingMap.put(0x2000, "FAST Multimedia DVM");
+        _audioEncodingMap.put(0x2001, "Dolby DTS (Digital Theater System)");
+        _audioEncodingMap.put(0x2002, "RealAudio 1 / 2 14.4");
+        _audioEncodingMap.put(0x2003, "RealAudio 1 / 2 28.8");
+        _audioEncodingMap.put(0x2004, "RealAudio G2 / 8 Cook (low bitrate)");
+        _audioEncodingMap.put(0x2005, "RealAudio 3 / 4 / 5 Music (DNET)");
+        _audioEncodingMap.put(0x2006, "RealAudio 10 AAC (RAAC)");
+        _audioEncodingMap.put(0x2007, "RealAudio 10 AAC+ (RACP)");
+        _audioEncodingMap.put(0x2500, "Reserved range to 0x2600 Microsoft");
+        _audioEncodingMap.put(0x3313, "makeAVIS (ffvfw fake AVI sound from AviSynth scripts)");
+        _audioEncodingMap.put(0x4143, "Divio MPEG-4 AAC audio");
+        _audioEncodingMap.put(0x4201, "Nokia adaptive multirate");
+        _audioEncodingMap.put(0x4243, "Divio G726 Divio, Inc.");
+        _audioEncodingMap.put(0x434c, "LEAD Speech");
+        _audioEncodingMap.put(0x564c, "LEAD Vorbis");
+        _audioEncodingMap.put(0x5756, "WavPack Audio");
+        _audioEncodingMap.put(0x674f, "Ogg Vorbis (mode 1)");
+        _audioEncodingMap.put(0x6750, "Ogg Vorbis (mode 2)");
+        _audioEncodingMap.put(0x6751, "Ogg Vorbis (mode 3)");
+        _audioEncodingMap.put(0x676f, "Ogg Vorbis (mode 1+)");
+        _audioEncodingMap.put(0x6770, "Ogg Vorbis (mode 2+)");
+        _audioEncodingMap.put(0x6771, "Ogg Vorbis (mode 3+)");
+        _audioEncodingMap.put(0x7000, "3COM NBX 3Com Corporation");
+        _audioEncodingMap.put(0x706d, "FAAD AAC");
+        _audioEncodingMap.put(0x7a21, "GSM-AMR (CBR, no SID)");
+        _audioEncodingMap.put(0x7a22, "GSM-AMR (VBR, including SID)");
+        _audioEncodingMap.put(0xa100, "Comverse Infosys Ltd. G723 1");
+        _audioEncodingMap.put(0xa101, "Comverse Infosys Ltd. AVQSBC");
+        _audioEncodingMap.put(0xa102, "Comverse Infosys Ltd. OLDSBC");
+        _audioEncodingMap.put(0xa103, "Symbol Technologies G729A");
+        _audioEncodingMap.put(0xa104, "VoiceAge AMR WB VoiceAge Corporation");
+        _audioEncodingMap.put(0xa105, "Ingenient Technologies Inc. G726");
+        _audioEncodingMap.put(0xa106, "ISO/MPEG-4 advanced audio Coding");
+        _audioEncodingMap.put(0xa107, "Encore Software Ltd G726");
+        _audioEncodingMap.put(0xa109, "Speex ACM Codec xiph.org");
+        _audioEncodingMap.put(0xdfac, "DebugMode SonicFoundry Vegas FrameServer ACM Codec");
+        _audioEncodingMap.put(0xe708, "Unknown -");
+        _audioEncodingMap.put(0xf1ac, "Free Lossless Audio Codec FLAC");
+        _audioEncodingMap.put(0xfffe, "Extensible");
+        _audioEncodingMap.put(0xffff, "Development");
     }
 
     public WavDirectory()
@@ -35,12 +325,14 @@ public class WavDirectory extends Directory
     }
 
     @Override
-    public String getName() {
+    public String getName()
+    {
         return "WAV";
     }
 
     @Override
-    protected HashMap<Integer, String> getTagNameMap() {
+    protected HashMap<Integer, String> getTagNameMap()
+    {
         return _tagNameMap;
     }
 }

--- a/Source/com/drew/metadata/wav/WavDirectory.java
+++ b/Source/com/drew/metadata/wav/WavDirectory.java
@@ -1,0 +1,47 @@
+package com.drew.metadata.wav;
+
+import com.drew.lang.annotations.NotNull;
+import com.drew.metadata.Directory;
+
+import java.util.HashMap;
+
+/**
+ * @author Payton Garland
+ */
+public class WavDirectory extends Directory
+{
+
+    public static final int TAG_FORMAT = 1;
+    public static final int TAG_CHANNELS = 2;
+    public static final int TAG_SAMPLES_PER_SEC = 3;
+    public static final int TAG_BYTES_PER_SEC = 4;
+    public static final int TAG_BLOCK_ALIGNMENT = 5;
+    public static final int TAG_BITS_PER_SAMPLE = 6;
+
+    @NotNull
+    protected static final HashMap<Integer, String> _tagNameMap = new HashMap<Integer, String>();
+
+    static {
+        _tagNameMap.put(TAG_FORMAT, "Format");
+        _tagNameMap.put(TAG_CHANNELS, "Channels");
+        _tagNameMap.put(TAG_SAMPLES_PER_SEC, "Samples Per Second");
+        _tagNameMap.put(TAG_BYTES_PER_SEC, "Bytes Per Second");
+        _tagNameMap.put(TAG_BLOCK_ALIGNMENT, "Block Alignment");
+        _tagNameMap.put(TAG_BITS_PER_SAMPLE, "Bits Per Sample");
+    }
+
+    public WavDirectory()
+    {
+        this.setDescriptor(new WavDescriptor(this));
+    }
+
+    @Override
+    public String getName() {
+        return "WAV";
+    }
+
+    @Override
+    protected HashMap<Integer, String> getTagNameMap() {
+        return _tagNameMap;
+    }
+}

--- a/Source/com/drew/metadata/wav/WavDirectory.java
+++ b/Source/com/drew/metadata/wav/WavDirectory.java
@@ -10,7 +10,6 @@ import java.util.HashMap;
  */
 public class WavDirectory extends Directory
 {
-
     public static final int TAG_FORMAT = 1;
     public static final int TAG_CHANNELS = 2;
     public static final int TAG_SAMPLES_PER_SEC = 3;

--- a/Source/com/drew/metadata/wav/WavRiffHandler.java
+++ b/Source/com/drew/metadata/wav/WavRiffHandler.java
@@ -33,6 +33,11 @@ public class WavRiffHandler implements RiffHandler
         return fourCC.equals("fmt ");
     }
 
+    @Override
+    public boolean shouldAcceptList(String fourCC) {
+        return false;
+    }
+
     public void processChunk(@NotNull String fourCC, @NotNull byte[] payload)
     {
         WavDirectory directory = new WavDirectory();

--- a/Source/com/drew/metadata/wav/WavRiffHandler.java
+++ b/Source/com/drew/metadata/wav/WavRiffHandler.java
@@ -1,0 +1,87 @@
+package com.drew.metadata.wav;
+
+import com.drew.imaging.riff.RiffHandler;
+import com.drew.lang.ByteArrayReader;
+import com.drew.lang.annotations.NotNull;
+import com.drew.metadata.Metadata;
+
+import java.io.IOException;
+
+/**
+ * Sources: http://www.neurophys.wisc.edu/auditory/riff-format.txt
+ *          http://www-mmsp.ece.mcgill.ca/Documents/AudioFormats/WAVE/WAVE.html
+ *
+ * @author Payton Garland
+ */
+public class WavRiffHandler implements RiffHandler
+{
+    @NotNull
+    private final Metadata _metadata;
+
+    public WavRiffHandler(@NotNull Metadata metadata)
+    {
+        _metadata = metadata;
+    }
+
+    public boolean shouldAcceptRiffIdentifier(@NotNull String identifier)
+    {
+        return identifier.equals("WAVE");
+    }
+
+    public boolean shouldAcceptChunk(@NotNull String fourCC)
+    {
+        return fourCC.equals("fmt ");
+    }
+
+    public void processChunk(@NotNull String fourCC, @NotNull byte[] payload)
+    {
+        WavDirectory directory = new WavDirectory();
+        _metadata.addDirectory(directory);
+
+//        System.out.println("Chunk " + fourCC + " " + payload.length + " bytes");
+
+        try {
+            if (fourCC.equals("fmt ")) {
+                ByteArrayReader reader = new ByteArrayReader(payload);
+                reader.setMotorolaByteOrder(false);
+                int wFormatTag = reader.getInt16(0);
+                int wChannels = reader.getInt16(2);
+                int dwSamplesPerSec = reader.getInt32(4);
+                int dwAvgBytesPerSec = reader.getInt32(8);
+                int wBlockAlign = reader.getInt16(12);
+
+                switch (wFormatTag) {
+                    // Microsoft Pulse Code Modulation (PCM)
+                    case (0x0001):
+                        int wBitsPerSample = reader.getInt16(14);
+                        directory.setInt(WavDirectory.TAG_BITS_PER_SAMPLE, wBitsPerSample);
+                        directory.setString(WavDirectory.TAG_FORMAT, "Microsoft Pulse Code Modulation (PCM)");
+                        break;
+                    // IBM mu-law
+                    case (0x0101):
+                        // Contents not handled
+                        directory.setString(WavDirectory.TAG_FORMAT, "IBM mu-law");
+                        break;
+                    // IBM a-law
+                    case (0x0102):
+                        // Contents not handled
+                        directory.setString(WavDirectory.TAG_FORMAT, "IBM a-law");
+                        break;
+                    // IBM AVC Adaptive Differential Pulse Code Modulation
+                    case (0x0103):
+                        // Contents not handled
+                        directory.setString(WavDirectory.TAG_FORMAT, "IBM AVC Adaptive Differential Pulse Code Modulation");
+                        break;
+                    default:
+                }
+
+                directory.setInt(WavDirectory.TAG_CHANNELS, wChannels);
+                directory.setInt(WavDirectory.TAG_SAMPLES_PER_SEC, dwSamplesPerSec);
+                directory.setInt(WavDirectory.TAG_BYTES_PER_SEC, dwAvgBytesPerSec);
+                directory.setInt(WavDirectory.TAG_BLOCK_ALIGNMENT, wBlockAlign);
+            }
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+}

--- a/Source/com/drew/metadata/wav/package-info.java
+++ b/Source/com/drew/metadata/wav/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Contains classes for the extraction and modelling of WAV file metadata.
+ */
+package com.drew.metadata.wav;

--- a/Source/com/drew/metadata/webp/WebpDirectory.java
+++ b/Source/com/drew/metadata/webp/WebpDirectory.java
@@ -36,6 +36,15 @@ public class WebpDirectory extends Directory
     public static final int TAG_HAS_ALPHA = 3;
     public static final int TAG_IS_ANIMATION = 4;
 
+    public static final String CHUNK_VP8X = "VP8X";
+    public static final String CHUNK_VP8L = "VP8L";
+    public static final String CHUNK_VP8 = "VP8 ";
+    public static final String CHUNK_EXIF = "EXIF";
+    public static final String CHUNK_ICCP = "ICCP";
+    public static final String CHUNK_XMP = "XMP ";
+
+    public static final String FORMAT = "WEBP";
+
     @NotNull
     protected static final HashMap<Integer, String> _tagNameMap = new HashMap<Integer, String>();
 

--- a/Source/com/drew/metadata/webp/WebpRiffHandler.java
+++ b/Source/com/drew/metadata/webp/WebpRiffHandler.java
@@ -55,35 +55,36 @@ public class WebpRiffHandler implements RiffHandler
 
     public boolean shouldAcceptRiffIdentifier(@NotNull String identifier)
     {
-        return identifier.equals("WEBP");
+        return identifier.equals(WebpDirectory.FORMAT);
     }
 
     public boolean shouldAcceptChunk(@NotNull String fourCC)
     {
-        return fourCC.equals("VP8X")
-            || fourCC.equals("VP8L")
-            || fourCC.equals("VP8 ")
-            || fourCC.equals("EXIF")
-            || fourCC.equals("ICCP")
-            || fourCC.equals("XMP ");
+        return fourCC.equals(WebpDirectory.CHUNK_VP8X)
+            || fourCC.equals(WebpDirectory.CHUNK_VP8L)
+            || fourCC.equals(WebpDirectory.CHUNK_VP8)
+            || fourCC.equals(WebpDirectory.CHUNK_EXIF)
+            || fourCC.equals(WebpDirectory.CHUNK_ICCP)
+            || fourCC.equals(WebpDirectory.CHUNK_XMP);
     }
 
     @Override
-    public boolean shouldAcceptList(String fourCC) {
+    public boolean shouldAcceptList(String fourCC)
+    {
         return false;
     }
 
     public void processChunk(@NotNull String fourCC, @NotNull byte[] payload)
     {
 //        System.out.println("Chunk " + fourCC + " " + payload.length + " bytes");
-
-        if (fourCC.equals("EXIF")) {
+        WebpDirectory directory = new WebpDirectory();
+        if (fourCC.equals(WebpDirectory.CHUNK_EXIF)) {
             new ExifReader().extract(new ByteArrayReader(payload), _metadata);
-        } else if (fourCC.equals("ICCP")) {
+        } else if (fourCC.equals(WebpDirectory.CHUNK_ICCP)) {
             new IccReader().extract(new ByteArrayReader(payload), _metadata);
-        } else if (fourCC.equals("XMP ")) {
+        } else if (fourCC.equals(WebpDirectory.CHUNK_XMP)) {
             new XmpReader().extract(payload, _metadata);
-        } else if (fourCC.equals("VP8X") && payload.length == 10) {
+        } else if (fourCC.equals(WebpDirectory.CHUNK_VP8X) && payload.length == 10) {
             RandomAccessReader reader = new ByteArrayReader(payload);
             reader.setMotorolaByteOrder(false);
 
@@ -100,7 +101,6 @@ public class WebpRiffHandler implements RiffHandler
                 int widthMinusOne = reader.getInt24(4);
                 int heightMinusOne = reader.getInt24(7);
 
-                WebpDirectory directory = new WebpDirectory();
                 directory.setInt(WebpDirectory.TAG_IMAGE_WIDTH, widthMinusOne + 1);
                 directory.setInt(WebpDirectory.TAG_IMAGE_HEIGHT, heightMinusOne + 1);
                 directory.setBoolean(WebpDirectory.TAG_HAS_ALPHA, hasAlpha);
@@ -111,7 +111,7 @@ public class WebpRiffHandler implements RiffHandler
             } catch (IOException e) {
                 e.printStackTrace(System.err);
             }
-        } else if (fourCC.equals("VP8L") && payload.length > 4) {
+        } else if (fourCC.equals(WebpDirectory.CHUNK_VP8L) && payload.length > 4) {
             RandomAccessReader reader = new ByteArrayReader(payload);
             reader.setMotorolaByteOrder(false);
 
@@ -130,7 +130,6 @@ public class WebpRiffHandler implements RiffHandler
                 // 14 bits for height
                 int heightMinusOne = (b4 & 0x0F) << 10 | b3 << 2 | (b2 & 0xC0) >> 6;
 
-                WebpDirectory directory = new WebpDirectory();
                 directory.setInt(WebpDirectory.TAG_IMAGE_WIDTH, widthMinusOne + 1);
                 directory.setInt(WebpDirectory.TAG_IMAGE_HEIGHT, heightMinusOne + 1);
 
@@ -139,7 +138,7 @@ public class WebpRiffHandler implements RiffHandler
             } catch (IOException e) {
                 e.printStackTrace(System.err);
             }
-        } else if (fourCC.equals("VP8 ") && payload.length > 9) {
+        } else if (fourCC.equals(WebpDirectory.CHUNK_VP8) && payload.length > 9) {
             RandomAccessReader reader = new ByteArrayReader(payload);
             reader.setMotorolaByteOrder(false);
 
@@ -155,14 +154,13 @@ public class WebpRiffHandler implements RiffHandler
                 int width = reader.getUInt16(6);
                 int height = reader.getUInt16(8);
 
-                WebpDirectory directory = new WebpDirectory();
                 directory.setInt(WebpDirectory.TAG_IMAGE_WIDTH, width);
                 directory.setInt(WebpDirectory.TAG_IMAGE_HEIGHT, height);
 
                 _metadata.addDirectory(directory);
 
-            } catch (IOException e) {
-                e.printStackTrace(System.err);
+            } catch (IOException ex) {
+                directory.addError(ex.getMessage());
             }
         }
     }

--- a/Source/com/drew/metadata/webp/WebpRiffHandler.java
+++ b/Source/com/drew/metadata/webp/WebpRiffHandler.java
@@ -68,6 +68,11 @@ public class WebpRiffHandler implements RiffHandler
             || fourCC.equals("XMP ");
     }
 
+    @Override
+    public boolean shouldAcceptList(String fourCC) {
+        return false;
+    }
+
     public void processChunk(@NotNull String fourCC, @NotNull byte[] payload)
     {
 //        System.out.println("Chunk " + fourCC + " " + payload.length + " bytes");


### PR DESCRIPTION
Modified RiffReader to recursively find all chunks and lists within Riff files.  As a result, the RiffHandler interface has been changed to have a shouldAcceptList method.  There is now support for AVI and WAV file formats and room for expanding to any other Riff file types.

Since all Riff files have the same magic byte, I added a helper method to FileTypeDetector that is triggered when a Riff file is found.  It will simply check 4 bytes ahead to where the Riff file type magic bytes are located and decide whether it is WebP, AVI, or WAV.  If none are found, it remains Riff, which is now considered unsupported.