### PR TITLE
Fix MOV/MP4 parsing issues

### DIFF
--- a/Source/com/drew/metadata/mov/QuickTimeDescriptor.java
+++ b/Source/com/drew/metadata/mov/QuickTimeDescriptor.java
@@ -20,6 +20,7 @@
  */
 package com.drew.metadata.mov;
 
+import com.drew.lang.Rational;
 import com.drew.lang.annotations.NotNull;
 import com.drew.metadata.TagDescriptor;
 
@@ -46,7 +47,7 @@ public class QuickTimeDescriptor extends TagDescriptor<QuickTimeDirectory> {
                 return getMajorBrandDescription();
             case TAG_COMPATIBLE_BRANDS:
                 return getCompatibleBrandsDescription();
-            case TAG_DURATION:
+            case TAG_DURATION_SECONDS:
                 return getDurationDescription();
             default:
                 return super.getDescription(tagType);
@@ -77,10 +78,11 @@ public class QuickTimeDescriptor extends TagDescriptor<QuickTimeDirectory> {
 
     private String getDurationDescription()
     {
-        Long value = _directory.getLongObject(TAG_DURATION);
-        if (value == null)
+        Rational duration = _directory.getRational(TAG_DURATION_SECONDS);
+        if (duration == null)
             return null;
 
+        double value = duration.doubleValue();
         Integer hours = (int)(value / (Math.pow(60, 2)));
         Integer minutes = (int)((value / (Math.pow(60, 1))) - (hours * 60));
         Integer seconds = (int)Math.ceil((value / (Math.pow(60, 0))) - (minutes * 60));

--- a/Source/com/drew/metadata/mov/atoms/SoundSampleDescriptionAtom.java
+++ b/Source/com/drew/metadata/mov/atoms/SoundSampleDescriptionAtom.java
@@ -48,7 +48,7 @@ public class SoundSampleDescriptionAtom extends SampleDescriptionAtom<SoundSampl
     {
         SoundSampleDescription description = sampleDescriptions.get(0);
 
-        directory.setString(QuickTimeSoundDirectory.TAG_AUDIO_FORMAT, QuickTimeDictionary.lookup(QuickTimeSoundDirectory.TAG_AUDIO_FORMAT, description.dataFormat));
+        QuickTimeDictionary.setLookup(QuickTimeSoundDirectory.TAG_AUDIO_FORMAT, description.dataFormat, directory);
         directory.setInt(QuickTimeSoundDirectory.TAG_NUMBER_OF_CHANNELS, description.numberOfChannels);
         directory.setInt(QuickTimeSoundDirectory.TAG_AUDIO_SAMPLE_SIZE, description.sampleSize);
     }

--- a/Source/com/drew/metadata/mov/atoms/TimeToSampleAtom.java
+++ b/Source/com/drew/metadata/mov/atoms/TimeToSampleAtom.java
@@ -48,8 +48,6 @@ public class TimeToSampleAtom extends FullAtom
         for (int i = 0; i < numberOfEntries; i++) {
             entries.add(new Entry(reader));
         }
-        sampleCount = reader.getUInt32();
-        sampleDuration = reader.getUInt32();
     }
 
     class Entry
@@ -66,7 +64,7 @@ public class TimeToSampleAtom extends FullAtom
 
     public void addMetadata(QuickTimeVideoDirectory directory)
     {
-        float frameRate = (float) QuickTimeHandlerFactory.HANDLER_PARAM_TIME_SCALE/(float)sampleDuration;
+        float frameRate = (float) QuickTimeHandlerFactory.HANDLER_PARAM_TIME_SCALE/(float)entries.get(0).sampleDuration;
         directory.setFloat(QuickTimeVideoDirectory.TAG_FRAME_RATE, frameRate);
     }
 }

--- a/Source/com/drew/metadata/mov/atoms/VideoSampleDescriptionAtom.java
+++ b/Source/com/drew/metadata/mov/atoms/VideoSampleDescriptionAtom.java
@@ -55,7 +55,11 @@ public class VideoSampleDescriptionAtom extends SampleDescriptionAtom<VideoSampl
         directory.setLong(QuickTimeVideoDirectory.TAG_SPATIAL_QUALITY, sampleDescription.spatialQuality);
         directory.setInt(QuickTimeVideoDirectory.TAG_WIDTH, sampleDescription.width);
         directory.setInt(QuickTimeVideoDirectory.TAG_HEIGHT, sampleDescription.height);
-        directory.setString(QuickTimeVideoDirectory.TAG_COMPRESSOR_NAME, sampleDescription.compressorName.trim());
+
+        String compressorName = sampleDescription.compressorName.trim();
+        if (!compressorName.isEmpty()) {
+            directory.setString(QuickTimeVideoDirectory.TAG_COMPRESSOR_NAME, compressorName);
+        }
 
         directory.setInt(QuickTimeVideoDirectory.TAG_DEPTH, sampleDescription.depth);
         directory.setInt(QuickTimeVideoDirectory.TAG_COLOR_TABLE, sampleDescription.colorTableID);
@@ -101,7 +105,7 @@ public class VideoSampleDescriptionAtom extends SampleDescriptionAtom<VideoSampl
             verticalResolution = reader.getUInt32();
             dataSize = reader.getUInt32();
             frameCount = reader.getUInt16();
-            compressorName = reader.getString(reader.getUInt8());
+            compressorName = reader.getString(32);
             depth = reader.getUInt16();
             colorTableID = reader.getInt16();
         }

