### PR TITLE
Fix raw number storage TODO, add null value checking for MP4/QT, and fix duration raw number storage

### DIFF
--- a/Source/com/drew/metadata/mov/QuickTimeDescriptor.java
+++ b/Source/com/drew/metadata/mov/QuickTimeDescriptor.java
@@ -26,6 +26,8 @@ import com.drew.metadata.TagDescriptor;
 import java.util.ArrayList;
 import java.util.Arrays;
 
+import static com.drew.metadata.mov.QuickTimeDirectory.*;
+
 /**
  * @author Payton Garland
  */
@@ -40,37 +42,33 @@ public class QuickTimeDescriptor extends TagDescriptor<QuickTimeDirectory> {
     public String getDescription(int tagType)
     {
         switch (tagType) {
-            case (QuickTimeDirectory.TAG_MAJOR_BRAND):
-                return getMajorBrandDescription(tagType);
-            case (QuickTimeDirectory.TAG_COMPATIBLE_BRANDS):
-                return getCompatibleBrandsDescription(tagType);
+            case TAG_MAJOR_BRAND:
+                return getMajorBrandDescription();
+            case TAG_COMPATIBLE_BRANDS:
+                return getCompatibleBrandsDescription();
             default:
                 return super.getDescription(tagType);
         }
     }
 
-    private String getMajorBrandDescription(int tagType)
+    private String getMajorBrandDescription()
     {
-        String majorBrandKey = new String(_directory.getByteArray(tagType));
-        String majorBrandValue = QuickTimeDictionary.lookup(QuickTimeDirectory.TAG_MAJOR_BRAND, majorBrandKey);
-        if (majorBrandValue != null) {
-            return majorBrandValue;
-        } else {
-            return majorBrandKey;
-        }
+        byte[] value = _directory.getByteArray(QuickTimeDirectory.TAG_MAJOR_BRAND);
+        if (value == null)
+            return null;
+        return QuickTimeDictionary.lookup(TAG_MAJOR_BRAND, new String(value));
     }
 
-    private String getCompatibleBrandsDescription(int tagType)
+    private String getCompatibleBrandsDescription()
     {
-        String[] compatibleBrandKeys = _directory.getStringArray(tagType);
+        String[] values = _directory.getStringArray(QuickTimeDirectory.TAG_COMPATIBLE_BRANDS);
+        if (values == null)
+            return null;
+
         ArrayList<String> compatibleBrandsValues = new ArrayList<String>();
-        for (String compatibleBrandsKey : compatibleBrandKeys) {
-            String compatibleBrandsValue = QuickTimeDictionary.lookup(QuickTimeDirectory.TAG_MAJOR_BRAND, compatibleBrandsKey);
-            if (compatibleBrandsValue != null) {
-                compatibleBrandsValues.add(compatibleBrandsValue);
-            } else {
-                compatibleBrandsValues.add(compatibleBrandsKey);
-            }
+        for (String value : values) {
+            String compatibleBrandsValue = QuickTimeDictionary.lookup(TAG_MAJOR_BRAND, value);
+            compatibleBrandsValues.add(compatibleBrandsValue == null ? value : compatibleBrandsValue);
         }
         return Arrays.toString(compatibleBrandsValues.toArray());
     }

--- a/Source/com/drew/metadata/mov/QuickTimeDescriptor.java
+++ b/Source/com/drew/metadata/mov/QuickTimeDescriptor.java
@@ -46,6 +46,8 @@ public class QuickTimeDescriptor extends TagDescriptor<QuickTimeDirectory> {
                 return getMajorBrandDescription();
             case TAG_COMPATIBLE_BRANDS:
                 return getCompatibleBrandsDescription();
+            case TAG_DURATION:
+                return getDurationDescription();
             default:
                 return super.getDescription(tagType);
         }
@@ -71,5 +73,17 @@ public class QuickTimeDescriptor extends TagDescriptor<QuickTimeDirectory> {
             compatibleBrandsValues.add(compatibleBrandsValue == null ? value : compatibleBrandsValue);
         }
         return Arrays.toString(compatibleBrandsValues.toArray());
+    }
+
+    private String getDurationDescription()
+    {
+        Long value = _directory.getLongObject(TAG_DURATION);
+        if (value == null)
+            return null;
+
+        Integer hours = (int)(value / (Math.pow(60, 2)));
+        Integer minutes = (int)((value / (Math.pow(60, 1))) - (hours * 60));
+        Integer seconds = (int)Math.ceil((value / (Math.pow(60, 0))) - (minutes * 60));
+        return String.format("%1$02d:%2$02d:%3$02d", hours, minutes, seconds);
     }
 }

