### PR TITLE
Exif GPS directory and descriptor updates

### DIFF
--- a/Source/com/drew/metadata/exif/GpsDescriptor.java
+++ b/Source/com/drew/metadata/exif/GpsDescriptor.java
@@ -26,7 +26,10 @@ import com.drew.lang.annotations.NotNull;
 import com.drew.lang.annotations.Nullable;
 import com.drew.metadata.TagDescriptor;
 
+import java.io.UnsupportedEncodingException;
 import java.text.DecimalFormat;
+import java.util.HashMap;
+import java.util.Map;
 
 import static com.drew.metadata.exif.GpsDirectory.*;
 
@@ -58,8 +61,12 @@ public class GpsDescriptor extends TagDescriptor<GpsDirectory>
                 return getGpsStatusDescription();
             case TAG_MEASURE_MODE:
                 return getGpsMeasureModeDescription();
+            case TAG_DOP:
+                return getGpsDopDescription();
             case TAG_SPEED_REF:
                 return getGpsSpeedRefDescription();
+            case TAG_SPEED:
+                return getGpsSpeedDescription();
             case TAG_TRACK_REF:
             case TAG_IMG_DIRECTION_REF:
             case TAG_DEST_BEARING_REF:
@@ -68,8 +75,14 @@ public class GpsDescriptor extends TagDescriptor<GpsDirectory>
             case TAG_IMG_DIRECTION:
             case TAG_DEST_BEARING:
                 return getGpsDirectionDescription(tagType);
+            case TAG_DEST_LATITUDE:
+                return getGpsDestLatitudeDescription();
+            case TAG_DEST_LONGITUDE:
+                return getGpsDestLongitudeDescription();
             case TAG_DEST_DISTANCE_REF:
                 return getGpsDestinationReferenceDescription();
+            case TAG_DEST_DISTANCE:
+                return getGpsDestDistanceDescription();
             case TAG_TIME_STAMP:
                 return getGpsTimeStampDescription();
             case TAG_LONGITUDE:
@@ -78,8 +91,13 @@ public class GpsDescriptor extends TagDescriptor<GpsDirectory>
             case TAG_LATITUDE:
                 // three rational numbers -- displayed in HH"MM"SS.ss
                 return getGpsLatitudeDescription();
+            case TAG_PROCESSING_METHOD:
+            case TAG_AREA_INFORMATION:
+                return getGpsEncodedTextDescription(tagType);
             case TAG_DIFFERENTIAL:
                 return getGpsDifferentialDescription();
+            case TAG_H_POSITIONING_ERROR:
+                return getGpsHPositioningErrorDescription();
             default:
                 return super.getDescription(tagType);
         }
@@ -120,6 +138,36 @@ public class GpsDescriptor extends TagDescriptor<GpsDirectory>
     }
 
     @Nullable
+    public String getGpsDestLatitudeDescription()
+    {
+        Rational[] latitudes = _directory.getRationalArray(TAG_DEST_LATITUDE);
+        String latitudeRef = _directory.getString(TAG_DEST_LATITUDE_REF);
+
+        if (latitudes == null || latitudes.length != 3 || latitudeRef == null)
+            return null;
+
+        Double lat = GeoLocation.degreesMinutesSecondsToDecimal(
+            latitudes[0], latitudes[1], latitudes[2], latitudeRef.equalsIgnoreCase("S"));
+
+        return lat == null ? null : GeoLocation.decimalToDegreesMinutesSecondsString(lat);
+    }
+
+    @Nullable
+    public String getGpsDestLongitudeDescription()
+    {
+        Rational[] longitudes = _directory.getRationalArray(TAG_LONGITUDE);
+        String longitudeRef = _directory.getString(TAG_LONGITUDE_REF);
+
+        if (longitudes == null || longitudes.length != 3 || longitudeRef == null)
+            return null;
+
+        Double lon = GeoLocation.degreesMinutesSecondsToDecimal(
+            longitudes[0], longitudes[1], longitudes[2], longitudeRef.equalsIgnoreCase("W"));
+
+        return lon == null ? null : GeoLocation.decimalToDegreesMinutesSecondsString(lon);
+    }
+
+    @Nullable
     public String getGpsDestinationReferenceDescription()
     {
         final String value = _directory.getString(TAG_DEST_DISTANCE_REF);
@@ -135,6 +183,18 @@ public class GpsDescriptor extends TagDescriptor<GpsDirectory>
         } else {
             return "Unknown (" + distanceRef + ")";
         }