--- a/Source/com/drew/metadata/mov/media/QuickTimeVideoDescriptor.java
+++ b/Source/com/drew/metadata/mov/media/QuickTimeVideoDescriptor.java
@@ -66,6 +66,14 @@ public class QuickTimeVideoDescriptor extends QuickTimeDescriptor
             return null;
 
         switch (value) {
+            case (1):
+            case (2):
+            case (4):
+            case (8):
+            case (16):
+            case (24):
+            case (32):
+                return value + "-bit color";
             case (40):
             case (36):
             case (34):

--- a/Source/com/drew/metadata/mp4/Mp4Descriptor.java
+++ b/Source/com/drew/metadata/mp4/Mp4Descriptor.java
@@ -20,6 +20,7 @@
  */
 package com.drew.metadata.mp4;
 
+import com.drew.lang.Rational;
 import com.drew.lang.annotations.NotNull;
 import com.drew.metadata.Directory;
 import com.drew.metadata.TagDescriptor;
@@ -44,7 +45,7 @@ public class Mp4Descriptor<T extends Directory> extends TagDescriptor<Mp4Directo
                 return getMajorBrandDescription();
             case TAG_COMPATIBLE_BRANDS:
                 return getCompatibleBrandsDescription();
-            case TAG_DURATION:
+            case TAG_DURATION_SECONDS:
                 return getDurationDescription();
             default:
                 return _directory.getString(tagType);
@@ -75,10 +76,11 @@ public class Mp4Descriptor<T extends Directory> extends TagDescriptor<Mp4Directo
 
     private String getDurationDescription()
     {
-        Long value = _directory.getLongObject(TAG_DURATION);
-        if (value == null)
+        Rational duration = _directory.getRational(TAG_DURATION_SECONDS);
+        if (duration == null)
             return null;
 
+        double value = duration.doubleValue();
         Integer hours = (int)(value / (Math.pow(60, 2)));
         Integer minutes = (int)((value / (Math.pow(60, 1))) - (hours * 60));
         Integer seconds = (int)Math.ceil((value / (Math.pow(60, 0))) - (minutes * 60));

--- a/Source/com/drew/metadata/mp4/boxes/AudioSampleEntry.java
+++ b/Source/com/drew/metadata/mp4/boxes/AudioSampleEntry.java
@@ -21,6 +21,7 @@
 package com.drew.metadata.mp4.boxes;
 
 import com.drew.lang.SequentialReader;
+import com.drew.metadata.mp4.Mp4Dictionary;
 import com.drew.metadata.mp4.media.Mp4SoundDirectory;
 
 import java.io.IOException;
@@ -51,8 +52,8 @@ public class AudioSampleEntry extends SampleEntry
 
     public void addMetadata(Mp4SoundDirectory directory)
     {
+        Mp4Dictionary.setLookup(Mp4SoundDirectory.TAG_AUDIO_FORMAT, format, directory);
         directory.setInt(Mp4SoundDirectory.TAG_NUMBER_OF_CHANNELS, channelcount);
         directory.setInt(Mp4SoundDirectory.TAG_AUDIO_SAMPLE_SIZE, samplesize);
-        directory.setLong(Mp4SoundDirectory.TAG_AUDIO_SAMPLE_RATE, samplerate);
     }
 }

--- a/Source/com/drew/metadata/mp4/boxes/VisualSampleEntry.java
+++ b/Source/com/drew/metadata/mp4/boxes/VisualSampleEntry.java
@@ -21,6 +21,7 @@
 package com.drew.metadata.mp4.boxes;
 
 import com.drew.lang.SequentialReader;
+import com.drew.metadata.mp4.Mp4Dictionary;
 import com.drew.metadata.mp4.media.Mp4VideoDirectory;
 
 import java.io.IOException;
@@ -65,9 +66,16 @@ public class VisualSampleEntry extends SampleEntry
 
     public void addMetadata(Mp4VideoDirectory directory)
     {
+        Mp4Dictionary.setLookup(Mp4VideoDirectory.TAG_COMPRESSION_TYPE, format, directory);
+
         directory.setInt(Mp4VideoDirectory.TAG_WIDTH, width);
         directory.setInt(Mp4VideoDirectory.TAG_HEIGHT, height);
-        directory.setString(Mp4VideoDirectory.TAG_COMPRESSION_TYPE, compressorname.trim());
+
+        String compressorName = compressorname.trim();
+        if (!compressorName.isEmpty()) {
+            directory.setString(Mp4VideoDirectory.TAG_COMPRESSOR_NAME, compressorName);
+        }
+
         directory.setInt(Mp4VideoDirectory.TAG_DEPTH, depth);
 
         // Calculate horizontal res

--- a/Source/com/drew/metadata/mp4/media/Mp4SoundDirectory.java
+++ b/Source/com/drew/metadata/mp4/media/Mp4SoundDirectory.java
@@ -27,12 +27,12 @@ import java.util.HashMap;
 public class Mp4SoundDirectory extends Mp4MediaDirectory
 {
     // Sound Sample Description Atom
-    public static final int TAG_AUDIO_FORMAT                            = 101;
-    public static final int TAG_NUMBER_OF_CHANNELS                      = 102;
-    public static final int TAG_AUDIO_SAMPLE_SIZE                       = 103;
-    public static final int TAG_AUDIO_SAMPLE_RATE                       = 104;
+    public static final int TAG_AUDIO_FORMAT                            = 301;
+    public static final int TAG_NUMBER_OF_CHANNELS                      = 302;
+    public static final int TAG_AUDIO_SAMPLE_SIZE                       = 303;
+    public static final int TAG_AUDIO_SAMPLE_RATE                       = 304;
 
-    public static final int TAG_SOUND_BALANCE                           = 105;
+    public static final int TAG_SOUND_BALANCE                           = 305;
 
     public Mp4SoundDirectory()
     {

--- a/Source/com/drew/metadata/mp4/media/Mp4VideoDescriptor.java
+++ b/Source/com/drew/metadata/mp4/media/Mp4VideoDescriptor.java
@@ -63,6 +63,14 @@ public class Mp4VideoDescriptor extends TagDescriptor<Mp4VideoDirectory>
             return null;
 
         switch (value) {
+            case (1):
+            case (2):
+            case (4):
+            case (8):
+            case (16):
+            case (24):
+            case (32):
+                return value + "-bit color";
             case (40):
             case (36):
             case (34):

--- a/Source/com/drew/metadata/mp4/media/Mp4VideoDirectory.java
+++ b/Source/com/drew/metadata/mp4/media/Mp4VideoDirectory.java
@@ -27,22 +27,22 @@ import java.util.HashMap;
 public class Mp4VideoDirectory extends Mp4MediaDirectory
 {
     // Video Sample Description Atom
-    public static final int TAG_VENDOR                                  = 101;
-    public static final int TAG_TEMPORAL_QUALITY                        = 102;
-    public static final int TAG_SPATIAL_QUALITY                         = 103;
-    public static final int TAG_WIDTH                                   = 104;
-    public static final int TAG_HEIGHT                                  = 105;
-    public static final int TAG_HORIZONTAL_RESOLUTION                   = 106;
-    public static final int TAG_VERTICAL_RESOLUTION                     = 107;
-    public static final int TAG_COMPRESSOR_NAME                         = 108;
-    public static final int TAG_DEPTH                                   = 109;
-    public static final int TAG_COMPRESSION_TYPE                        = 110;
+    public static final int TAG_VENDOR                                  = 201;
+    public static final int TAG_TEMPORAL_QUALITY                        = 202;
+    public static final int TAG_SPATIAL_QUALITY                         = 203;
+    public static final int TAG_WIDTH                                   = 204;
+    public static final int TAG_HEIGHT                                  = 205;
+    public static final int TAG_HORIZONTAL_RESOLUTION                   = 206;
+    public static final int TAG_VERTICAL_RESOLUTION                     = 207;
+    public static final int TAG_COMPRESSOR_NAME                         = 208;
+    public static final int TAG_DEPTH                                   = 209;
+    public static final int TAG_COMPRESSION_TYPE                        = 210;
 
     // Video Media Information Header Atom
-    public static final int TAG_GRAPHICS_MODE                           = 111;
-    public static final int TAG_OPCOLOR                                 = 112;
-    public static final int TAG_COLOR_TABLE                             = 113;
-    public static final int TAG_FRAME_RATE                              = 114;
+    public static final int TAG_GRAPHICS_MODE                           = 211;
+    public static final int TAG_OPCOLOR                                 = 212;
+    public static final int TAG_COLOR_TABLE                             = 213;
+    public static final int TAG_FRAME_RATE                              = 214;
 
     public Mp4VideoDirectory()
     {


### PR DESCRIPTION
### Problems

I noticed a few issues of MOV and MP4 parsing.
```
[QuickTime] Major Brand = Apple QuickTime (.MOV/QT)
[QuickTime] Minor Version = 512
[QuickTime] Compatible Brands = [Apple QuickTime (.MOV/QT)]
[QuickTime] Creation Time = Fri Jan 01 00:00:00 +06:55 1904
[QuickTime] Modification Time = Fri Jan 01 00:00:00 +06:55 1904
[QuickTime] Duration = 01:32:3650                                  <-- Problem 1
[QuickTime] Media Time Scale = 1000
[QuickTime] Duration in Seconds = 5.57
[QuickTime] Preferred Rate = 1
[QuickTime] Preferred Volume = 1
[QuickTime] Preview Time = 0
[QuickTime] Preview Duration = 0
[QuickTime] Poster Time = 0
[QuickTime] Selection Time = 0
[QuickTime] Selection Duration = 0
[QuickTime] Current Time = 0
[QuickTime] Next Track ID = 3
ERROR: End of data reached.
[QuickTime Video] Creation Time = Fri Jan 01 00:00:00 SGT 1904
[QuickTime Video] Modification Time = Fri Jan 01 00:00:00 SGT 1904
[QuickTime Video] Opcolor = 0 0 0
[QuickTime Video] Graphics Mode = Copy
[QuickTime Video] Vendor = FFmpeg
[QuickTime Video] Compression Type = MPEG-4
[QuickTime Video] Temporal Quality = 512
[QuickTime Video] Spatial Quality = 512
[QuickTime Video] Width = 560 pixels
[QuickTime Video] Height = 320 pixels
[QuickTime Video] Compressor Name = mpeg4
[QuickTime Video] Depth = Unknown (0)                              <-- Problem 2
[QuickTime Video] Color Table = Color table within file
[QuickTime Video] Horizontal Resolution = 72
[QuickTime Video] Vertical Resolution = 72
ERROR: End of data reached.                                        <-- Problem 3
[QuickTime Sound] Creation Time = Fri Jan 01 00:00:00 SGT 1904
[QuickTime Sound] Modification Time = Fri Jan 01 00:00:00 SGT 1904
[QuickTime Sound] Balance = 0
[QuickTime Sound] Format = MPEG-4, Advanced Audio Coding (AAC)
[QuickTime Sound] Number of Channels = 1
[QuickTime Sound] Sample Size = 16
[QuickTime Sound] Sample Rate = 44100
```
```
[MP4] Major Brand = MP4 v2 [ISO 14496-14]
[MP4] Minor Version = 0
[MP4] Compatible Brands = [MP4 v2 [ISO 14496-14], MP4  Base Media v1 [IS0 14496-12:2003], MP4 Base w/ AVC ext [ISO 14496-12:2005]]
[MP4] Creation Time = Sat Mar 20 22:33:46 SGT 2010
[MP4] Modification Time = Sat Mar 20 22:33:47 SGT 2010
[MP4] Duration = 139:12:500400                                     <-- Problem 1
[MP4] Media Time Scale = 90000
[MP4] Duration in Seconds = 696/125
[MP4] Transformation Matrix = 65536 0 0 0 65536 0 0 0 1073741824
[MP4] Preferred Rate = 1
[MP4] Preferred Volume = 1
[MP4] Next Track ID = 3
ERROR: End of data reached.
[MP4 Video] Vendor = Sat Mar 20 22:33:46 SGT 2010                  <-- Problem 4
[MP4 Video] Temporal Quality = Sat Mar 20 22:33:47 SGT 2010        <-- Problem 4
[MP4 Video] Width = 560 pixels
[MP4 Video] Opcolor = 0 0 0
[MP4 Video] Graphics Mode = Copy
[MP4 Video] Height = 320 pixels
[MP4 Video] Compression Type = JVT/AVC Coding                      <-- Problem 5
[MP4 Video] Depth = Unknown (24)                                   <-- Problem 2
[MP4 Video] Horizontal Resolution = 72
[MP4 Video] Vertical Resolution = 72
[MP4 Video] Frame Rate = 30
[MP4 Sound] Format = Sat Mar 20 22:33:46 SGT 2010                  <-- Problem 4
[MP4 Sound] Number of Channels = 1
[MP4 Sound] Sample Rate = 48000
[MP4 Sound] Balance = 0
[MP4 Sound] Sample Size = 16
```
**Problem 1**: Duration is in wrong format. 

**Problem 2**: This QuickTime video should have 24-bit depth, but it shows 0. Also, Depth always shows Unknown (*).

**Problem 3**: [QuickTime Video] Frame Rate tag is missing. Error at the end of [QuickTime Video] section.

**Problem 4**: [MP4 Video] Vendor, Temporal Quality and [MP4 Sound] Format tags have wrong values.

**Problem 5**: 'JVT/AVC Coding' should be Compressor Name, and 'H.264' should be Compression Type.

### Solutions

1. `getDurationDescription()` is called on `TAG_DURATION_SECONDS`, not on `TAG_DURATION`.

2. The Compressor Name value was read as a variable length string, so the offsets for the following values were wrong. This was fixed. Also, the description for Depth tag was improved.

3. `TimeToSampleAtom` was wrongly parsed. Removed extra reads, and fix the frame rate calculation.

4. Some tag IDs in `Mp4VideoDirectory` and `Mp4SoundDirectory` conflicted with ones in `Mp4MediaDirectory`. This was a problem because they are subclasses of `Mp4MediaDirectory`. Shifted IDs in these directories.

5. Added `Mp4SoundDirectory.TAG_AUDIO_FORMAT` and `Mp4VideoDirectory.TAG_COMPRESSION_TYPE` parsing. Also, added empty checking of `TAG_COMPRESSOR_NAME`.

Here is the output of the fixed code.
```
[QuickTime] Major Brand = Apple QuickTime (.MOV/QT)
[QuickTime] Minor Version = 512
[QuickTime] Compatible Brands = [Apple QuickTime (.MOV/QT)]
[QuickTime] Creation Time = Fri Jan 01 00:00:00 +06:55 1904
[QuickTime] Modification Time = Fri Jan 01 00:00:00 +06:55 1904
[QuickTime] Duration = 5570
[QuickTime] Media Time Scale = 1000
[QuickTime] Duration in Seconds = 00:00:06
[QuickTime] Preferred Rate = 1
[QuickTime] Preferred Volume = 1
[QuickTime] Preview Time = 0
[QuickTime] Preview Duration = 0
[QuickTime] Poster Time = 0
[QuickTime] Selection Time = 0
[QuickTime] Selection Duration = 0
[QuickTime] Current Time = 0
[QuickTime] Next Track ID = 3
ERROR: End of data reached.
[QuickTime Video] Creation Time = Fri Jan 01 00:00:00 SGT 1904
[QuickTime Video] Modification Time = Fri Jan 01 00:00:00 SGT 1904
[QuickTime Video] Opcolor = 0 0 0
[QuickTime Video] Graphics Mode = Copy
[QuickTime Video] Vendor = FFmpeg
[QuickTime Video] Compression Type = MPEG-4
[QuickTime Video] Temporal Quality = 512
[QuickTime Video] Spatial Quality = 512
[QuickTime Video] Width = 560 pixels
[QuickTime Video] Height = 320 pixels
[QuickTime Video] Compressor Name = mpeg4
[QuickTime Video] Depth = 24-bit color
[QuickTime Video] Color Table = None
[QuickTime Video] Horizontal Resolution = 72
[QuickTime Video] Vertical Resolution = 72
[QuickTime Video] Frame Rate = 30
[QuickTime Sound] Creation Time = Fri Jan 01 00:00:00 SGT 1904
[QuickTime Sound] Modification Time = Fri Jan 01 00:00:00 SGT 1904
[QuickTime Sound] Balance = 0
[QuickTime Sound] Format = MPEG-4, Advanced Audio Coding (AAC)
[QuickTime Sound] Number of Channels = 1
[QuickTime Sound] Sample Size = 16
[QuickTime Sound] Sample Rate = 44100
```
```
[MP4] Major Brand = MP4 v2 [ISO 14496-14]
[MP4] Minor Version = 0
[MP4] Compatible Brands = [MP4 v2 [ISO 14496-14], MP4  Base Media v1 [IS0 14496-12:2003], MP4 Base w/ AVC ext [ISO 14496-12:2005]]
[MP4] Creation Time = Sat Mar 20 22:33:46 SGT 2010
[MP4] Modification Time = Sat Mar 20 22:33:47 SGT 2010
[MP4] Duration = 501120
[MP4] Media Time Scale = 90000
[MP4] Duration in Seconds = 00:00:06
[MP4] Transformation Matrix = 65536 0 0 0 65536 0 0 0 1073741824
[MP4] Preferred Rate = 1
[MP4] Preferred Volume = 1
[MP4] Next Track ID = 3
ERROR: End of data reached.
[MP4 Video] Creation Time = Sat Mar 20 22:33:46 SGT 2010
[MP4 Video] Modification Time = Sat Mar 20 22:33:47 SGT 2010
[MP4 Video] ISO 639-2 Language Code = und
[MP4 Video] Opcolor = 0 0 0
[MP4 Video] Graphics Mode = Copy
[MP4 Video] Compression Type = H.264
[MP4 Video] Width = 560 pixels
[MP4 Video] Height = 320 pixels
[MP4 Video] Compressor Name = JVT/AVC Coding
[MP4 Video] Depth = 24-bit color
[MP4 Video] Horizontal Resolution = 72
[MP4 Video] Vertical Resolution = 72
[MP4 Video] Frame Rate = 30
[MP4 Sound] Creation Time = Sat Mar 20 22:33:46 SGT 2010
[MP4 Sound] Modification Time = Sat Mar 20 22:33:47 SGT 2010
[MP4 Sound] ISO 639-2 Language Code = eng
[MP4 Sound] Balance = 0
[MP4 Sound] Format = MPEG-4, Advanced Audio Coding (AAC)
[MP4 Sound] Number of Channels = 1
[MP4 Sound] Sample Size = 16
[MP4 Sound] Sample Rate = 48000
```