### PR TITLE
Support extraction of ICC Profile and Photoshop settings embedded in IFD0 of TIFF file

### DIFF
--- a/Source/com/drew/metadata/exif/ExifDirectoryBase.java
+++ b/Source/com/drew/metadata/exif/ExifDirectoryBase.java
@@ -188,6 +188,7 @@ public abstract class ExifDirectoryBase extends Directory
      */
     public static final int TAG_FNUMBER                           = 0x829D;
     public static final int TAG_IPTC_NAA                          = 0x83BB;
+    public static final int TAG_PHOTOSHOP_SETTINGS                = 0x8649;
     public static final int TAG_INTER_COLOR_PROFILE               = 0x8773;
     /**
      * Exposure program that the camera used when image was taken. '1' means


### PR DESCRIPTION
### Problem

The Photoshop settings (tag 0x8649) and ICC Profile (tag 0x8773) embedded in IFD0 of TIFF files are not extracted into directories. For example:

```
[Exif IFD0] New Subfile Type = Full-resolution image
[Exif IFD0] Image Width = 128 pixels
[Exif IFD0] Image Height = 174 pixels
[Exif IFD0] Bits Per Sample = 8 8 8 bits/component/pixel
[Exif IFD0] Compression = LZW
[Exif IFD0] Photometric Interpretation = RGB
[Exif IFD0] Strip Offsets = 23876
[Exif IFD0] Orientation = Top, left side (Horizontal / normal)
[Exif IFD0] Samples Per Pixel = 3 samples/pixel
[Exif IFD0] Rows Per Strip = 174 rows/strip
[Exif IFD0] Strip Byte Counts = 26556 bytes
[Exif IFD0] X Resolution = 72009/1000 dots per inch
[Exif IFD0] Y Resolution = 72009/1000 dots per inch
[Exif IFD0] Planar Configuration = Chunky (contiguous for each subsampling pixel)
[Exif IFD0] Resolution Unit = Inch
[Exif IFD0] Software = Adobe Photoshop CS2 Windows
[Exif IFD0] Date/Time = 2016:02:05 01:25:42
[Exif IFD0] Predictor = 2
[Exif IFD0] Unknown tag (0x8649) = [5390 values]
[Exif IFD0] Inter Color Profile = [3144 values]
[XMP] XMP Value Count = 21
[Exif SubIFD] Color Space = sRGB
[Exif SubIFD] Exif Image Width = 128 pixels
[Exif SubIFD] Exif Image Height = 174 pixels
[File Type] Detected File Type Name = ARW
[File Type] Detected File Type Long Name = Sony Camera Raw
[File Type] Expected File Name Extension = arw
[File] File Name = rose-128x174-24bit-lzw.tiff
[File] File Size = 50476 bytes
[File] File Modified Date = Fri Mar 30 13:04:44 +00:00 2018
```

### Solution
Add custom processing code in `ExifTiffHandler.customProcessTag()`. The result is:

```
[Exif IFD0] New Subfile Type = Full-resolution image
[Exif IFD0] Image Width = 128 pixels
[Exif IFD0] Image Height = 174 pixels
[Exif IFD0] Bits Per Sample = 8 8 8 bits/component/pixel
[Exif IFD0] Compression = LZW
[Exif IFD0] Photometric Interpretation = RGB
[Exif IFD0] Strip Offsets = 23876
[Exif IFD0] Orientation = Top, left side (Horizontal / normal)
[Exif IFD0] Samples Per Pixel = 3 samples/pixel
[Exif IFD0] Rows Per Strip = 174 rows/strip
[Exif IFD0] Strip Byte Counts = 26556 bytes
[Exif IFD0] X Resolution = 72009/1000 dots per inch
[Exif IFD0] Y Resolution = 72009/1000 dots per inch
[Exif IFD0] Planar Configuration = Chunky (contiguous for each subsampling pixel)
[Exif IFD0] Resolution Unit = Inch
[Exif IFD0] Software = Adobe Photoshop CS2 Windows
[Exif IFD0] Date/Time = 2016:02:05 01:25:42
[Exif IFD0] Predictor = 2
[XMP] XMP Value Count = 21
[Photoshop] Caption Digest = 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
[Photoshop] Resolution Info = 72.01x72.01 DPI
[Photoshop] Print Scale = Centered, Scale 1.0
[Photoshop] Global Angle = 30
[Photoshop] Global Altitude = 30
[Photoshop] Print Flags = 0 0 0 0 0 0 0 0 1
[Photoshop] Copyright Flag = No
[Photoshop] Print Flags Information = 0 1 0 0 0 0 0 0 0 2
[Photoshop] Color Halftoning Information = [72 values]
[Photoshop] Color Transfer Functions = [112 values]
[Photoshop] Layer State Information = 0 0
[Photoshop] Layers Group Information = 0 0
[Photoshop] Layer Groups Enabled ID = 1
[Photoshop] Layer Selection IDs = 0 1 0 0 0 3
[Photoshop] Grid and Guides Information = 0 0 0 1 0 0 2 64 0 0 2 64 0 0 0 0
[Photoshop] URL List = 0
[Photoshop] Slices = flower-rose-red-transparent-background-0128-10030.tiff (0,0,174,128) 1 Slices
[Photoshop] Pixel Aspect Ratio = 1.0
[Photoshop] Seed Number = 4
[Photoshop] Thumbnail Data = JpegRGB, 118x160, Decomp 56960 bytes, 1572865 bpp, 3786 bytes
[Photoshop] Version Info = 1 (Adobe Photoshop, Adobe Photoshop CS2) 1
[Exif SubIFD] Color Space = sRGB
[Exif SubIFD] Exif Image Width = 128 pixels
[Exif SubIFD] Exif Image Height = 174 pixels
[ICC Profile] Profile Size = 3144
[ICC Profile] CMM Type = Lino
[ICC Profile] Version = 2.1.0
[ICC Profile] Class = Display Device
[ICC Profile] Color space = RGB 
[ICC Profile] Profile Connection Space = XYZ 
[ICC Profile] Profile Date/Time = 1998:02:09 06:49:00
[ICC Profile] Signature = acsp
[ICC Profile] Primary Platform = Microsoft Corporation
[ICC Profile] Device manufacturer = IEC 
[ICC Profile] Device model = sRGB
[ICC Profile] XYZ values = 0.964 1 0.825
[ICC Profile] Tag Count = 17
[ICC Profile] Copyright = Copyright (c) 1998 Hewlett-Packard Company
[ICC Profile] Profile Description = sRGB IEC61966-2.1
[ICC Profile] Media White Point = (0.9505, 1, 1.0891)
[ICC Profile] Media Black Point = (0, 0, 0)
[ICC Profile] Red Colorant = (0.4361, 0.2225, 0.0139)
[ICC Profile] Green Colorant = (0.3851, 0.7169, 0.0971)
[ICC Profile] Blue Colorant = (0.1431, 0.0606, 0.7141)
[ICC Profile] Device Mfg Description = IEC http://www.iec.ch
[ICC Profile] Device Model Description = IEC 61966-2.1 Default RGB colour space - sRGB
[ICC Profile] Viewing Conditions Description = Reference Viewing Condition in IEC61966-2.1
[ICC Profile] Viewing Conditions = view (0x76696577): 36 bytes
[ICC Profile] Luminance = (76.0365, 80, 87.1246)
[ICC Profile] Measurement = 1931 2° Observer, Backing (0, 0, 0), Geometry Unknown, Flare 1%, Illuminant D65
[ICC Profile] Technology = CRT 
[ICC Profile] Red TRC = 0.0, 0.0000763, 0.0001526, 0.0002289, 0.0003052, 0.0003815, 0.0004578, 0.0005341, 0.0006104, 0.0006867, 0.000763, 0.0008392, 0.0009003, 0.0009766, 0.0010529, 0.0011292, 0.0012055, 0.0012818, 0.0013581, 0.0014343, 0.0015106, 0.0015869, 0.0016632, 0.0017395, 0.0018158, 0.0018921, 0.0019684, 0.0020447, 0.002121, 0.0021973, 0.0022736, 0.0023499, 0.0024262, 0.0025025, 0.0025788, 0.0026551, 0.0027161, 0.0027924, 0.0028687, 0.002945, 0.0030213, 0.0030976, 0.0031739, 0.0032502, 0.0033417, 0.003418, 0.0034943, 0.0035859, 0.0036622, 0.0037537, 0.00383, 0.0039216, 0.0040131, 0.0041047, 0.0041962, 0.0042878, 0.0043793, 0.0044709, 0.0045624, 0.0046693, 0.0047608, 0.0048524, 0.0049592, 0.005066, 0.0051575, 0.0052644, 0.0053712, 0.005478, 0.0055848, 0.0056916, 0.0057984, 0.0059052, 0.0060273, 0.0061341, 0.0062562, 0.006363, 0.0064851, 0.0066072, 0.0067292, 0.0068513, 0.0069734, 0.0070954, 0.0072175, 0.0073396, 0.0074617, 0.007599, 0.0077211, 0.0078584, 0.0079957, 0.0081178, 0.0082551, 0.0083925, 0.0085298, 0.0086671, 0.0088...
[ICC Profile] Green TRC = 0.0, 0.0000763, 0.0001526, 0.0002289, 0.0003052, 0.0003815, 0.0004578, 0.0005341, 0.0006104, 0.0006867, 0.000763, 0.0008392, 0.0009003, 0.0009766, 0.0010529, 0.0011292, 0.0012055, 0.0012818, 0.0013581, 0.0014343, 0.0015106, 0.0015869, 0.0016632, 0.0017395, 0.0018158, 0.0018921, 0.0019684, 0.0020447, 0.002121, 0.0021973, 0.0022736, 0.0023499, 0.0024262, 0.0025025, 0.0025788, 0.0026551, 0.0027161, 0.0027924, 0.0028687, 0.002945, 0.0030213, 0.0030976, 0.0031739, 0.0032502, 0.0033417, 0.003418, 0.0034943, 0.0035859, 0.0036622, 0.0037537, 0.00383, 0.0039216, 0.0040131, 0.0041047, 0.0041962, 0.0042878, 0.0043793, 0.0044709, 0.0045624, 0.0046693, 0.0047608, 0.0048524, 0.0049592, 0.005066, 0.0051575, 0.0052644, 0.0053712, 0.005478, 0.0055848, 0.0056916, 0.0057984, 0.0059052, 0.0060273, 0.0061341, 0.0062562, 0.006363, 0.0064851, 0.0066072, 0.0067292, 0.0068513, 0.0069734, 0.0070954, 0.0072175, 0.0073396, 0.0074617, 0.007599, 0.0077211, 0.0078584, 0.0079957, 0.0081178, 0.0082551, 0.0083925, 0.0085298, 0.0086671, 0.0088...
[ICC Profile] Blue TRC = 0.0, 0.0000763, 0.0001526, 0.0002289, 0.0003052, 0.0003815, 0.0004578, 0.0005341, 0.0006104, 0.0006867, 0.000763, 0.0008392, 0.0009003, 0.0009766, 0.0010529, 0.0011292, 0.0012055, 0.0012818, 0.0013581, 0.0014343, 0.0015106, 0.0015869, 0.0016632, 0.0017395, 0.0018158, 0.0018921, 0.0019684, 0.0020447, 0.002121, 0.0021973, 0.0022736, 0.0023499, 0.0024262, 0.0025025, 0.0025788, 0.0026551, 0.0027161, 0.0027924, 0.0028687, 0.002945, 0.0030213, 0.0030976, 0.0031739, 0.0032502, 0.0033417, 0.003418, 0.0034943, 0.0035859, 0.0036622, 0.0037537, 0.00383, 0.0039216, 0.0040131, 0.0041047, 0.0041962, 0.0042878, 0.0043793, 0.0044709, 0.0045624, 0.0046693, 0.0047608, 0.0048524, 0.0049592, 0.005066, 0.0051575, 0.0052644, 0.0053712, 0.005478, 0.0055848, 0.0056916, 0.0057984, 0.0059052, 0.0060273, 0.0061341, 0.0062562, 0.006363, 0.0064851, 0.0066072, 0.0067292, 0.0068513, 0.0069734, 0.0070954, 0.0072175, 0.0073396, 0.0074617, 0.007599, 0.0077211, 0.0078584, 0.0079957, 0.0081178, 0.0082551, 0.0083925, 0.0085298, 0.0086671, 0.0088...
[File Type] Detected File Type Name = ARW
[File Type] Detected File Type Long Name = Sony Camera Raw
[File Type] Expected File Name Extension = arw
[File] File Name = rose-128x174-24bit-lzw.tiff
[File] File Size = 50476 bytes
[File] File Modified Date = Fri Mar 30 13:04:44 +00:00 2018
```