+    }
+
+    @Nullable
+    public String getGpsDestDistanceDescription()
+    {
+        final Rational value = _directory.getRational(TAG_DEST_DISTANCE);
+        if (value == null)
+            return null;
+        final String unit = getGpsDestinationReferenceDescription();
+        return String.format("%s %s",
+            new DecimalFormat("0.##").format(value.doubleValue()),
+            unit == null ? "unit" : unit.toLowerCase());
     }
 
     @Nullable
@@ -165,6 +225,13 @@ public class GpsDescriptor extends TagDescriptor<GpsDirectory>
     }
 
     @Nullable
+    public String getGpsDopDescription()
+    {
+        final Rational value = _directory.getRational(TAG_DOP);
+        return value == null ? null : new DecimalFormat("0.##").format(value.doubleValue());
+    }
+
+    @Nullable
     public String getGpsSpeedRefDescription()
     {
         final String value = _directory.getString(TAG_SPEED_REF);
@@ -180,6 +247,18 @@ public class GpsDescriptor extends TagDescriptor<GpsDirectory>
         } else {
             return "Unknown (" + gpsSpeedRef + ")";
         }
+    }
+
+    @Nullable
+    public String getGpsSpeedDescription()
+    {
+        final Rational value = _directory.getRational(TAG_SPEED);
+        if (value == null)
+            return null;
+        final String unit = getGpsSpeedRefDescription();
+        return String.format("%s %s",
+            new DecimalFormat("0.##").format(value.doubleValue()),
+            unit == null ? "unit" : unit.toLowerCase());
     }
 
     @Nullable
@@ -224,13 +303,60 @@ public class GpsDescriptor extends TagDescriptor<GpsDirectory>
     public String getGpsAltitudeDescription()
     {
         final Rational value = _directory.getRational(TAG_ALTITUDE);
-        return value == null ? null : value.intValue() + " metres";
+        return value == null ? null : new DecimalFormat("0.##").format(value.doubleValue()) + " metres";
+    }
+
+    @Nullable
+    public String getGpsEncodedTextDescription(int tagType)
+    {
+        byte[] commentBytes = _directory.getByteArray(tagType);
+        if (commentBytes == null)
+            return null;
+        if (commentBytes.length == 0)
+            return "";
+
+        final Map<String, String> encodingMap = new HashMap<String, String>();
+        encodingMap.put("ASCII", System.getProperty("file.encoding")); // Someone suggested "ISO-8859-1".
+        encodingMap.put("UNICODE", "UTF-16LE");
+        encodingMap.put("JIS", "Shift-JIS"); // We assume this charset for now.  Another suggestion is "JIS".
+
+        try {
+            if (commentBytes.length >= 10) {
+                String firstTenBytesString = new String(commentBytes, 0, 10);
+
+                // try each encoding name
+                for (Map.Entry<String, String> pair : encodingMap.entrySet()) {
+                    String encodingName = pair.getKey();
+                    String charset = pair.getValue();
+                    if (firstTenBytesString.startsWith(encodingName)) {
+                        // skip any null or blank characters commonly present after the encoding name, up to a limit of 10 from the start
+                        for (int j = encodingName.length(); j < 10; j++) {
+                            byte b = commentBytes[j];
+                            if (b != '\0' && b != ' ')
+                                return new String(commentBytes, j, commentBytes.length - j, charset).trim();
+                        }
+                        return new String(commentBytes, 10, commentBytes.length - 10, charset).trim();
+                    }
+                }
+            }
+            // special handling fell through, return a plain string representation
+            return new String(commentBytes, System.getProperty("file.encoding")).trim();
+        } catch (UnsupportedEncodingException ex) {
+            return null;
+        }
     }
 
     @Nullable
     public String getGpsDifferentialDescription()
     {
         return getIndexedDescription(TAG_DIFFERENTIAL, "No Correction", "Differential Corrected");
+    }
+
+    @Nullable
+    public String getGpsHPositioningErrorDescription()
+    {
+        final Rational value = _directory.getRational(TAG_H_POSITIONING_ERROR);
+        return value == null ? null : new DecimalFormat("0.##").format(value.doubleValue()) + " metres";
     }
 
     @Nullable

