### PR TITLE
Implement basic support for MP3 files without ID3

### DIFF
--- a/Source/com/drew/imaging/FileType.java
+++ b/Source/com/drew/imaging/FileType.java
@@ -48,6 +48,7 @@ public enum FileType
     Mp4("MP4", "MPEG-4 Part 14", "video/mp4", "mp4", "m4a", "m4p", "m4b", "m4r", "m4v"),
     Heif("HEIF", "High Efficiency Image File Format", "image/heif", "heif", "heic"),
     Eps("EPS", "Encapsulated PostScript", "application/postscript", "eps", "epsf", "epsi"),
+    Mp3("MP3", "MP3", "audio/mpeg", "mp3"),
 
     /** Sony camera raw. */
     Arw("ARW", "Sony Camera Raw", null, "arw"),

--- a/Source/com/drew/imaging/FileTypeDetector.java
+++ b/Source/com/drew/imaging/FileTypeDetector.java
@@ -73,6 +73,7 @@ public class FileTypeDetector
         _root.addPath(FileType.Rw2, "II".getBytes(), new byte[]{0x55, 0x00});
         _root.addPath(FileType.Eps, "%!PS".getBytes());
         _root.addPath(FileType.Eps, new byte[]{(byte)0xC5, (byte)0xD0, (byte)0xD3, (byte)0xC6});
+        _root.addPath(FileType.Mp3, new byte[]{(byte)0xFF});
 
         _ftypMap = new HashMap<String, FileType>();
 

--- a/Source/com/drew/imaging/ImageMetadataReader.java
+++ b/Source/com/drew/imaging/ImageMetadataReader.java
@@ -27,6 +27,7 @@ import com.drew.imaging.gif.GifMetadataReader;
 import com.drew.imaging.heif.HeifMetadataReader;
 import com.drew.imaging.ico.IcoMetadataReader;
 import com.drew.imaging.jpeg.JpegMetadataReader;
+import com.drew.imaging.mp3.Mp3MetadataReader;
 import com.drew.imaging.mp4.Mp4MetadataReader;
 import com.drew.imaging.quicktime.QuickTimeMetadataReader;
 import com.drew.imaging.pcx.PcxMetadataReader;
@@ -173,6 +174,8 @@ public class ImageMetadataReader
                 return QuickTimeMetadataReader.readMetadata(inputStream);
             case Mp4:
                 return Mp4MetadataReader.readMetadata(inputStream);
+            case Mp3:
+                return Mp3MetadataReader.readMetadata(inputStream);
             case Eps:
                 return EpsMetadataReader.readMetadata(inputStream);
             case Heif:

--- a/Source/com/drew/imaging/mp3/Mp3MetadataReader.java
+++ b/Source/com/drew/imaging/mp3/Mp3MetadataReader.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2002-2017 Drew Noakes
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ * More information about this project is available at:
+ *
+ *    https://drewnoakes.com/code/exif/
+ *    https://github.com/drewnoakes/metadata-extractor
+ */
+package com.drew.imaging.mp3;
+
+import com.drew.lang.annotations.NotNull;
+import com.drew.metadata.Metadata;
+import com.drew.metadata.file.FileSystemMetadataReader;
+import com.drew.metadata.mp3.Mp3Reader;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+
+/**
+ * Obtains metadata from MP3 files.
+ *
+ * @author Payton Garland
+ */
+public class Mp3MetadataReader
+{
+    @NotNull
+    public static Metadata readMetadata(@NotNull File file) throws IOException
+    {
+        InputStream inputStream = new FileInputStream(file);
+        Metadata metadata;
+        try {
+            metadata = readMetadata(inputStream);
+        } finally {
+            inputStream.close();
+        }
+        new FileSystemMetadataReader().read(file, metadata);
+        return metadata;
+    }
+
+    @NotNull
+    public static Metadata readMetadata(@NotNull InputStream inputStream)
+    {
+        Metadata metadata = new Metadata();
+        new Mp3Reader().extract(inputStream, metadata);
+        return metadata;
+    }
+}

--- a/Source/com/drew/imaging/mp3/package-info.java
+++ b/Source/com/drew/imaging/mp3/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Contains classes for working with MP3 files.
+ */
+package com.drew.imaging.mp3;