--- a/Source/com/drew/metadata/mov/atoms/MovieHeaderAtom.java
+++ b/Source/com/drew/metadata/mov/atoms/MovieHeaderAtom.java
@@ -27,6 +27,8 @@ import java.io.IOException;
 import java.util.Calendar;
 import java.util.Date;
 
+import static com.drew.metadata.mov.QuickTimeDirectory.*;
+
 /**
  * https://developer.apple.com/library/content/documentation/QuickTime/QTFF/QTFFChap2/qtff2.html#//apple_ref/doc/uid/TP40000939-CH204-BBCGFGJG
  *
@@ -89,34 +91,30 @@ public class MovieHeaderAtom extends FullAtom
         long macToUnixEpochOffset = date.getTime();
         String creationTimeStamp = new Date(creationTime * 1000 + macToUnixEpochOffset).toString();
         String modificationTimeStamp = new Date(modificationTime * 1000 + macToUnixEpochOffset).toString();
-        directory.setString(QuickTimeDirectory.TAG_CREATION_TIME, creationTimeStamp);
-        directory.setString(QuickTimeDirectory.TAG_MODIFICATION_TIME, modificationTimeStamp);
+        directory.setString(TAG_CREATION_TIME, creationTimeStamp);
+        directory.setString(TAG_MODIFICATION_TIME, modificationTimeStamp);
 
         // Get duration and time scale
         duration = duration / timescale;
-        Integer hours = (int)duration / (int)(Math.pow(60, 2));
-        Integer minutes = ((int)duration / (int)(Math.pow(60, 1))) - (hours * 60);
-        Integer seconds = (int)Math.ceil((duration / (Math.pow(60, 0))) - (minutes * 60));
-        String time = String.format("%1$02d:%2$02d:%3$02d", hours, minutes, seconds);
-        directory.setString(QuickTimeDirectory.TAG_DURATION, time);
-        directory.setLong(QuickTimeDirectory.TAG_TIME_SCALE, timescale);
+        directory.setLong(TAG_DURATION, duration);
+        directory.setLong(TAG_TIME_SCALE, timescale);
 
         // Calculate preferred rate fixed point
         double preferredRateInteger = (preferredRate & 0xFFFF0000) >> 16;
         double preferredRateFraction = (preferredRate & 0x0000FFFF) / Math.pow(2, 4);
-        directory.setDouble(QuickTimeDirectory.TAG_PREFERRED_RATE, preferredRateInteger + preferredRateFraction);
+        directory.setDouble(TAG_PREFERRED_RATE, preferredRateInteger + preferredRateFraction);
 
         // Calculate preferred volume fixed point
         double preferredVolumeInteger = (preferredVolume & 0xFF00) >> 8;
         double preferredVolumeFraction = (preferredVolume & 0x00FF) / Math.pow(2, 2);
-        directory.setDouble(QuickTimeDirectory.TAG_PREFERRED_VOLUME, preferredVolumeInteger + preferredVolumeFraction);
+        directory.setDouble(TAG_PREFERRED_VOLUME, preferredVolumeInteger + preferredVolumeFraction);
 
-        directory.setLong(QuickTimeDirectory.TAG_PREVIEW_TIME, previewTime);
-        directory.setLong(QuickTimeDirectory.TAG_PREVIEW_DURATION, previewDuration);
-        directory.setLong(QuickTimeDirectory.TAG_POSTER_TIME, posterTime);
-        directory.setLong(QuickTimeDirectory.TAG_SELECTION_TIME, selectionTime);
-        directory.setLong(QuickTimeDirectory.TAG_SELECTION_DURATION, selectionDuration);
-        directory.setLong(QuickTimeDirectory.TAG_CURRENT_TIME, currentTime);
-        directory.setLong(QuickTimeDirectory.TAG_NEXT_TRACK_ID, nextTrackID);
+        directory.setLong(TAG_PREVIEW_TIME, previewTime);
+        directory.setLong(TAG_PREVIEW_DURATION, previewDuration);
+        directory.setLong(TAG_POSTER_TIME, posterTime);
+        directory.setLong(TAG_SELECTION_TIME, selectionTime);
+        directory.setLong(TAG_SELECTION_DURATION, selectionDuration);
+        directory.setLong(TAG_CURRENT_TIME, currentTime);
+        directory.setLong(TAG_NEXT_TRACK_ID, nextTrackID);
     }
 }

--- a/Source/com/drew/metadata/mov/atoms/VideoInformationMediaHeaderAtom.java
+++ b/Source/com/drew/metadata/mov/atoms/VideoInformationMediaHeaderAtom.java
@@ -46,37 +46,6 @@ public class VideoInformationMediaHeaderAtom extends FullAtom
     public void addMetadata(QuickTimeVideoDirectory directory)
     {
         directory.setIntArray(QuickTimeVideoDirectory.TAG_OPCOLOR, opcolor);
-
-        // TODO store the raw number, and use a descriptor to decode it
-        switch (graphicsMode) {
-            case (0x00):
-                directory.setString(QuickTimeVideoDirectory.TAG_GRAPHICS_MODE, "Copy");
-                break;
-            case (0x40):
-                directory.setString(QuickTimeVideoDirectory.TAG_GRAPHICS_MODE, "Dither copy");
-                break;
-            case (0x20):
-                directory.setString(QuickTimeVideoDirectory.TAG_GRAPHICS_MODE, "Blend");
-                break;
-            case (0x24):
-                directory.setString(QuickTimeVideoDirectory.TAG_GRAPHICS_MODE, "Transparent");
-                break;
-            case (0x100):
-                directory.setString(QuickTimeVideoDirectory.TAG_GRAPHICS_MODE, "Straight alpha");
-                break;
-            case (0x101):
-                directory.setString(QuickTimeVideoDirectory.TAG_GRAPHICS_MODE, "Premul white alpha");
-                break;
-            case (0x102):
-                directory.setString(QuickTimeVideoDirectory.TAG_GRAPHICS_MODE, "Premul black alpha");
-                break;
-            case (0x104):
-                directory.setString(QuickTimeVideoDirectory.TAG_GRAPHICS_MODE, "Straight alpha blend");
-                break;
-            case (0x103):
-                directory.setString(QuickTimeVideoDirectory.TAG_GRAPHICS_MODE, "Composition (dither copy)");
-                break;
-            default:
-        }
+        directory.setInt(QuickTimeVideoDirectory.TAG_GRAPHICS_MODE, graphicsMode);
     }
 }

--- a/Source/com/drew/metadata/mov/media/QuickTimeVideoDescriptor.java
+++ b/Source/com/drew/metadata/mov/media/QuickTimeVideoDescriptor.java
@@ -23,6 +23,8 @@ package com.drew.metadata.mov.media;
 import com.drew.lang.annotations.NotNull;
 import com.drew.metadata.mov.QuickTimeDescriptor;
 
+import static com.drew.metadata.mov.media.QuickTimeVideoDirectory.*;
+
 /**
  * @author Payton Garland
  */
