### PR TITLE
Add 'File Type' and 'MIME Type' to enum and container/content handling

### DIFF
--- a/Source/com/drew/imaging/FileType.java
+++ b/Source/com/drew/imaging/FileType.java
@@ -31,51 +31,66 @@ import com.drew.lang.annotations.Nullable;
  */
 public enum FileType
 {
-    Unknown("Unknown", null),
-    Jpeg("Jpeg", "image/jpeg"),
-    Tiff("Tiff", "image/tiff"),
-    Psd("Psd", "image/vnd.adobe.photoshop"),
-    Png("Png", "image/png"),
-    Bmp("Bmp", "image/bmp"),
-    Gif("Gif", "image/gif"),
-    Ico("Ico", "image/x-icon"),
-    Pcx("Pcx", "image/x-pcx"),
-    Riff("Riff", null),
+    Unknown(null, false),
+    Jpeg("image/jpeg", false, ".jpg", ".jpeg", ".jpe"),
+    Tiff("image/tiff", true, ".tiff", ".tif"),
+    Psd("image/vnd.adobe.photoshop", false, ".psd"),
+    Png("image/png", false, ".png"),
+    Bmp("image/bmp", false, ".bmp"),
+    Gif("image/gif", false, ".gif"),
+    Ico("image/x-icon", false, ".ico"),
+    Pcx("image/x-pcx", false, ".pcx"),
+    Riff(null, true, null),
 
     /** Sony camera raw. */
-    Arw("Arw", null),
+    Arw(null, false, ".arw"),
     /** Canon camera raw, version 1. */
-    Crw("Crw", null),
+    Crw(null, false, ".crw"),
     /** Canon camera raw, version 2. */
-    Cr2("Cr2", null),
+    Cr2(null, false, ".cr2"),
     /** Nikon camera raw. */
-    Nef("Nef", null),
+    Nef(null, false, ".nef"),
     /** Olympus camera raw. */
-    Orf("Orf", null),
+    Orf(null, false, ".orf"),
     /** FujiFilm camera raw. */
-    Raf("Raf", null),
+    Raf(null, false, ".raf"),
     /** Panasonic camera raw. */
-    Rw2("Rw2", null);
-
-    private final String _name;
+    Rw2(null, false, ".rw2");
 
     private final String _mimeType;
 
-    FileType(String name, String mimeType)
+    private final boolean _isContainer;
+
+    private final String[] _extensions;
+
+    FileType(String mimeType, boolean isContainer, String... extensions)
     {
-        _name = name;
         _mimeType = mimeType;
+        _isContainer = isContainer;
+        _extensions = extensions;
     }
 
     @NotNull
     public String getName()
     {
-        return _name;
+        return this.name();
     }
 
     @Nullable
     public String getMimeType()
     {
         return _mimeType;
+    }
+
+    @NotNull
+    public boolean getIsContainer()
+    {
+        return _isContainer;
+    }
+
+    @Nullable
+    public String[] getExtension()
+    {
+        return _extensions;
     }
 }

--- a/Source/com/drew/imaging/FileType.java
+++ b/Source/com/drew/imaging/FileType.java
@@ -20,34 +20,62 @@
  */
 package com.drew.imaging;
 
+import com.drew.lang.annotations.NotNull;
+import com.drew.lang.annotations.Nullable;
+
 /**
  * Enumeration of supported image file formats.
+ *
+ * MIME Type Source: https://www.freeformatter.com/mime-types-list.html
+ *                   https://www.iana.org/assignments/media-types/media-types.xhtml
  */
 public enum FileType
 {
-    Unknown,
-    Jpeg,
-    Tiff,
-    Psd,
-    Png,
-    Bmp,
-    Gif,
-    Ico,
-    Pcx,
-    Riff,
+    Unknown("Unknown", null),
+    Jpeg("Jpeg", "image/jpeg"),
+    Tiff("Tiff", "image/tiff"),
+    Psd("Psd", "image/vnd.adobe.photoshop"),
+    Png("Png", "image/png"),
+    Bmp("Bmp", "image/bmp"),
+    Gif("Gif", "image/gif"),
+    Ico("Ico", "image/x-icon"),
+    Pcx("Pcx", "image/x-pcx"),
+    Riff("Riff", null),
 
     /** Sony camera raw. */
-    Arw,
+    Arw("Arw", null),
     /** Canon camera raw, version 1. */
-    Crw,
+    Crw("Crw", null),
     /** Canon camera raw, version 2. */
-    Cr2,
+    Cr2("Cr2", null),
     /** Nikon camera raw. */
-    Nef,
+    Nef("Nef", null),
     /** Olympus camera raw. */
-    Orf,
+    Orf("Orf", null),
     /** FujiFilm camera raw. */
-    Raf,
+    Raf("Raf", null),
     /** Panasonic camera raw. */
-    Rw2
+    Rw2("Rw2", null);
+
+    private final String _name;
+
+    private final String _mimeType;
+
+    FileType(String name, String mimeType)
+    {
+        _name = name;
+        _mimeType = mimeType;
+    }
+
+    @NotNull
+    public String getName()
+    {
+        return _name;
+    }
+
+    @Nullable
+    public String getMimeType()
+    {
+        return _mimeType;
+    }
 }

