### PR TITLE
Add a tag for duration in seconds to mp4 directory

### DIFF
--- a/Source/com/drew/metadata/mp4/Mp4Directory.java
+++ b/Source/com/drew/metadata/mp4/Mp4Directory.java
@@ -31,8 +31,9 @@ public class Mp4Directory extends Directory {
     public static final int TAG_MODIFICATION_TIME                       = 0x0101;
     public static final int TAG_TIME_SCALE                              = 0x0102;
     public static final int TAG_DURATION                                = 0x0103;
-    public static final int TAG_PREFERRED_RATE                          = 0x0104;
-    public static final int TAG_PREFERRED_VOLUME                        = 0x0105;
+    public static final int TAG_DURATION_SECONDS                        = 0x0104;
+    public static final int TAG_PREFERRED_RATE                          = 0x0105;
+    public static final int TAG_PREFERRED_VOLUME                        = 0x0106;
     public static final int TAG_PREVIEW_TIME                            = 0x0108;
     public static final int TAG_PREVIEW_DURATION                        = 0x0109;
     public static final int TAG_POSTER_TIME                             = 0x010A;
@@ -59,6 +60,7 @@ public class Mp4Directory extends Directory {
         _tagNameMap.put(TAG_MODIFICATION_TIME, "Modification Time");
         _tagNameMap.put(TAG_TIME_SCALE, "Media Time Scale");
         _tagNameMap.put(TAG_DURATION, "Duration");
+        _tagNameMap.put(TAG_DURATION_SECONDS, "Duration in Seconds");
         _tagNameMap.put(TAG_PREFERRED_RATE, "Preferred Rate");
         _tagNameMap.put(TAG_PREFERRED_VOLUME, "Preferred Volume");
         _tagNameMap.put(TAG_PREVIEW_TIME, "Preview Time");

--- a/Source/com/drew/metadata/mp4/boxes/MovieHeaderBox.java
+++ b/Source/com/drew/metadata/mp4/boxes/MovieHeaderBox.java
@@ -20,6 +20,7 @@
  */
 package com.drew.metadata.mp4.boxes;
 
+import com.drew.lang.Rational;
 import com.drew.lang.SequentialReader;
 import com.drew.metadata.mp4.Mp4Directory;
 
@@ -84,9 +85,9 @@ public class MovieHeaderBox extends FullBox
         directory.setDate(Mp4Directory.TAG_MODIFICATION_TIME, new Date((modificationTime * 1000) + macToUnixEpochOffset));
 
         // Get duration and time scale
-        duration = duration / timescale;
         directory.setLong(Mp4Directory.TAG_DURATION, duration);
         directory.setLong(Mp4Directory.TAG_TIME_SCALE, timescale);
+        directory.setRational(Mp4Directory.TAG_DURATION_SECONDS, new Rational(duration, timescale));
 
         directory.setIntArray(Mp4Directory.TAG_TRANSFORMATION_MATRIX, matrix);
 


### PR DESCRIPTION
This changes add a new tag `TAG_DURATION_SECONDS` to `Mp4Directory`.
The property that corresponds to the tag is video duration in seconds, stored as `Rational` whose numerator and denominator are the corresponding property of `TAG_DURATION` and `TAG_TIME_SCALE` respectively.

This PR resolves the issue #312 .