### PR TITLE
Comment out the usage of HANDLER_PARAM variables

### DIFF
--- a/Source/com/drew/metadata/mov/QuickTimeHandlerFactory.java
+++ b/Source/com/drew/metadata/mov/QuickTimeHandlerFactory.java
@@ -42,10 +42,10 @@ public class QuickTimeHandlerFactory
 
     private QuickTimeHandler caller;
 
-    public static Long HANDLER_PARAM_TIME_SCALE              = null;
-    public static Long HANDLER_PARAM_CREATION_TIME           = null;
-    public static Long HANDLER_PARAM_MODIFICATION_TIME       = null;
-    public static Long HANDLER_PARAM_DURATION                = null;
+//    public static Long HANDLER_PARAM_TIME_SCALE              = null;
+//    public static Long HANDLER_PARAM_CREATION_TIME           = null;
+//    public static Long HANDLER_PARAM_MODIFICATION_TIME       = null;
+//    public static Long HANDLER_PARAM_DURATION                = null;
 
     public QuickTimeHandlerFactory(QuickTimeHandler caller)
     {

--- a/Source/com/drew/metadata/mov/QuickTimeMediaHandler.java
+++ b/Source/com/drew/metadata/mov/QuickTimeMediaHandler.java
@@ -44,17 +44,17 @@ public abstract class QuickTimeMediaHandler<T extends QuickTimeDirectory> extend
     public QuickTimeMediaHandler(Metadata metadata)
     {
         super(metadata);
-        if (QuickTimeHandlerFactory.HANDLER_PARAM_CREATION_TIME != null && QuickTimeHandlerFactory.HANDLER_PARAM_MODIFICATION_TIME != null) {
-            // Get creation/modification times
-            Calendar calendar = Calendar.getInstance();
-            calendar.set(1904, 0, 1, 0, 0, 0);      // January 1, 1904  -  Macintosh Time Epoch
-            Date date = calendar.getTime();
-            long macToUnixEpochOffset = date.getTime();
-            String creationTimeStamp = new Date(QuickTimeHandlerFactory.HANDLER_PARAM_CREATION_TIME * 1000 + macToUnixEpochOffset).toString();
-            String modificationTimeStamp = new Date(QuickTimeHandlerFactory.HANDLER_PARAM_MODIFICATION_TIME * 1000 + macToUnixEpochOffset).toString();
-            directory.setString(QuickTimeMediaDirectory.TAG_CREATION_TIME, creationTimeStamp);
-            directory.setString(QuickTimeMediaDirectory.TAG_MODIFICATION_TIME, modificationTimeStamp);
-        }
+//        if (QuickTimeHandlerFactory.HANDLER_PARAM_CREATION_TIME != null && QuickTimeHandlerFactory.HANDLER_PARAM_MODIFICATION_TIME != null) {
+//            // Get creation/modification times
+//            Calendar calendar = Calendar.getInstance();
+//            calendar.set(1904, 0, 1, 0, 0, 0);      // January 1, 1904  -  Macintosh Time Epoch
+//            Date date = calendar.getTime();
+//            long macToUnixEpochOffset = date.getTime();
+//            String creationTimeStamp = new Date(QuickTimeHandlerFactory.HANDLER_PARAM_CREATION_TIME * 1000 + macToUnixEpochOffset).toString();
+//            String modificationTimeStamp = new Date(QuickTimeHandlerFactory.HANDLER_PARAM_MODIFICATION_TIME * 1000 + macToUnixEpochOffset).toString();
+//            directory.setString(QuickTimeMediaDirectory.TAG_CREATION_TIME, creationTimeStamp);
+//            directory.setString(QuickTimeMediaDirectory.TAG_MODIFICATION_TIME, modificationTimeStamp);
+//        }
     }
 
     @Override

--- a/Source/com/drew/metadata/mov/atoms/MediaHeaderAtom.java
+++ b/Source/com/drew/metadata/mov/atoms/MediaHeaderAtom.java
@@ -50,10 +50,9 @@ public class MediaHeaderAtom extends FullAtom
         language = reader.getUInt16();
         quality = reader.getUInt16();
 
-        // TODO can't use static fields here as it breaks concurrency
-        QuickTimeHandlerFactory.HANDLER_PARAM_CREATION_TIME = creationTime;
-        QuickTimeHandlerFactory.HANDLER_PARAM_MODIFICATION_TIME = modificationTime;
-        QuickTimeHandlerFactory.HANDLER_PARAM_TIME_SCALE = timescale;
-        QuickTimeHandlerFactory.HANDLER_PARAM_DURATION = duration;
+//        QuickTimeHandlerFactory.HANDLER_PARAM_CREATION_TIME = creationTime;
+//        QuickTimeHandlerFactory.HANDLER_PARAM_MODIFICATION_TIME = modificationTime;
+//        QuickTimeHandlerFactory.HANDLER_PARAM_TIME_SCALE = timescale;
+//        QuickTimeHandlerFactory.HANDLER_PARAM_DURATION = duration;
     }
 }

