### PR TITLE
Store date instead of string for creation/modification time

### DIFF
--- a/Source/com/drew/metadata/mov/atoms/MovieHeaderAtom.java
+++ b/Source/com/drew/metadata/mov/atoms/MovieHeaderAtom.java
@@ -89,10 +89,8 @@ public class MovieHeaderAtom extends FullAtom
         calendar.set(1904, 0, 1, 0, 0, 0);      // January 1, 1904  -  Macintosh Time Epoch
         Date date = calendar.getTime();
         long macToUnixEpochOffset = date.getTime();
-        String creationTimeStamp = new Date(creationTime * 1000 + macToUnixEpochOffset).toString();
-        String modificationTimeStamp = new Date(modificationTime * 1000 + macToUnixEpochOffset).toString();
-        directory.setString(TAG_CREATION_TIME, creationTimeStamp);
-        directory.setString(TAG_MODIFICATION_TIME, modificationTimeStamp);
+        directory.setDate(TAG_CREATION_TIME, new Date((creationTime * 1000) + macToUnixEpochOffset));
+        directory.setDate(TAG_MODIFICATION_TIME, new Date((modificationTime * 1000) + macToUnixEpochOffset));
 
         // Get duration and time scale
         duration = duration / timescale;

--- a/Source/com/drew/metadata/mp4/boxes/MovieHeaderBox.java
+++ b/Source/com/drew/metadata/mp4/boxes/MovieHeaderBox.java
@@ -80,10 +80,8 @@ public class MovieHeaderBox extends FullBox
         calendar.set(1904, 0, 1, 0, 0, 0);      // January 1, 1904  -  Macintosh Time Epoch
         Date date = calendar.getTime();
         long macToUnixEpochOffset = date.getTime();
-        String creationTimeStamp = new Date(creationTime*1000 + macToUnixEpochOffset).toString();
-        String modificationTimeStamp = new Date(modificationTime*1000 + macToUnixEpochOffset).toString();
-        directory.setString(Mp4Directory.TAG_CREATION_TIME, creationTimeStamp);
-        directory.setString(Mp4Directory.TAG_MODIFICATION_TIME, modificationTimeStamp);
+        directory.setDate(Mp4Directory.TAG_CREATION_TIME, new Date((creationTime * 1000) + macToUnixEpochOffset));
+        directory.setDate(Mp4Directory.TAG_MODIFICATION_TIME, new Date((modificationTime * 1000) + macToUnixEpochOffset));
 
         // Get duration and time scale
         duration = duration / timescale;


### PR DESCRIPTION
Fixes #303 

Since QuickTime files (including MP4), use the reference time of January 1, 1904, the date must be calculated differently than others.  Previously, the date object was created and then toString was called to store it in the directory.  I have opted to just store the date itself since we create it anyways.  This will solve the issue since Directory's getDate will return at line 867 if the object is already an instance of java.util.Date.