--- a/Source/com/drew/imaging/FileTypeDetector.java
+++ b/Source/com/drew/imaging/FileTypeDetector.java
@@ -104,7 +104,33 @@ public class FileTypeDetector
 
         inputStream.reset();
 
+        FileType fileType = _root.find(bytes);
+
+        if (fileType.getIsContainer()) {
+            fileType = handleContainer(inputStream, fileType);
+        }
+
         //noinspection ConstantConditions
-        return _root.find(bytes);
+        return fileType;
+    }
+
+    /**
+     * Skips to identifier location for potential container file types and calls detectFileType on new inputStream
+     * location.  In the case of fileTypes without magic bytes to identify with (Zip), the fileType will be
+     * found within this method alone.
+     *
+     * @throws IOException if an IO error occurred or the input stream ended unexpectedly.
+     */
+    @NotNull
+    public static FileType handleContainer(@NotNull final BufferedInputStream inputStream, @NotNull FileType fileType) throws IOException
+    {
+        switch (fileType) {
+            case Riff:
+                inputStream.skip(8);
+                return detectFileType(inputStream);
+            case Tiff:
+            default:
+                return fileType;
+        }
     }
 }

--- a/Source/com/drew/imaging/ImageMetadataReader.java
+++ b/Source/com/drew/imaging/ImageMetadataReader.java
@@ -107,7 +107,11 @@ public class ImageMetadataReader
 
         FileType fileType = FileTypeDetector.detectFileType(bufferedInputStream);
 