--- a/Source/com/drew/metadata/mp3/Mp3Descriptor.java
+++ b/Source/com/drew/metadata/mp3/Mp3Descriptor.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2002-2017 Drew Noakes
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ * More information about this project is available at:
+ *
+ *    https://drewnoakes.com/code/exif/
+ *    https://github.com/drewnoakes/metadata-extractor
+ */
+package com.drew.metadata.mp3;
+
+import com.drew.lang.annotations.Nullable;
+import com.drew.metadata.TagDescriptor;
+
+/**
+ * @author Payton Garland
+ */
+public class Mp3Descriptor extends TagDescriptor<Mp3Directory>
+{
+
+    public Mp3Descriptor(Mp3Directory directory)
+    {
+        super(directory);
+    }
+
+    @Override
+    @Nullable
+    public String getDescription(int tagType)
+    {
+        return super.getDescription(tagType);
+    }
+
+}

--- a/Source/com/drew/metadata/mp3/Mp3Directory.java
+++ b/Source/com/drew/metadata/mp3/Mp3Directory.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2002-2017 Drew Noakes
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ * More information about this project is available at:
+ *
+ *    https://drewnoakes.com/code/exif/
+ *    https://github.com/drewnoakes/metadata-extractor
+ */
+package com.drew.metadata.mp3;
+
+import com.drew.lang.annotations.NotNull;
+import com.drew.metadata.Directory;
+
+import java.util.HashMap;
+
+/**
+ * @author Payton Garland
+ */
+public class Mp3Directory extends Directory
+{
+
+    public static final int TAG_ID = 1;
+    public static final int TAG_LAYER = 2;
+    public static final int TAG_BITRATE = 3;
+    public static final int TAG_FREQUENCY = 4;
+    public static final int TAG_MODE = 5;
+    public static final int TAG_EMPHASIS = 6;
+    public static final int TAG_COPYRIGHT = 7;
+    public static final int TAG_FRAME_SIZE = 8;
+
+    @NotNull
+    protected static final HashMap<Integer, String> _tagNameMap = new HashMap<Integer, String>();
+
+    static
+    {
+        _tagNameMap.put(TAG_ID, "ID");
+        _tagNameMap.put(TAG_LAYER, "Layer");
+        _tagNameMap.put(TAG_BITRATE, "Bitrate");
+        _tagNameMap.put(TAG_FREQUENCY, "Frequency");
+        _tagNameMap.put(TAG_MODE, "Mode");
+        _tagNameMap.put(TAG_EMPHASIS, "Emphasis Method");
+        _tagNameMap.put(TAG_COPYRIGHT, "Copyright");
+        _tagNameMap.put(TAG_FRAME_SIZE, "Frame Size");
+    }
+
+    public Mp3Directory()
+    {
+        this.setDescriptor(new Mp3Descriptor(this));
+    }
+
+    @Override
+    public String getName()
+    {
+        return "MP3";
+    }
+
+    @Override
+    protected HashMap<Integer, String> getTagNameMap()
+    {
+        return _tagNameMap;
+    }
+}