@@ -37,13 +39,15 @@ public class QuickTimeVideoDescriptor extends QuickTimeDescriptor
     public String getDescription(int tagType)
     {
         switch (tagType) {
-            case (QuickTimeVideoDirectory.TAG_HEIGHT):
-            case (QuickTimeVideoDirectory.TAG_WIDTH):
+            case TAG_HEIGHT:
+            case TAG_WIDTH:
                 return getPixelDescription(tagType);
-            case (QuickTimeVideoDirectory.TAG_DEPTH):
+            case TAG_DEPTH:
                 return getDepthDescription(tagType);
-            case (QuickTimeVideoDirectory.TAG_COLOR_TABLE):
+            case TAG_COLOR_TABLE:
                 return getColorTableDescription(tagType);
+            case TAG_GRAPHICS_MODE:
+                return getGraphicsModeDescription();
             default:
                 return super.getDescription(tagType);
         }
@@ -51,29 +55,35 @@ public class QuickTimeVideoDescriptor extends QuickTimeDescriptor
 
     private String getPixelDescription(int tagType)
     {
-        return _directory.getString(tagType) + " pixels";
+        String value = _directory.getString(tagType);
+        return value == null ? null : value + " pixels";
     }
 
     private String getDepthDescription(int tagType)
     {
-        int depth = _directory.getInteger(tagType);
-        switch (depth) {
+        Integer value = _directory.getInteger(tagType);
+        if (value == null)
+            return null;
+
+        switch (value) {
             case (40):
             case (36):
             case (34):
-                return (depth - 32) + "-bit grayscale";
+                return (value - 32) + "-bit grayscale";
             default:
-                return Integer.toString(depth);
+                return "Unknown (" + value + ")";
         }
     }
 
     private String getColorTableDescription(int tagType)
     {
-        int colorTableId = _directory.getInteger(tagType);
+        Integer value = _directory.getInteger(tagType);
+        if (value == null)
+            return null;
 
-        switch (colorTableId) {
+        switch (value) {
             case (-1):
-                if (_directory.getInteger(QuickTimeVideoDirectory.TAG_DEPTH) < 16) {
+                if (_directory.getInteger(TAG_DEPTH) < 16) {
                     return "Default";
                 } else {
                     return "None";
@@ -81,7 +91,37 @@ public class QuickTimeVideoDescriptor extends QuickTimeDescriptor
             case (0):
                 return "Color table within file";
             default:
-                return Integer.toString(colorTableId);
+                return "Unknown (" + value + ")";
+        }
+    }
+
+    private String getGraphicsModeDescription()
+    {
+        Integer value = _directory.getInteger(TAG_GRAPHICS_MODE);
+        if (value == null)
+            return null;
+
+        switch (value) {
+            case (0x00):
+                return "Copy";
+            case (0x40):
+                return "Dither copy";
+            case (0x20):
+                return "Blend";
+            case (0x24):
+                return "Transparent";
+            case (0x100):
+                return "Straight alpha";
+            case (0x101):
+                return "Premul white alpha";
+            case (0x102):
+                return "Premul black alpha";
+            case (0x104):
+                return "Straight alpha blend";
+            case (0x103):
+                return "Composition (dither copy)";
+            default:
+                return "Unknown (" + value + ")";
         }
     }
 }

--- a/Source/com/drew/metadata/mp4/Mp4Descriptor.java
+++ b/Source/com/drew/metadata/mp4/Mp4Descriptor.java
@@ -27,6 +27,8 @@ import com.drew.metadata.TagDescriptor;
 import java.util.ArrayList;
 import java.util.Arrays;
 
+import static com.drew.metadata.mp4.Mp4Directory.*;
+
 public class Mp4Descriptor<T extends Directory> extends TagDescriptor<Mp4Directory> {
 
     public Mp4Descriptor(@NotNull Mp4Directory directory)
@@ -38,37 +40,33 @@ public class Mp4Descriptor<T extends Directory> extends TagDescriptor<Mp4Directo
     public String getDescription(int tagType)
     {
         switch (tagType) {
-            case (Mp4Directory.TAG_MAJOR_BRAND):
-                return getMajorBrandDescription(tagType);
-            case (Mp4Directory.TAG_COMPATIBLE_BRANDS):
-                return getCompatibleBrandsDescription(tagType);
+            case TAG_MAJOR_BRAND:
+                return getMajorBrandDescription();
+            case TAG_COMPATIBLE_BRANDS:
+                return getCompatibleBrandsDescription();
             default:
                 return _directory.getString(tagType);
         }
     }
 
-    private String getMajorBrandDescription(int tagType)
+    private String getMajorBrandDescription()
     {
-        String majorBrandKey = new String(_directory.getByteArray(tagType));
-        String majorBrandValue = Mp4Dictionary.lookup(Mp4Directory.TAG_MAJOR_BRAND, majorBrandKey);
-        if (majorBrandValue != null) {
-            return majorBrandValue;
-        } else {
-            return majorBrandKey;
-        }
+        byte[] value = _directory.getByteArray(Mp4Directory.TAG_MAJOR_BRAND);
+        if (value == null)
+            return null;
+        return Mp4Dictionary.lookup(TAG_MAJOR_BRAND, new String(value));
     }
 
-    private String getCompatibleBrandsDescription(int tagType)
+    private String getCompatibleBrandsDescription()
     {
-        String[] compatibleBrandKeys = _directory.getStringArray(tagType);
+        String[] values = _directory.getStringArray(Mp4Directory.TAG_COMPATIBLE_BRANDS);
+        if (values == null)
+            return null;
+
         ArrayList<String> compatibleBrandsValues = new ArrayList<String>();
-        for (String compatibleBrandsKey : compatibleBrandKeys) {
-            String compatibleBrandsValue = Mp4Dictionary.lookup(Mp4Directory.TAG_MAJOR_BRAND, compatibleBrandsKey);
-            if (compatibleBrandsValue != null) {
-                compatibleBrandsValues.add(compatibleBrandsValue);
-            } else {
-                compatibleBrandsValues.add(compatibleBrandsKey);
-            }
+        for (String value : values) {
+            String compatibleBrandsValue = Mp4Dictionary.lookup(TAG_MAJOR_BRAND, value);
+            compatibleBrandsValues.add(compatibleBrandsValue == null ? value : compatibleBrandsValue);
         }
         return Arrays.toString(compatibleBrandsValues.toArray());
     }

--- a/Source/com/drew/metadata/mp4/Mp4Descriptor.java
+++ b/Source/com/drew/metadata/mp4/Mp4Descriptor.java
@@ -44,6 +44,8 @@ public class Mp4Descriptor<T extends Directory> extends TagDescriptor<Mp4Directo
                 return getMajorBrandDescription();
             case TAG_COMPATIBLE_BRANDS:
                 return getCompatibleBrandsDescription();
+            case TAG_DURATION:
+                return getDurationDescription();
             default:
                 return _directory.getString(tagType);
         }
@@ -69,5 +71,17 @@ public class Mp4Descriptor<T extends Directory> extends TagDescriptor<Mp4Directo
             compatibleBrandsValues.add(compatibleBrandsValue == null ? value : compatibleBrandsValue);
         }
         return Arrays.toString(compatibleBrandsValues.toArray());
+    }
+
+    private String getDurationDescription()
+    {
+        Long value = _directory.getLongObject(TAG_DURATION);
+        if (value == null)
+            return null;
+
+        Integer hours = (int)(value / (Math.pow(60, 2)));
+        Integer minutes = (int)((value / (Math.pow(60, 1))) - (hours * 60));
+        Integer seconds = (int)Math.ceil((value / (Math.pow(60, 0))) - (minutes * 60));
+        return String.format("%1$02d:%2$02d:%3$02d", hours, minutes, seconds);
     }
 }

--- a/Source/com/drew/metadata/mp4/boxes/MovieHeaderBox.java
+++ b/Source/com/drew/metadata/mp4/boxes/MovieHeaderBox.java
@@ -87,11 +87,7 @@ public class MovieHeaderBox extends FullBox
 
         // Get duration and time scale
         duration = duration / timescale;
-        Integer hours = (int)duration / (int)(Math.pow(60, 2));
-        Integer minutes = ((int)duration / (int)(Math.pow(60, 1))) - (hours * 60);
-        Integer seconds = (int)Math.ceil((duration / (Math.pow(60, 0))) - (minutes * 60));
-        String time = String.format("%1$02d:%2$02d:%3$02d", hours, minutes, seconds);
-        directory.setString(Mp4Directory.TAG_DURATION, time);
+        directory.setLong(Mp4Directory.TAG_DURATION, duration);
         directory.setLong(Mp4Directory.TAG_TIME_SCALE, timescale);
 
         directory.setIntArray(Mp4Directory.TAG_TRANSFORMATION_MATRIX, matrix);

--- a/Source/com/drew/metadata/mp4/boxes/VideoMediaHeaderBox.java
+++ b/Source/com/drew/metadata/mp4/boxes/VideoMediaHeaderBox.java
@@ -30,50 +30,20 @@ import java.io.IOException;
  */
 public class VideoMediaHeaderBox extends FullBox
 {
-    int graphicsmode;
+    int graphicsMode;
     int[] opcolor;
 
     public VideoMediaHeaderBox(SequentialReader reader, Box box) throws IOException
     {
         super(reader, box);
 
-        graphicsmode = reader.getUInt16();
+        graphicsMode = reader.getUInt16();
         opcolor = new int[]{reader.getUInt16(), reader.getUInt16(), reader.getUInt16()};
     }
 
     public void addMetadata(Mp4VideoDirectory directory)
     {
         directory.setIntArray(Mp4VideoDirectory.TAG_OPCOLOR, opcolor);
-
-        switch (graphicsmode) {
-            case (0x00):
-                directory.setString(Mp4VideoDirectory.TAG_GRAPHICS_MODE, "Copy");
-                break;
-            case (0x40):
-                directory.setString(Mp4VideoDirectory.TAG_GRAPHICS_MODE, "Dither copy");
-                break;
-            case (0x20):
-                directory.setString(Mp4VideoDirectory.TAG_GRAPHICS_MODE, "Blend");
-                break;
-            case (0x24):
-                directory.setString(Mp4VideoDirectory.TAG_GRAPHICS_MODE, "Transparent");
-                break;
-            case (0x100):
-                directory.setString(Mp4VideoDirectory.TAG_GRAPHICS_MODE, "Straight alpha");
-                break;
-            case (0x101):
-                directory.setString(Mp4VideoDirectory.TAG_GRAPHICS_MODE, "Premul white alpha");
-                break;
-            case (0x102):
-                directory.setString(Mp4VideoDirectory.TAG_GRAPHICS_MODE, "Premul black alpha");
-                break;
-            case (0x104):
-                directory.setString(Mp4VideoDirectory.TAG_GRAPHICS_MODE, "Straight alpha blend");
-                break;
-            case (0x103):
-                directory.setString(Mp4VideoDirectory.TAG_GRAPHICS_MODE, "Composition (dither copy)");
-                break;
-            default:
-        }
+        directory.setInt(Mp4VideoDirectory.TAG_GRAPHICS_MODE, graphicsMode);
     }
 }

--- a/Source/com/drew/metadata/mp4/media/Mp4VideoDescriptor.java
+++ b/Source/com/drew/metadata/mp4/media/Mp4VideoDescriptor.java
@@ -23,6 +23,8 @@ package com.drew.metadata.mp4.media;
 import com.drew.lang.annotations.NotNull;
 import com.drew.metadata.TagDescriptor;
 
+import static com.drew.metadata.mp4.media.Mp4VideoDirectory.*;
+
 public class Mp4VideoDescriptor extends TagDescriptor<Mp4VideoDirectory>
 {
     public Mp4VideoDescriptor(@NotNull Mp4VideoDirectory directory)
@@ -34,13 +36,15 @@ public class Mp4VideoDescriptor extends TagDescriptor<Mp4VideoDirectory>
     public String getDescription(int tagType)
     {
         switch (tagType) {
-            case (Mp4VideoDirectory.TAG_HEIGHT):
-            case (Mp4VideoDirectory.TAG_WIDTH):
+            case TAG_HEIGHT:
+            case TAG_WIDTH:
                 return getPixelDescription(tagType);
-            case (Mp4VideoDirectory.TAG_DEPTH):
-                return getDepthDescription(tagType);
-            case (Mp4VideoDirectory.TAG_COLOR_TABLE):
-                return getColorTableDescription(tagType);
+            case TAG_DEPTH:
+                return getDepthDescription();
+            case TAG_COLOR_TABLE:
+                return getColorTableDescription();
+            case TAG_GRAPHICS_MODE:
+                return getGraphicsModeDescription();
             default:
                 return super.getDescription(tagType);
         }
@@ -48,29 +52,39 @@ public class Mp4VideoDescriptor extends TagDescriptor<Mp4VideoDirectory>
 
     private String getPixelDescription(int tagType)
     {
-        return _directory.getString(tagType) + " pixels";
+        String value = _directory.getString(tagType);
+        return value == null ? null : value + " pixels";
     }
 
-    private String getDepthDescription(int tagType)
+    private String getDepthDescription()
     {
-        int depth = _directory.getInteger(tagType);
-        switch (depth) {
+        Integer value = _directory.getInteger(TAG_DEPTH);
+        if (value == null)
+            return null;
+
+        switch (value) {
             case (40):
             case (36):
             case (34):
-                return (depth - 32) + "-bit grayscale";
+                return (value - 32) + "-bit grayscale";
             default:
-                return Integer.toString(depth);
+                return "Unknown (" + value + ")";
         }
     }
 
-    private String getColorTableDescription(int tagType)
+    private String getColorTableDescription()
     {
-        int colorTableId = _directory.getInteger(tagType);
+        Integer value = _directory.getInteger(TAG_COLOR_TABLE);
+        if (value == null)
+            return null;
 
-        switch (colorTableId) {
+        switch (value) {
             case (-1):
-                if (_directory.getInteger(Mp4VideoDirectory.TAG_DEPTH) < 16) {
+                Integer depth = _directory.getInteger(TAG_DEPTH);
+                if (depth == null)
+                    return "None";
+
+                if (depth < 16) {
                     return "Default";
                 } else {
                     return "None";
@@ -78,7 +92,37 @@ public class Mp4VideoDescriptor extends TagDescriptor<Mp4VideoDirectory>
             case (0):
                 return "Color table within file";
             default:
-                return Integer.toString(colorTableId);
+                return "Unknown (" + value + ")";
+        }
+    }
+
+    private String getGraphicsModeDescription()
+    {
+        Integer value = _directory.getInteger(TAG_GRAPHICS_MODE);
+        if (value == null)
+            return null;
+
+        switch (value) {
+            case (0x00):
+                return "Copy";
+            case (0x40):
+                return "Dither copy";
+            case (0x20):
+                return "Blend";
+            case (0x24):
+                return "Transparent";
+            case (0x100):
+                return "Straight alpha";
+            case (0x101):
+                return "Premul white alpha";
+            case (0x102):
+                return "Premul black alpha";
+            case (0x104):
+                return "Straight alpha blend";
+            case (0x103):
+                return "Composition (dither copy)";
+            default:
+                return "Unknown (" + value + ")";
         }
     }
 }


### PR DESCRIPTION
Fixes TODO about Graphics Mode raw data storage from c74bc8311509b and adds null value checking for MP4 and QuickTime descriptors.  Also moves duration raw number storage to directory and puts the duration calculation in the descriptor.