### PR TITLE
Show XMP tags in ImageMetadataReader main method

### DIFF
--- a/Source/com/drew/imaging/ImageMetadataReader.java
+++ b/Source/com/drew/imaging/ImageMetadataReader.java
@@ -47,11 +47,13 @@ import com.drew.metadata.Tag;
 import com.drew.metadata.exif.ExifIFD0Directory;
 import com.drew.metadata.file.FileSystemMetadataReader;
 import com.drew.metadata.file.FileTypeDirectory;
+import com.drew.metadata.xmp.XmpDirectory;
 
 import java.io.*;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Map;
 
 /**
  * Reads metadata from any supported file format.
@@ -302,6 +304,24 @@ public class ImageMetadataReader
                             System.out.printf("[%s - %s] %s = %s%n", directoryName, tag.getTagTypeHex(), tagName, description);
                         } else {
                             System.out.printf("[%s] %s = %s%n", directoryName, tagName, description);
+                        }
+                    }
+                }
+
+                if (directory instanceof XmpDirectory) {
+                    Map<String, String> xmpProperties = ((XmpDirectory)directory).getXmpProperties();
+                    for (Map.Entry<String, String> property : xmpProperties.entrySet()) {
+                        String key = property.getKey();
+                        String value = property.getValue();
+
+                        if (value != null && value.length() > 1024) {
+                            value = value.substring(0, 1024) + "...";
+                        }
+
+                        if (markdownFormat) {
+                            System.out.printf("%s||%s|%s%n", directoryName, key, value);
+                        } else {
+                            System.out.printf("[%s] %s = %s%n", directoryName, key, value);
                         }
                     }
                 }


### PR DESCRIPTION
The current implementation only shows the XMP Value Count, but this fix lists all of XMP properties as well.

```
$ java -cp xmpcore-5.1.3.jar:metadata-extractor-2.11.1-SNAPSHOT.jar com.drew.imaging.ImageMetadataReader rose-128x174-24bit-lzw.tiff
...
[Exif IFD0] Predictor = 2
[Exif IFD0] Unknown tag (0x8649) = [5390 values]
[Exif IFD0] Inter Color Profile = [3144 values]
[XMP] XMP Value Count = 21
[XMP] xmp:ModifyDate = 2016-02-05T01:25:42+09:00
[XMP] xmp:MetadataDate = 2016-02-05T01:25:42+09:00
[XMP] xmp:CreatorTool = Adobe Photoshop CS2 Windows
[XMP] photoshop:History = 
[XMP] photoshop:ICCProfile = sRGB IEC61966-2.1
[XMP] tiff:XResolution = 720090/10000
[XMP] xmpMM:DerivedFrom/stRef:documentID = uuid:755EFE1B5BCBE51191D2BA1A4A34CC1F
[XMP] tiff:NativeDigest = 256,257,258,259,262,274,277,284,530,531,282,283,296,301,318,319,529,532,306,270,271,272,305,315,33432;6A3819C79FDE56A3CEB49BE0CECF0E4B
[XMP] exif:PixelYDimension = 174
[XMP] dc:format = image/tiff
[XMP] tiff:ResolutionUnit = 2
[XMP] tiff:Orientation = 1
[XMP] xmpMM:DocumentID = uuid:785EFE1B5BCBE51191D2BA1A4A34CC1F
[XMP] exif:ColorSpace = 1
[XMP] photoshop:ColorMode = 3
[XMP] exif:PixelXDimension = 128
[XMP] exif:NativeDigest = 36864,40960,40961,37121,37122,40962,40963,37510,40964,36867,36868,33434,33437,34850,34852,34855,34856,37377,37378,37379,37380,37381,37382,37383,37384,37385,37386,37396,41483,41484,41486,41487,41488,41492,41493,41495,41728,41729,41730,41985,41986,41987,41988,41989,41990,41991,41992,41993,41994,41995,41996,42016,0,2,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,20,22,23,24,25,26,27,28,30;EB685DEADF67388F7E939885A41C0ECF
[XMP] xmp:CreateDate = 2016-02-05T01:25:42+09:00
[XMP] xmpMM:DerivedFrom/stRef:instanceID = uuid:765EFE1B5BCBE51191D2BA1A4A34CC1F
[XMP] xmpMM:InstanceID = uuid:795EFE1B5BCBE51191D2BA1A4A34CC1F
[XMP] tiff:YResolution = 720090/10000
...
```