### PR TITLE
Remove XMP array and struct parent properties

### DIFF
--- a/Source/com/drew/metadata/xmp/XmpDirectory.java
+++ b/Source/com/drew/metadata/xmp/XmpDirectory.java
@@ -23,6 +23,7 @@ package com.drew.metadata.xmp;
 import com.adobe.xmp.XMPException;
 import com.adobe.xmp.XMPMeta;
 import com.adobe.xmp.impl.XMPMetaImpl;
+import com.adobe.xmp.options.IteratorOptions;
 import com.adobe.xmp.properties.XMPPropertyInfo;
 import com.drew.lang.annotations.NotNull;
 import com.drew.lang.annotations.Nullable;
@@ -91,7 +92,8 @@ public class XmpDirectory extends Directory
         if (_xmpMeta != null)
         {
             try {
-                for (Iterator i = _xmpMeta.iterator(); i.hasNext(); ) {
+                IteratorOptions options = new IteratorOptions().setJustLeafnodes(true);
+                for (Iterator i = _xmpMeta.iterator(options); i.hasNext(); ) {
                     XMPPropertyInfo prop = (XMPPropertyInfo)i.next();
                     String path = prop.getPath();
                     String value = prop.getValue();
@@ -112,7 +114,8 @@ public class XmpDirectory extends Directory
 
         try {
             int valueCount = 0;
-            for (Iterator i = _xmpMeta.iterator(); i.hasNext(); ) {
+            IteratorOptions options = new IteratorOptions().setJustLeafnodes(true);
+            for (Iterator i = _xmpMeta.iterator(options); i.hasNext(); ) {
                 XMPPropertyInfo prop = (XMPPropertyInfo)i.next();
                 if (prop.getPath() != null) {
                     valueCount++;

--- a/Tests/com/drew/metadata/xmp/XmpReaderTest.java
+++ b/Tests/com/drew/metadata/xmp/XmpReaderTest.java
@@ -64,7 +64,7 @@ public class XmpReaderTest
     @Test
     public void testExtract_PropertyCount() throws Exception
     {
-        assertEquals(179, _directory.getInt(XmpDirectory.TAG_XMP_VALUE_COUNT));
+        assertEquals(168, _directory.getInt(XmpDirectory.TAG_XMP_VALUE_COUNT));
     }
 
     @Test
@@ -72,7 +72,7 @@ public class XmpReaderTest
     {
         Map<String,String> propertyMap = _directory.getXmpProperties();
 
-        assertEquals(179, propertyMap.size());
+        assertEquals(168, propertyMap.size());
 
         assertTrue(propertyMap.containsKey("photoshop:Country"));
         assertEquals("Deutschland", propertyMap.get("photoshop:Country"));


### PR DESCRIPTION
### Problem

`XmpDirectory.getXmpProperties` returns a map of XMP properties, but it includes array and struct parent properties which don't have an actual value. I suggest that it is preferable to exclude them from the map.

Example:
```
...
"Iptc4xmpCore:CountryCode": "DE"
"Iptc4xmpCore:Location": "Fotostudio HS"
"Iptc4xmpCore:CreatorContactInfo": ""           <-- Struct parent node
"Iptc4xmpCore:CreatorContactInfo/Iptc4xmpCore:CiAdrCity": "Mainz"
"Iptc4xmpCore:CreatorContactInfo/Iptc4xmpCore:CiAdrCtry": "Deutschland"
"Iptc4xmpCore:CreatorContactInfo/Iptc4xmpCore:CiAdrExtadr": "Konrad-Adenauer-Str. 33"
"Iptc4xmpCore:CreatorContactInfo/Iptc4xmpCore:CiAdrPcode": "55129"
"Iptc4xmpCore:CreatorContactInfo/Iptc4xmpCore:CiAdrRegion": "Rheinland-Pfalz"
"Iptc4xmpCore:CreatorContactInfo/Iptc4xmpCore:CiEmailWork": "pb@meine-ansichten.de"
"Iptc4xmpCore:CreatorContactInfo/Iptc4xmpCore:CiTelWork": "06136/958638"
"Iptc4xmpCore:CreatorContactInfo/Iptc4xmpCore:CiUrlWork": "http://www.meine-ansichten.de"
...
"dc:format": "image/tiff"
"dc:creator": ""                                <-- Array parent node
"dc:creator[1]": "Peter Bemmann"
"dc:rights": ""                                 <-- Array parent node
"dc:rights[1]": "© Peter Bemmann"
"dc:rights[1]/xml:lang": "x-default"
"dc:description": ""                            <-- Array parent node 
"dc:description[1]": "mit blauem Kleid"
"dc:description[1]/xml:lang": "x-default"
...
```

### Solution

Pass an `IteratorOptions` object when getting `XMPIterator` objects to limit the type of properties only to leaf nodes in a XMP tree.