### PR TITLE
Account for extra 16 bytes in UUID atoms

### DIFF
--- a/Source/com/drew/imaging/mp4/Mp4Reader.java
+++ b/Source/com/drew/imaging/mp4/Mp4Reader.java
@@ -56,6 +56,8 @@ public class Mp4Reader
                     processBoxes(reader, box.size + reader.getPosition() - 8, handler.processContainer(box));
                 } else if (handler.shouldAcceptBox(box)) {
                     handler = handler.processBox(box, reader.getBytes((int)box.size - 8));
+                } else if (box.usertype != null) {
+                    reader.skip(box.size - 24);
                 } else if (box.size > 1) {
                     reader.skip(box.size - 8);
                 } else if (box.size == -1) {

--- a/Source/com/drew/metadata/mp4/boxes/Box.java
+++ b/Source/com/drew/metadata/mp4/boxes/Box.java
@@ -31,7 +31,7 @@ public class Box
 {
     public long size;
     public String type;
-    String usertype;
+    public String usertype;
 
     public Box(SequentialReader reader) throws IOException
     {


### PR DESCRIPTION
Fixes #306 

Added correct handling of UUID atoms in Mp4Reader.
Reader was not skipping the extra 16 bytes before the payload that is the actual UUID.