-        return readMetadata(bufferedInputStream, streamLength, fileType);
+        Metadata metadata = readMetadata(bufferedInputStream, streamLength, fileType);
+
+        new FileMetadataReader().read(metadata, fileType);
+
+        return metadata;
     }
 
     /**

--- a/Source/com/drew/metadata/file/FileMetadataDirectory.java
+++ b/Source/com/drew/metadata/file/FileMetadataDirectory.java
@@ -36,6 +36,7 @@ public class FileMetadataDirectory extends Directory
     public static final int TAG_FILE_MODIFIED_DATE = 3;
     public static final int TAG_FILE_TYPE = 4;
     public static final int TAG_FILE_MIME_TYPE = 5;
+    public static final int TAG_FILE_EXTENSION = 6;
 
     @NotNull
     protected static final HashMap<Integer, String> _tagNameMap = new HashMap<Integer, String>();
@@ -46,6 +47,7 @@ public class FileMetadataDirectory extends Directory
         _tagNameMap.put(TAG_FILE_MODIFIED_DATE, "File Modified Date");
         _tagNameMap.put(TAG_FILE_TYPE, "File Type");
         _tagNameMap.put(TAG_FILE_MIME_TYPE, "MIME Type");
+        _tagNameMap.put(TAG_FILE_EXTENSION, "File Extensions");
     }
 
     public FileMetadataDirectory()

--- a/Source/com/drew/metadata/file/FileMetadataDirectory.java
+++ b/Source/com/drew/metadata/file/FileMetadataDirectory.java
@@ -34,6 +34,8 @@ public class FileMetadataDirectory extends Directory
     public static final int TAG_FILE_NAME = 1;
     public static final int TAG_FILE_SIZE = 2;
     public static final int TAG_FILE_MODIFIED_DATE = 3;
+    public static final int TAG_FILE_TYPE = 4;
+    public static final int TAG_FILE_MIME_TYPE = 5;
 
     @NotNull
     protected static final HashMap<Integer, String> _tagNameMap = new HashMap<Integer, String>();
@@ -42,6 +44,8 @@ public class FileMetadataDirectory extends Directory
         _tagNameMap.put(TAG_FILE_NAME, "File Name");
         _tagNameMap.put(TAG_FILE_SIZE, "File Size");
         _tagNameMap.put(TAG_FILE_MODIFIED_DATE, "File Modified Date");
+        _tagNameMap.put(TAG_FILE_TYPE, "File Type");
+        _tagNameMap.put(TAG_FILE_MIME_TYPE, "MIME Type");
     }
 
     public FileMetadataDirectory()

--- a/Source/com/drew/metadata/file/FileMetadataReader.java
+++ b/Source/com/drew/metadata/file/FileMetadataReader.java
@@ -60,6 +60,10 @@ public class FileMetadataReader
             directory.setString(FileMetadataDirectory.TAG_FILE_MIME_TYPE, fileType.getMimeType());
         }
 
+        if (fileType.getExtension() != null) {
+            directory.setStringArray(FileMetadataDirectory.TAG_FILE_EXTENSION, fileType.getExtension());
+        }
+
         metadata.addDirectory(directory);
     }
 }

--- a/Source/com/drew/metadata/file/FileMetadataReader.java
+++ b/Source/com/drew/metadata/file/FileMetadataReader.java
@@ -25,10 +25,7 @@ import com.drew.imaging.FileTypeDetector;
 import com.drew.lang.annotations.NotNull;
 import com.drew.metadata.Metadata;
 
-import java.io.BufferedInputStream;
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.IOException;
+import java.io.*;
 import java.util.Date;
 
 public class FileMetadataReader
@@ -42,14 +39,22 @@ public class FileMetadataReader
         if (!file.canRead())
             throw new IOException("File is not readable");
 
-        FileMetadataDirectory directory = new FileMetadataDirectory();
-        FileInputStream inputStream = new FileInputStream(file);
-        FileType fileType = FileTypeDetector.detectFileType(new BufferedInputStream(inputStream));
-        inputStream.close();
+        FileMetadataDirectory directory = metadata.getFirstDirectoryOfType(FileMetadataDirectory.class);
+
+        if (directory == null) {
+            directory = new FileMetadataDirectory();
+            metadata.addDirectory(directory);
+        }
 
         directory.setString(FileMetadataDirectory.TAG_FILE_NAME, file.getName());
         directory.setLong(FileMetadataDirectory.TAG_FILE_SIZE, file.length());
         directory.setDate(FileMetadataDirectory.TAG_FILE_MODIFIED_DATE, new Date(file.lastModified()));
+    }
+
+    public void read(@NotNull Metadata metadata, @NotNull FileType fileType) throws IOException
+    {
+        FileMetadataDirectory directory = new FileMetadataDirectory();
+
         directory.setString(FileMetadataDirectory.TAG_FILE_TYPE, fileType.getName());
         if (fileType.getMimeType() != null) {
             directory.setString(FileMetadataDirectory.TAG_FILE_MIME_TYPE, fileType.getMimeType());

--- a/Source/com/drew/metadata/file/FileMetadataReader.java
+++ b/Source/com/drew/metadata/file/FileMetadataReader.java
@@ -20,10 +20,14 @@
  */
 package com.drew.metadata.file;
 
+import com.drew.imaging.FileType;
+import com.drew.imaging.FileTypeDetector;
 import com.drew.lang.annotations.NotNull;
 import com.drew.metadata.Metadata;
 
+import java.io.BufferedInputStream;
 import java.io.File;
+import java.io.FileInputStream;
 import java.io.IOException;
 import java.util.Date;
 
@@ -39,10 +43,17 @@ public class FileMetadataReader
             throw new IOException("File is not readable");
 
         FileMetadataDirectory directory = new FileMetadataDirectory();
+        FileInputStream inputStream = new FileInputStream(file);
+        FileType fileType = FileTypeDetector.detectFileType(new BufferedInputStream(inputStream));
+        inputStream.close();
 
         directory.setString(FileMetadataDirectory.TAG_FILE_NAME, file.getName());
         directory.setLong(FileMetadataDirectory.TAG_FILE_SIZE, file.length());
         directory.setDate(FileMetadataDirectory.TAG_FILE_MODIFIED_DATE, new Date(file.lastModified()));
+        directory.setString(FileMetadataDirectory.TAG_FILE_TYPE, fileType.getName());
+        if (fileType.getMimeType() != null) {
+            directory.setString(FileMetadataDirectory.TAG_FILE_MIME_TYPE, fileType.getMimeType());
+        }
 
         metadata.addDirectory(directory);
     }


### PR DESCRIPTION
This is something that our organization would find useful in the library as it expands.  It would be nice to have file detection for some file formats like those using the zip container even if there isn't any metadata associated with it just yet.  

I have simply added to the FileType enum class to allow a File Type String and MIME Type String to be stored.  This data is then stored in the File Metadata Directory.

If this isn't something you would like in the library, no big deal.  I figured I would throw it out there, though!