--- a/Source/com/drew/metadata/mov/atoms/TimeToSampleAtom.java
+++ b/Source/com/drew/metadata/mov/atoms/TimeToSampleAtom.java
@@ -66,7 +66,7 @@ public class TimeToSampleAtom extends FullAtom
 
     public void addMetadata(QuickTimeVideoDirectory directory)
     {
-        float frameRate = (float) QuickTimeHandlerFactory.HANDLER_PARAM_TIME_SCALE/(float)sampleDuration;
-        directory.setFloat(QuickTimeVideoDirectory.TAG_FRAME_RATE, frameRate);
+//        float frameRate = (float) QuickTimeHandlerFactory.HANDLER_PARAM_TIME_SCALE/(float)sampleDuration;
+//        directory.setFloat(QuickTimeVideoDirectory.TAG_FRAME_RATE, frameRate);
     }
 }

--- a/Source/com/drew/metadata/mov/media/QuickTimeSoundHandler.java
+++ b/Source/com/drew/metadata/mov/media/QuickTimeSoundHandler.java
@@ -69,6 +69,6 @@ public class QuickTimeSoundHandler extends QuickTimeMediaHandler<QuickTimeSoundD
     @Override
     protected void processTimeToSample(@NotNull SequentialReader reader, @NotNull Atom atom) throws IOException
     {
-        directory.setDouble(QuickTimeSoundDirectory.TAG_AUDIO_SAMPLE_RATE, QuickTimeHandlerFactory.HANDLER_PARAM_TIME_SCALE);
+//        directory.setDouble(QuickTimeSoundDirectory.TAG_AUDIO_SAMPLE_RATE, QuickTimeHandlerFactory.HANDLER_PARAM_TIME_SCALE);
     }
 }

--- a/Source/com/drew/metadata/mp4/Mp4HandlerFactory.java
+++ b/Source/com/drew/metadata/mp4/Mp4HandlerFactory.java
@@ -35,11 +35,11 @@ public class Mp4HandlerFactory
 
     private Mp4Handler caller;
 
-    public static Long HANDLER_PARAM_TIME_SCALE              = null;
-    public static Long HANDLER_PARAM_CREATION_TIME           = null;
-    public static Long HANDLER_PARAM_MODIFICATION_TIME       = null;
-    public static Long HANDLER_PARAM_DURATION                = null;
-    public static String HANDLER_PARAM_LANGUAGE              = null;
+//    public static Long HANDLER_PARAM_TIME_SCALE              = null;
+//    public static Long HANDLER_PARAM_CREATION_TIME           = null;
+//    public static Long HANDLER_PARAM_MODIFICATION_TIME       = null;
+//    public static Long HANDLER_PARAM_DURATION                = null;
+//    public static String HANDLER_PARAM_LANGUAGE              = null;
 
     public Mp4HandlerFactory(Mp4Handler caller)
     {

--- a/Source/com/drew/metadata/mp4/Mp4MediaHandler.java
+++ b/Source/com/drew/metadata/mp4/Mp4MediaHandler.java
@@ -38,19 +38,19 @@ public abstract class Mp4MediaHandler<T extends Mp4MediaDirectory> extends Mp4Ha
     public Mp4MediaHandler(Metadata metadata)
     {
         super(metadata);
-        if (Mp4HandlerFactory.HANDLER_PARAM_CREATION_TIME != null && Mp4HandlerFactory.HANDLER_PARAM_MODIFICATION_TIME != null) {
-            // Get creation/modification times
-            Calendar calendar = Calendar.getInstance();
-            calendar.set(1904, 0, 1, 0, 0, 0);      // January 1, 1904  -  Macintosh Time Epoch
-            Date date = calendar.getTime();
-            long macToUnixEpochOffset = date.getTime();
-            String creationTimeStamp = new Date(Mp4HandlerFactory.HANDLER_PARAM_CREATION_TIME * 1000 + macToUnixEpochOffset).toString();
-            String modificationTimeStamp = new Date(Mp4HandlerFactory.HANDLER_PARAM_MODIFICATION_TIME * 1000 + macToUnixEpochOffset).toString();
-            String language = Mp4HandlerFactory.HANDLER_PARAM_LANGUAGE;
-            directory.setString(Mp4MediaDirectory.TAG_CREATION_TIME, creationTimeStamp);
-            directory.setString(Mp4MediaDirectory.TAG_MODIFICATION_TIME, modificationTimeStamp);
-            directory.setString(Mp4MediaDirectory.TAG_LANGUAGE_CODE, language);
-        }
+//        if (Mp4HandlerFactory.HANDLER_PARAM_CREATION_TIME != null && Mp4HandlerFactory.HANDLER_PARAM_MODIFICATION_TIME != null) {
+//            // Get creation/modification times
+//            Calendar calendar = Calendar.getInstance();
+//            calendar.set(1904, 0, 1, 0, 0, 0);      // January 1, 1904  -  Macintosh Time Epoch
+//            Date date = calendar.getTime();
+//            long macToUnixEpochOffset = date.getTime();
+//            String creationTimeStamp = new Date(Mp4HandlerFactory.HANDLER_PARAM_CREATION_TIME * 1000 + macToUnixEpochOffset).toString();
+//            String modificationTimeStamp = new Date(Mp4HandlerFactory.HANDLER_PARAM_MODIFICATION_TIME * 1000 + macToUnixEpochOffset).toString();
+//            String language = Mp4HandlerFactory.HANDLER_PARAM_LANGUAGE;
+//            directory.setString(Mp4MediaDirectory.TAG_CREATION_TIME, creationTimeStamp);
+//            directory.setString(Mp4MediaDirectory.TAG_MODIFICATION_TIME, modificationTimeStamp);
+//            directory.setString(Mp4MediaDirectory.TAG_LANGUAGE_CODE, language);
+//        }
     }
 
     @Override

--- a/Source/com/drew/metadata/mp4/boxes/MediaHeaderBox.java
+++ b/Source/com/drew/metadata/mp4/boxes/MediaHeaderBox.java
@@ -56,10 +56,10 @@ public class MediaHeaderBox extends FullBox
             (char)(((languageBits & 0x03E0) >> 5) + 0x60),
             (char)((languageBits & 0x001F) + 0x60)});
 