--- a/Source/com/drew/metadata/mp3/Mp3Reader.java
+++ b/Source/com/drew/metadata/mp3/Mp3Reader.java
@@ -1,0 +1,236 @@
+/*
+ * Copyright 2002-2017 Drew Noakes
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ * More information about this project is available at:
+ *
+ *    https://drewnoakes.com/code/exif/
+ *    https://github.com/drewnoakes/metadata-extractor
+ */
+package com.drew.metadata.mp3;
+
+import com.drew.imaging.ImageProcessingException;
+import com.drew.lang.SequentialReader;
+import com.drew.lang.StreamReader;
+import com.drew.lang.annotations.NotNull;
+import com.drew.metadata.Metadata;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+/**
+ * Sources: http://id3.org/mp3Frame
+ *          https://www.loc.gov/preservation/digital/formats/fdd/fdd000105.shtml
+ *
+ * @author Payton Garland
+ */
+public class Mp3Reader
+{
+
+    public void extract(@NotNull final InputStream inputStream, @NotNull final Metadata metadata)
+    {
+        Mp3Directory directory = new Mp3Directory();
+        metadata.addDirectory(directory);
+
+        try {
+            inputStream.reset();
+            SequentialReader reader = new StreamReader(inputStream);
+
+            int header = reader.getInt32();
+
+            // ID: MPEG-2.5, MPEG-2, or MPEG-1
+            double id = 0;
+            switch ((header & 0x000180000) >> 19) {
+                case (0):
+                    directory.setString(Mp3Directory.TAG_ID, "MPEG-2.5");
+                    id = 2.5;
+                    throw new ImageProcessingException("MPEG-2.5 not supported.");
+                case (2):
+                    directory.setString(Mp3Directory.TAG_ID, "MPEG-2");
+                    id = 2;
+                    break;
+                case (3):
+                    directory.setString(Mp3Directory.TAG_ID, "MPEG-1");
+                    id = 1;
+                    break;
+                default:
+            }
+
+            // Layer Type: 1, 2, 3, or not defined
+            int layer = ((header & 0x00060000) >> 17);
+            switch (layer) {
+                case(0):
+                    directory.setString(Mp3Directory.TAG_LAYER, "Not defined");
+                    break;
+                case(1):
+                    directory.setString(Mp3Directory.TAG_LAYER, "Layer III");
+                    break;
+                case(2):
+                    directory.setString(Mp3Directory.TAG_LAYER, "Layer II");
+                    break;
+                case(3):
+                    directory.setString(Mp3Directory.TAG_LAYER, "Layer I");
+                    break;
+                default:
+            }
+
+
+            int protectionBit = ((header & 0x00010000) >> 16);
+
+            // Bitrate: depends on ID and Layer
+            int bitrate = ((header & 0x0000F000) >> 12);
+            if (bitrate != 0 && bitrate != 15)
+                directory.setInt(Mp3Directory.TAG_BITRATE, setBitrate(bitrate, layer, id));
+
+            // Frequency: depends on ID
+            int frequency = ((header & 0x00000C00) >> 10);
+            int[][] frequencyMapping = new int[2][3];
+            frequencyMapping[0] = new int[]{44100, 48000, 32000};
+            frequencyMapping[1] = new int[]{22050, 24000, 16000};
+            if (id == 2) {
+                directory.setInt(directory.TAG_FREQUENCY, frequencyMapping[1][frequency]);
+                frequency = frequencyMapping[1][frequency];
+            } else if (id == 1) {
+                directory.setInt(directory.TAG_FREQUENCY, frequencyMapping[0][frequency]);
+                frequency = frequencyMapping[0][frequency];
+            }
+
+
+            int paddingBit = ((header & 0x00000200) >> 9);
+
+            // Encoding type: Stereo, Joint Stereo, Dual Channel, or Mono
+            int mode = ((header & 0x000000C0) >> 6);
+            switch (mode){
+                case(0):
+                    directory.setString(Mp3Directory.TAG_MODE, "Stereo");
+                    break;
+                case(1):
+                    directory.setString(Mp3Directory.TAG_MODE, "Joint stereo");
+                    break;
+                case(2):
+                    directory.setString(Mp3Directory.TAG_MODE, "Dual channel");
+                    break;
+                case(3):
+                    directory.setString(Mp3Directory.TAG_MODE, "Mono");
+                    break;
+                default:
+            }
+
+            // Copyright boolean
+            int copyright = ((header & 0x00000008) >> 3);
+            switch (copyright) {
+                case(0):
+                    directory.setString(Mp3Directory.TAG_COPYRIGHT, "False");
+                    break;
+                case(1):
+                    directory.setString(Mp3Directory.TAG_COPYRIGHT, "True");
+                    break;
+                default:
+            }
+
+            int emphasis = (header & 0x00000003);
+            switch (emphasis) {
+                case (0):
+                    directory.setString(Mp3Directory.TAG_EMPHASIS, "none");
+                    break;
+                case (1):
+                    directory.setString(Mp3Directory.TAG_EMPHASIS, "50/15ms");
+                    break;
+                case (3):
+                    directory.setString(Mp3Directory.TAG_EMPHASIS, "CCITT j.17");
+                    break;
+                default:
+            }
+
+            int frameSize = ((setBitrate(bitrate, layer, id) * 1000) * 144) / frequency;
+            directory.setString(Mp3Directory.TAG_FRAME_SIZE, frameSize + " bytes");
+        } catch (IOException e) {
+            e.printStackTrace();
+        } catch (ImageProcessingException e) {
+            e.printStackTrace();
+        }
+    }
+
+    public int setBitrate(int bitrate, int layer, double id)
+    {
+        int[][] bitrateMapping = new int[14][6];
+        bitrateMapping[0] = new int[]{32, 32, 32, 32, 32, 8};
+        bitrateMapping[1] = new int[]{64, 48, 40, 64, 48, 16};
+        bitrateMapping[2] = new int[]{96, 56, 48, 96, 56, 24};
+        bitrateMapping[3] = new int[]{128, 64, 56, 128, 64, 32};
+        bitrateMapping[4] = new int[]{160, 80, 64, 160, 80, 64};
+        bitrateMapping[5] = new int[]{192, 96, 80, 192, 96, 80};
+        bitrateMapping[6] = new int[]{224, 112, 96, 224, 112, 56};
+        bitrateMapping[7] = new int[]{256, 128, 112, 256, 128, 64};
+        bitrateMapping[8] = new int[]{288, 160, 128, 28, 160, 128};
+        bitrateMapping[9] = new int[]{320, 192, 160, 320, 192, 160};
+        bitrateMapping[10] = new int[]{352, 224, 192, 352, 224, 112};
+        bitrateMapping[11] = new int[]{384, 256, 224, 384, 256, 128};
+        bitrateMapping[12] = new int[]{416, 320, 256, 416, 320, 256};
+        bitrateMapping[13] = new int[]{448, 384, 320, 448, 384, 320};
+
+        int xPos = 0;
+        int yPos = bitrate - 1;
+
+        if (id == 2) {
+            // MPEG-2
+            switch (layer) {
+                case (1):
+                    xPos = 5;
+                    break;
+                case (2):
+                    xPos = 4;
+                    break;
+                case (3):
+                    xPos = 3;
+                    break;
+                default:
+            }
+        } else if (id == 1) {
+            // MPEG-1
+            switch (layer) {
+                case(1):
+                    xPos = 2;
+                    break;
+                case(2):
+                    xPos = 1;
+                    break;
+                case(3):
+                    xPos = 0;
+                    break;
+                default:
+            }
+        }
+
+        return bitrateMapping[yPos][xPos];
+    }
+
+    /**
+     * https://phoxis.org/2010/05/08/synch-safe/
+     */
+    public static int getSyncSafeSize(int decode)
+    {
+        int a = decode & 0xFF;
+        int b = (decode >> 8) & 0xFF;
+        int c  = (decode >> 16) & 0xFF;
+        int d = (decode >> 24) & 0xFF;
+
+        int decoded = 0x0;
+        decoded = decoded | a;
+        decoded = decoded | (b << 7);
+        decoded = decoded | (c << 14);
+        decoded = decoded | (d << 21);
+        return decoded;
+    }
+}

--- a/Source/com/drew/metadata/mp3/package-info.java
+++ b/Source/com/drew/metadata/mp3/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Contains classes for the extraction and modelling of MP3 file metadata.
+ */
+package com.drew.metadata.mp3;


### PR DESCRIPTION
This is a very basic implementation for MP3 support under the assumption that no ID3 block is present at the beginning of the file. As a result of this assumption, many MP3 files will not yet be recognized as it is very common for an ID3 block to be present.

I opted to still create this PR to kick start development of MP3.

File identification is based off of the first frame header in the file, which has this structure
http://mpgedit.org/mpgedit/mpeg_format/MP3Format.html

### Issues
* It is only guaranteed that the first 11 bits are set, so I only check that the file starts with 0xFF as the signature. One option is to add the remaining combinations (MPEG1 + Layer2, MPEG2 + Layer2, etc) to filetypedetector, but that would be cumbersome.
* Some MPEG files use bitrate switching, which means the first frame bitrate is not necessarily the same for the rest of the file's frames.
* MPEG 2.5 not yet supported

ID3 documentation can be found here: http://id3.org/Home