--- a/Source/com/drew/metadata/exif/GpsDirectory.java
+++ b/Source/com/drew/metadata/exif/GpsDirectory.java
@@ -94,12 +94,16 @@ public class GpsDirectory extends ExifDirectoryBase
     public static final int TAG_DEST_DISTANCE_REF = 0x0019;
     /** Distance to destination GPSDestDistance 26 1A RATIONAL 1 */
     public static final int TAG_DEST_DISTANCE = 0x001A;
-
-    /** Values of "GPS", "CELLID", "WLAN" or "MANUAL" by the EXIF spec. */
+    /** Name of the method used for location finding GPSProcessingMethod 27 1B UNDEFINED Any */
     public static final int TAG_PROCESSING_METHOD = 0x001B;
+    /** Name of the GPS area GPSAreaInformation 28 1C UNDEFINED Any */
     public static final int TAG_AREA_INFORMATION = 0x001C;
+    /** Date and time GPSDateStamp 29 1D ASCII 11 */
     public static final int TAG_DATE_STAMP = 0x001D;
+    /** Whether differential correction is applied GPSDifferential 30 1E SHORT 1 */
     public static final int TAG_DIFFERENTIAL = 0x001E;
+    /** Horizontal positioning errors GPSHPositioningError 31 1F RATIONAL 1 */
+    public static final int TAG_H_POSITIONING_ERROR = 0x001F;
 
     @NotNull
     protected static final HashMap<Integer, String> _tagNameMap = new HashMap<Integer, String>();
@@ -139,6 +143,7 @@ public class GpsDirectory extends ExifDirectoryBase
         _tagNameMap.put(TAG_AREA_INFORMATION, "GPS Area Information");
         _tagNameMap.put(TAG_DATE_STAMP, "GPS Date Stamp");
         _tagNameMap.put(TAG_DIFFERENTIAL, "GPS Differential");
+        _tagNameMap.put(TAG_H_POSITIONING_ERROR, "GPS H Positioning Error");
     }
 
     public GpsDirectory()


### PR DESCRIPTION
### GPSDirectory

- Add `TAG_H_POSITIONING_ERROR` (0x001F), which was added in the Exif 2.3 specification

### GPSDescriptor

- Add a description for `TAG_DOP` providing a decimal version of rational numbers
- Add a description for `TAG_SPEED` providing a decimal version of rational numbers with unit
- Add a description for `TAG_DEST_LATITUDE` providing a DMS representation of rational numbers with unit
- Add a description for `TAG_DEST_LONGITUDE` providing a DMS representation of rational numbers with unit
- Add a description for `TAG_DEST_DISTANCE` providing a decimal version of rational numbers with unit
- Add a description for `TAG_PROCESSING_METHOD` and `TAG_AREA_INFORMATION` providing a string representation using the character code stored in the first 8 bytes of the byte array
- Add a description for `TAG_H_POSITIONING_ERROR` providing a decimal version of rational numbers with unit