### PR TITLE
Stop EPS reader at first non-comment line and add PhotoshopTiffHandler for Photoshop-specific tags

### DIFF
--- a/Source/com/drew/metadata/eps/EpsReader.java
+++ b/Source/com/drew/metadata/eps/EpsReader.java
@@ -128,7 +128,7 @@ public class EpsReader
             }
 
             // Stop when we hit a line that is not a comment
-            if (line.length() == 0 || line.charAt(0) != '%')
+            if (line.length() != 0 && line.charAt(0) != '%')
                 break;
 
             String name;

--- a/Source/com/drew/metadata/eps/EpsReader.java
+++ b/Source/com/drew/metadata/eps/EpsReader.java
@@ -6,9 +6,9 @@ import com.drew.lang.*;
 import com.drew.lang.annotations.NotNull;
 import com.drew.lang.annotations.Nullable;
 import com.drew.metadata.Metadata;
-import com.drew.metadata.exif.ExifTiffHandler;
 import com.drew.metadata.icc.IccReader;
 import com.drew.metadata.photoshop.PhotoshopReader;
+import com.drew.metadata.photoshop.PhotoshopTiffHandler;
 import com.drew.metadata.xmp.XmpReader;
 
 import java.io.ByteArrayOutputStream;
@@ -80,7 +80,7 @@ public class EpsReader
                     // Get Tiff metadata
                     try {
                         ByteArrayReader byteArrayReader = new ByteArrayReader(reader.getBytes(tifOffset, tifSize));
-                        new TiffReader().processTiff(byteArrayReader, new ExifTiffHandler(metadata, null), 0);
+                        new TiffReader().processTiff(byteArrayReader, new PhotoshopTiffHandler(metadata, null), 0);
                     } catch (TiffProcessingException ex) {
                         directory.addError("Unable to process TIFF data: " + ex.getMessage());
                     }
@@ -127,9 +127,9 @@ public class EpsReader
                 line.append(c);
             }
 
-            // Skip any blank lines, or lines that don't start with '%'
+            // Stop when we hit a line that is not a comment
             if (line.length() == 0 || line.charAt(0) != '%')
-                continue;
+                break;
 
             String name;
 
@@ -151,12 +151,6 @@ public class EpsReader
                 extractIccData(metadata, reader);
             } else if (name.equals("%begin_xml_packet")) {
                 extractXmpData(metadata, reader);
-            } else if (
-                name.equals("%%BeginBinary") ||
-                name.equals("%%BeginData") ||
-                name.equals("%AI9_PrivateDataEnd")) {
-                // Stop parsing once we hit one of these sections
-                return;
             }
         }
     }

--- a/Source/com/drew/metadata/photoshop/PhotoshopTiffHandler.java
+++ b/Source/com/drew/metadata/photoshop/PhotoshopTiffHandler.java
@@ -1,0 +1,61 @@
+package com.drew.metadata.photoshop;
+
+import com.drew.lang.ByteArrayReader;
+import com.drew.lang.RandomAccessReader;
+import com.drew.lang.SequentialByteArrayReader;
+import com.drew.lang.annotations.NotNull;
+import com.drew.metadata.Directory;
+import com.drew.metadata.Metadata;
+import com.drew.metadata.exif.ExifTiffHandler;
+import com.drew.metadata.icc.IccReader;
+import com.drew.metadata.xmp.XmpReader;
+
+import java.io.IOException;
+import java.util.Set;
+
+/**
+ * @author Payton Garland
+ */
+public class PhotoshopTiffHandler extends ExifTiffHandler
+{
+    // Photoshop-specific Tiff Tags
+    // http://www.adobe.com/devnet-apps/photoshop/fileformatashtml/#50577413_pgfId-1039502
+    private static final int TAG_PAGE_MAKER_EXTENSION = 0x014A;
+    private static final int TAG_JPEG_TABLES = 0X01B5;
+    private static final int TAG_XMP = 0x02BC;
+    private static final int TAG_FILE_INFORMATION = 0x83BB;
+    private static final int TAG_PHOTOSHOP_IMAGE_RESOURCES = 0x8649;
+    private static final int TAG_EXIF_IFD_POINTER = 0x8769;
+    private static final int TAG_ICC_PROFILES = 0x8773;
+    private static final int TAG_EXIF_GPS = 0x8825;
+    private static final int TAG_T_IMAGE_SOURCE_DATA = 0x935C;
+    private static final int TAG_T_ANNOTATIONS = 0xC44F;
+
+    public PhotoshopTiffHandler(Metadata metadata, Directory parentDirectory)
+    {
+        super(metadata, parentDirectory);
+    }
+
+    public boolean customProcessTag(final int tagOffset,
+                                    final @NotNull Set<Integer> processedIfdOffsets,
+                                    final int tiffHeaderOffset,
+                                    final @NotNull RandomAccessReader reader,
+                                    final int tagId,
+                                    final int byteCount) throws IOException
+    {
+        switch (tagId) {
+            case TAG_XMP:
+                new XmpReader().extract(reader.getBytes(tagOffset, byteCount), _metadata);
+                return true;
+            case TAG_PHOTOSHOP_IMAGE_RESOURCES:
+                new PhotoshopReader().extract(new SequentialByteArrayReader(reader.getBytes(tagOffset, byteCount)), byteCount, _metadata);
+                return true;
+            case TAG_ICC_PROFILES:
+                new IccReader().extract(new ByteArrayReader(reader.getBytes(tagOffset, byteCount)), _metadata);
+                return true;
+        }
+
+
+        return super.customProcessTag(tagOffset, processedIfdOffsets, tiffHeaderOffset, reader, tagId, byteCount);
+    }
+}


### PR DESCRIPTION
Prevents the EPS reader from commonly throwing IOExceptions by stopping the reader at the first non-comment line similar to Exif Tool. Also implement PhotoshopTiffHandler for photoshop-specific tiff tags used in the EPS reader.

This PR replaces #295.