-        Mp4HandlerFactory.HANDLER_PARAM_CREATION_TIME = creationTime;
-        Mp4HandlerFactory.HANDLER_PARAM_MODIFICATION_TIME = modificationTime;
-        Mp4HandlerFactory.HANDLER_PARAM_TIME_SCALE = timescale;
-        Mp4HandlerFactory.HANDLER_PARAM_DURATION = duration;
-        Mp4HandlerFactory.HANDLER_PARAM_LANGUAGE = language;
+//        Mp4HandlerFactory.HANDLER_PARAM_CREATION_TIME = creationTime;
+//        Mp4HandlerFactory.HANDLER_PARAM_MODIFICATION_TIME = modificationTime;
+//        Mp4HandlerFactory.HANDLER_PARAM_TIME_SCALE = timescale;
+//        Mp4HandlerFactory.HANDLER_PARAM_DURATION = duration;
+//        Mp4HandlerFactory.HANDLER_PARAM_LANGUAGE = language;
     }
 }

--- a/Source/com/drew/metadata/mp4/boxes/TimeToSampleBox.java
+++ b/Source/com/drew/metadata/mp4/boxes/TimeToSampleBox.java
@@ -49,13 +49,13 @@ public class TimeToSampleBox extends FullBox
 
     public void addMetadata(Mp4VideoDirectory directory)
     {
-        float frameRate = (float) Mp4HandlerFactory.HANDLER_PARAM_TIME_SCALE/(float)entries.get(0).sampleDelta;
-        directory.setFloat(Mp4VideoDirectory.TAG_FRAME_RATE, frameRate);
+//        float frameRate = (float) Mp4HandlerFactory.HANDLER_PARAM_TIME_SCALE/(float)entries.get(0).sampleDelta;
+//        directory.setFloat(Mp4VideoDirectory.TAG_FRAME_RATE, frameRate);
     }
 
     public void addMetadata(Mp4SoundDirectory directory)
     {
-        directory.setDouble(Mp4SoundDirectory.TAG_AUDIO_SAMPLE_RATE, Mp4HandlerFactory.HANDLER_PARAM_TIME_SCALE);
+//        directory.setDouble(Mp4SoundDirectory.TAG_AUDIO_SAMPLE_RATE, Mp4HandlerFactory.HANDLER_PARAM_TIME_SCALE);
     }
 
     class EntryCount


### PR DESCRIPTION
Fixes TODO about static variable usage from c74bc83.  HANDLER_PARAM usage has been commented out for future reimplementation without using static variables.  No vital directory entries are lost. 