### PR TITLE
Fix for "Auto" noise reduction setting

### DIFF
--- a/Source/com/drew/metadata/exif/makernotes/OlympusRawDevelopment2MakernoteDescriptor.java
+++ b/Source/com/drew/metadata/exif/makernotes/OlympusRawDevelopment2MakernoteDescriptor.java
@@ -110,8 +110,12 @@ public class OlympusRawDevelopment2MakernoteDescriptor extends TagDescriptor<Oly
         if ((v        & 1) != 0) sb.append("Noise Reduction, ");
         if (((v >> 1) & 1) != 0) sb.append("Noise Filter, ");
         if (((v >> 2) & 1) != 0) sb.append("Noise Filter (ISO Boost), ");
-
-        return sb.substring(0, sb.length() - 2);
+        if (((v >> 3) & 1) != 0) sb.append("Noise Filter (Auto), ");
+        
+        if (sb.length() > 2) {
+            sb.delete(sb.length() - 2, sb.length());
+        }
+        return sb.toString();
     }
 
     @Nullable


### PR DESCRIPTION
Olympus cameras with the "Auto" noise reduction setting  (bit 3 set) causes this code to crash with an IndexOutOfBoundsException.
I've now added support for bit 3 ("Auto") and made the code fault tolerant if future bits are added.

Reference: https://sno.phy.queensu.ca/~phil/exiftool/TagNames/Olympus.html

I add a sample image so you can reproduce the bug and verify the fix I made too.
![olympus auto noise reduction](https://user-images.githubusercontent.com/2260296/38695581-00dc5c66-3e8d-11e8-9cf7-a3c84e8c2052.jpg)
