### PR TITLE
Add Exif 2.31 tags

### DIFF
--- a/Source/com/drew/metadata/exif/ExifDescriptorBase.java
+++ b/Source/com/drew/metadata/exif/ExifDescriptorBase.java
@@ -64,71 +64,81 @@ public abstract class ExifDescriptorBase<T extends Directory> extends TagDescrip
     @Override
     public String getDescription(int tagType)
     {
-        // TODO order case blocks and corresponding methods in the same order as the TAG_* values are defined
-
         switch (tagType) {
             case TAG_INTEROP_INDEX:
                 return getInteropIndexDescription();
             case TAG_INTEROP_VERSION:
                 return getInteropVersionDescription();
-            case TAG_ORIENTATION:
-                return getOrientationDescription();
-            case TAG_RESOLUTION_UNIT:
-                return getResolutionDescription();
-            case TAG_YCBCR_POSITIONING:
-                return getYCbCrPositioningDescription();
-            case TAG_X_RESOLUTION:
-                return getXResolutionDescription();
-            case TAG_Y_RESOLUTION:
-                return getYResolutionDescription();
+            case TAG_NEW_SUBFILE_TYPE:
+                return getNewSubfileTypeDescription();
+            case TAG_SUBFILE_TYPE:
+                return getSubfileTypeDescription();
             case TAG_IMAGE_WIDTH:
                 return getImageWidthDescription();
             case TAG_IMAGE_HEIGHT:
                 return getImageHeightDescription();
             case TAG_BITS_PER_SAMPLE:
                 return getBitsPerSampleDescription();
+            case TAG_COMPRESSION:
+                return getCompressionDescription();
             case TAG_PHOTOMETRIC_INTERPRETATION:
                 return getPhotometricInterpretationDescription();
-            case TAG_ROWS_PER_STRIP:
-                return getRowsPerStripDescription();
-            case TAG_STRIP_BYTE_COUNTS:
-                return getStripByteCountsDescription();
-            case TAG_SAMPLES_PER_PIXEL:
-                return getSamplesPerPixelDescription();
-            case TAG_PLANAR_CONFIGURATION:
-                return getPlanarConfigurationDescription();
-            case TAG_YCBCR_SUBSAMPLING:
-                return getYCbCrSubsamplingDescription();
-            case TAG_REFERENCE_BLACK_WHITE:
-                return getReferenceBlackWhiteDescription();
-            case TAG_WIN_AUTHOR:
-                return getWindowsAuthorDescription();
-            case TAG_WIN_COMMENT:
-                return getWindowsCommentDescription();
-            case TAG_WIN_KEYWORDS:
-                return getWindowsKeywordsDescription();
-            case TAG_WIN_SUBJECT:
-                return getWindowsSubjectDescription();
-            case TAG_WIN_TITLE:
-                return getWindowsTitleDescription();
-            case TAG_NEW_SUBFILE_TYPE:
-                return getNewSubfileTypeDescription();
-            case TAG_SUBFILE_TYPE:
-                return getSubfileTypeDescription();
             case TAG_THRESHOLDING:
                 return getThresholdingDescription();
             case TAG_FILL_ORDER:
                 return getFillOrderDescription();
+            case TAG_ORIENTATION:
+                return getOrientationDescription();
+            case TAG_SAMPLES_PER_PIXEL:
+                return getSamplesPerPixelDescription();
+            case TAG_ROWS_PER_STRIP:
+                return getRowsPerStripDescription();
+            case TAG_STRIP_BYTE_COUNTS:
+                return getStripByteCountsDescription();
+            case TAG_X_RESOLUTION:
+                return getXResolutionDescription();
+            case TAG_Y_RESOLUTION:
+                return getYResolutionDescription();
+            case TAG_PLANAR_CONFIGURATION:
+                return getPlanarConfigurationDescription();
+            case TAG_RESOLUTION_UNIT:
+                return getResolutionDescription();
+            case TAG_JPEG_PROC:
+                return getJpegProcDescription();
+            case TAG_YCBCR_SUBSAMPLING:
+                return getYCbCrSubsamplingDescription();
+            case TAG_YCBCR_POSITIONING:
+                return getYCbCrPositioningDescription();
+            case TAG_REFERENCE_BLACK_WHITE:
+                return getReferenceBlackWhiteDescription();
             case TAG_CFA_PATTERN_2:
                 return getCfaPattern2Description();
             case TAG_EXPOSURE_TIME:
                 return getExposureTimeDescription();
-            case TAG_SHUTTER_SPEED:
-                return getShutterSpeedDescription();
             case TAG_FNUMBER:
                 return getFNumberDescription();
+            case TAG_EXPOSURE_PROGRAM:
+                return getExposureProgramDescription();
+            case TAG_ISO_EQUIVALENT:
+                return getIsoEquivalentDescription();
+            case TAG_SENSITIVITY_TYPE:
+                return getSensitivityTypeRangeDescription();
+            case TAG_EXIF_VERSION:
+                return getExifVersionDescription();
+            case TAG_COMPONENTS_CONFIGURATION:
+                return getComponentConfigurationDescription();
             case TAG_COMPRESSED_AVERAGE_BITS_PER_PIXEL:
                 return getCompressedAverageBitsPerPixelDescription();
+            case TAG_SHUTTER_SPEED:
+                return getShutterSpeedDescription();
+            case TAG_APERTURE:
+                return getApertureValueDescription();
+            case TAG_BRIGHTNESS_VALUE:
+                return getBrightnessValueDescription();
+            case TAG_EXPOSURE_BIAS:
+                return getExposureBiasDescription();
+            case TAG_MAX_APERTURE:
+                return getMaxApertureValueDescription();
             case TAG_SUBJECT_DISTANCE:
                 return getSubjectDistanceDescription();
             case TAG_METERING_MODE:
@@ -139,44 +149,52 @@ public abstract class ExifDescriptorBase<T extends Directory> extends TagDescrip
                 return getFlashDescription();
             case TAG_FOCAL_LENGTH:
                 return getFocalLengthDescription();
+            case TAG_USER_COMMENT:
+                return getUserCommentDescription();
+            case TAG_TEMPERATURE:
+                return getTemperatureDescription();
+            case TAG_HUMIDITY:
+                return getHumidityDescription();
+            case TAG_PRESSURE:
+                return getPressureDescription();
+            case TAG_WATER_DEPTH:
+                return getWaterDepthDescription();
+            case TAG_ACCELERATION:
+                return getAccelerationDescription();
+            case TAG_CAMERA_ELEVATION_ANGLE:
+                return getCameraElevationAngleDescription();
+            case TAG_WIN_TITLE:
+                return getWindowsTitleDescription();
+            case TAG_WIN_COMMENT:
+                return getWindowsCommentDescription();
+            case TAG_WIN_AUTHOR:
+                return getWindowsAuthorDescription();
+            case TAG_WIN_KEYWORDS:
+                return getWindowsKeywordsDescription();
+            case TAG_WIN_SUBJECT:
+                return getWindowsSubjectDescription();
+            case TAG_FLASHPIX_VERSION:
+                return getFlashPixVersionDescription();
             case TAG_COLOR_SPACE:
                 return getColorSpaceDescription();
             case TAG_EXIF_IMAGE_WIDTH:
                 return getExifImageWidthDescription();
             case TAG_EXIF_IMAGE_HEIGHT:
                 return getExifImageHeightDescription();
-            case TAG_FOCAL_PLANE_RESOLUTION_UNIT:
-                return getFocalPlaneResolutionUnitDescription();
             case TAG_FOCAL_PLANE_X_RESOLUTION:
                 return getFocalPlaneXResolutionDescription();
             case TAG_FOCAL_PLANE_Y_RESOLUTION:
                 return getFocalPlaneYResolutionDescription();
-            case TAG_EXPOSURE_PROGRAM:
-                return getExposureProgramDescription();
-            case TAG_APERTURE:
-                return getApertureValueDescription();
-            case TAG_MAX_APERTURE:
-                return getMaxApertureValueDescription();
+            case TAG_FOCAL_PLANE_RESOLUTION_UNIT:
+                return getFocalPlaneResolutionUnitDescription();
             case TAG_SENSING_METHOD:
                 return getSensingMethodDescription();
-            case TAG_EXPOSURE_BIAS:
-                return getExposureBiasDescription();
             case TAG_FILE_SOURCE:
                 return getFileSourceDescription();
             case TAG_SCENE_TYPE:
                 return getSceneTypeDescription();
             case TAG_CFA_PATTERN:
                 return getCfaPatternDescription();
-            case TAG_COMPONENTS_CONFIGURATION:
-                return getComponentConfigurationDescription();
-            case TAG_EXIF_VERSION:
-                return getExifVersionDescription();
-            case TAG_FLASHPIX_VERSION:
-                return getFlashPixVersionDescription();
-            case TAG_ISO_EQUIVALENT:
-                return getIsoEquivalentDescription();
-            case TAG_USER_COMMENT:
-                return getUserCommentDescription();
             case TAG_CUSTOM_RENDERED:
                 return getCustomRenderedDescription();
             case TAG_EXPOSURE_MODE:
@@ -199,23 +217,11 @@ public abstract class ExifDescriptorBase<T extends Directory> extends TagDescrip
                 return getSharpnessDescription();
             case TAG_SUBJECT_DISTANCE_RANGE:
                 return getSubjectDistanceRangeDescription();
-            case TAG_SENSITIVITY_TYPE:
-                return getSensitivityTypeRangeDescription();
-            case TAG_COMPRESSION:
-                return getCompressionDescription();
-            case TAG_JPEG_PROC:
-                return getJpegProcDescription();
             case TAG_LENS_SPECIFICATION:
                 return getLensSpecificationDescription();
             default:
                 return super.getDescription(tagType);
         }
-    }
-
-    @Nullable
-    public String getInteropVersionDescription()
-    {
-        return getVersionBytesDescription(TAG_INTEROP_VERSION, 2);
     }
 
     @Nullable
@@ -229,6 +235,264 @@ public abstract class ExifDescriptorBase<T extends Directory> extends TagDescrip
         return "R98".equalsIgnoreCase(value.trim())
             ? "Recommended Exif Interoperability Rules (ExifR98)"
             : "Unknown (" + value + ")";
+    }
+
+    @Nullable
+    public String getInteropVersionDescription()
+    {
+        return getVersionBytesDescription(TAG_INTEROP_VERSION, 2);
+    }
+
+    @Nullable
+    public String getNewSubfileTypeDescription()
+    {
+        return getIndexedDescription(TAG_NEW_SUBFILE_TYPE, 0,
+            "Full-resolution image",
+            "Reduced-resolution image",
+            "Single page of multi-page image",
+            "Single page of multi-page reduced-resolution image",
+            "Transparency mask",
+            "Transparency mask of reduced-resolution image",
+            "Transparency mask of multi-page image",
+            "Transparency mask of reduced-resolution multi-page image"
+        );
+    }
+
+    @Nullable
+    public String getSubfileTypeDescription()
+    {
+        return getIndexedDescription(TAG_SUBFILE_TYPE, 1,
+            "Full-resolution image",
+            "Reduced-resolution image",
+            "Single page of multi-page image"
+        );
+    }
+
+    @Nullable
+    public String getImageWidthDescription()
+    {
+        String value = _directory.getString(TAG_IMAGE_WIDTH);
+        return value == null ? null : value + " pixels";
+    }
+
+    @Nullable
+    public String getImageHeightDescription()
+    {
+        String value = _directory.getString(TAG_IMAGE_HEIGHT);
+        return value == null ? null : value + " pixels";
+    }
+
+    @Nullable
+    public String getBitsPerSampleDescription()
+    {
+        String value = _directory.getString(TAG_BITS_PER_SAMPLE);
+        return value == null ? null : value + " bits/component/pixel";
+    }
+
+    @Nullable
+    public String getCompressionDescription()
+    {
+        Integer value = _directory.getInteger(TAG_COMPRESSION);
+        if (value == null)
+            return null;
+        switch (value) {
+            case 1: return "Uncompressed";
+            case 2: return "CCITT 1D";
+            case 3: return "T4/Group 3 Fax";
+            case 4: return "T6/Group 4 Fax";
+            case 5: return "LZW";
+            case 6: return "JPEG (old-style)";
+            case 7: return "JPEG";
+            case 8: return "Adobe Deflate";
+            case 9: return "JBIG B&W";
+            case 10: return "JBIG Color";
+            case 99: return "JPEG";
+            case 262: return "Kodak 262";
+            case 32766: return "Next";
+            case 32767: return "Sony ARW Compressed";
+            case 32769: return "Packed RAW";
+            case 32770: return "Samsung SRW Compressed";
+            case 32771: return "CCIRLEW";
+            case 32772: return "Samsung SRW Compressed 2";
+            case 32773: return "PackBits";
+            case 32809: return "Thunderscan";
+            case 32867: return "Kodak KDC Compressed";
+            case 32895: return "IT8CTPAD";
+            case 32896: return "IT8LW";
+            case 32897: return "IT8MP";
+            case 32898: return "IT8BL";
+            case 32908: return "PixarFilm";
+            case 32909: return "PixarLog";
+            case 32946: return "Deflate";
+            case 32947: return "DCS";
+            case 34661: return "JBIG";
+            case 34676: return "SGILog";
+            case 34677: return "SGILog24";
+            case 34712: return "JPEG 2000";
+            case 34713: return "Nikon NEF Compressed";
+            case 34715: return "JBIG2 TIFF FX";
+            case 34718: return "Microsoft Document Imaging (MDI) Binary Level Codec";
+            case 34719: return "Microsoft Document Imaging (MDI) Progressive Transform Codec";
+            case 34720: return "Microsoft Document Imaging (MDI) Vector";
+            case 34892: return "Lossy JPEG";
+            case 65000: return "Kodak DCR Compressed";
+            case 65535: return "Pentax PEF Compressed";
+            default:
+                return "Unknown (" + value + ")";
+        }
+    }
+
+    @Nullable
+    public String getPhotometricInterpretationDescription()
+    {
+        // Shows the color space of the image data components
+        Integer value = _directory.getInteger(TAG_PHOTOMETRIC_INTERPRETATION);
+        if (value == null)
+            return null;
+        switch (value) {
+            case 0: return "WhiteIsZero";
+            case 1: return "BlackIsZero";
+            case 2: return "RGB";
+            case 3: return "RGB Palette";
+            case 4: return "Transparency Mask";
+            case 5: return "CMYK";
+            case 6: return "YCbCr";
+            case 8: return "CIELab";
+            case 9: return "ICCLab";
+            case 10: return "ITULab";
+            case 32803: return "Color Filter Array";
+            case 32844: return "Pixar LogL";
+            case 32845: return "Pixar LogLuv";
+            case 32892: return "Linear Raw";
+            default:
+                return "Unknown colour space";
+        }
+    }
+
+    @Nullable
+    public String getThresholdingDescription()
+    {
+        return getIndexedDescription(TAG_THRESHOLDING, 1,
+            "No dithering or halftoning",
+            "Ordered dither or halftone",
+            "Randomized dither"
+        );
+    }
+
+    @Nullable
+    public String getFillOrderDescription()
+    {
+        return getIndexedDescription(TAG_FILL_ORDER, 1,
+            "Normal",
+            "Reversed"
+        );
+    }
+
+    @Nullable
+    public String getOrientationDescription()
+    {
+        return super.getOrientationDescription(TAG_ORIENTATION);
+    }
+
+    @Nullable
+    public String getSamplesPerPixelDescription()
+    {
+        String value = _directory.getString(TAG_SAMPLES_PER_PIXEL);
+        return value == null ? null : value + " samples/pixel";
+    }
+
+    @Nullable
+    public String getRowsPerStripDescription()
+    {
+        final String value = _directory.getString(TAG_ROWS_PER_STRIP);
+        return value == null ? null : value + " rows/strip";
+    }
+
+    @Nullable
+    public String getStripByteCountsDescription()
+    {
+        final String value = _directory.getString(TAG_STRIP_BYTE_COUNTS);
+        return value == null ? null : value + " bytes";
+    }
+
+    @Nullable
+    public String getXResolutionDescription()
+    {
+        Rational value = _directory.getRational(TAG_X_RESOLUTION);
+        if (value == null)
+            return null;
+        final String unit = getResolutionDescription();
+        return String.format("%s dots per %s",
+            value.toSimpleString(_allowDecimalRepresentationOfRationals),
+            unit == null ? "unit" : unit.toLowerCase());
+    }
+
+    @Nullable
+    public String getYResolutionDescription()
+    {
+        Rational value = _directory.getRational(TAG_Y_RESOLUTION);
+        if (value==null)
+            return null;
+        final String unit = getResolutionDescription();
+        return String.format("%s dots per %s",
+            value.toSimpleString(_allowDecimalRepresentationOfRationals),
+            unit == null ? "unit" : unit.toLowerCase());
+    }
+
+    @Nullable
+    public String getPlanarConfigurationDescription()
+    {
+        // When image format is no compression YCbCr, this value shows byte aligns of YCbCr
+        // data. If value is '1', Y/Cb/Cr value is chunky format, contiguous for each subsampling
+        // pixel. If value is '2', Y/Cb/Cr value is separated and stored to Y plane/Cb plane/Cr
+        // plane format.
+        return getIndexedDescription(TAG_PLANAR_CONFIGURATION,
+            1,
+            "Chunky (contiguous for each subsampling pixel)",
+            "Separate (Y-plane/Cb-plane/Cr-plane format)"
+        );
+    }
+
+    @Nullable
+    public String getResolutionDescription()
+    {
+        // '1' means no-unit, '2' means inch, '3' means centimeter. Default value is '2'(inch)
+        return getIndexedDescription(TAG_RESOLUTION_UNIT, 1, "(No unit)", "Inch", "cm");
+    }
+
+    @Nullable
+    public String getJpegProcDescription()
+    {
+        Integer value = _directory.getInteger(TAG_JPEG_PROC);
+        if (value == null)
+            return null;
+        switch (value) {
+            case 1: return "Baseline";
+            case 14: return "Lossless";
+            default:
+                return "Unknown (" + value + ")";
+        }
+    }
+
+    @Nullable
+    public String getYCbCrSubsamplingDescription()
+    {
+        int[] positions = _directory.getIntArray(TAG_YCBCR_SUBSAMPLING);
+        if (positions == null || positions.length < 2)
+            return null;
+        if (positions[0] == 2 && positions[1] == 1) {
+            return "YCbCr4:2:2";
+        } else if (positions[0] == 2 && positions[1] == 2) {
+            return "YCbCr4:2:0";
+        } else {
+            return "(Unknown)";
+        }
+    }
+
+    @Nullable
+    public String getYCbCrPositioningDescription()
+    {
+        return getIndexedDescription(TAG_YCBCR_POSITIONING, 1, "Center of pixel array", "Datum point");
     }
 
     @Nullable
@@ -261,427 +525,6 @@ public abstract class ExifDescriptorBase<T extends Directory> extends TagDescrip
         int blackB = ints[4];
         int whiteB = ints[5];
         return String.format("[%d,%d,%d] [%d,%d,%d]", blackR, blackG, blackB, whiteR, whiteG, whiteB);
-    }
-
-    @Nullable
-    public String getYResolutionDescription()
-    {
-        Rational value = _directory.getRational(TAG_Y_RESOLUTION);
-        if (value==null)
-            return null;
-        final String unit = getResolutionDescription();
-        return String.format("%s dots per %s",
-            value.toSimpleString(_allowDecimalRepresentationOfRationals),
-            unit == null ? "unit" : unit.toLowerCase());
-    }
-
-    @Nullable
-    public String getXResolutionDescription()
-    {
-        Rational value = _directory.getRational(TAG_X_RESOLUTION);
-        if (value == null)
-            return null;
-        final String unit = getResolutionDescription();
-        return String.format("%s dots per %s",
-            value.toSimpleString(_allowDecimalRepresentationOfRationals),
-            unit == null ? "unit" : unit.toLowerCase());
-    }
-
-    @Nullable
-    public String getYCbCrPositioningDescription()
-    {
-        return getIndexedDescription(TAG_YCBCR_POSITIONING, 1, "Center of pixel array", "Datum point");
-    }
-
-    @Nullable
-    public String getOrientationDescription()
-    {
-        return super.getOrientationDescription(TAG_ORIENTATION);
-    }
-
-    @Nullable
-    public String getResolutionDescription()
-    {
-        // '1' means no-unit, '2' means inch, '3' means centimeter. Default value is '2'(inch)
-        return getIndexedDescription(TAG_RESOLUTION_UNIT, 1, "(No unit)", "Inch", "cm");
-    }
-
-    /** The Windows specific tags uses plain Unicode. */
-    @Nullable
-    private String getUnicodeDescription(int tag)
-    {
-        byte[] bytes = _directory.getByteArray(tag);
-        if (bytes == null)
-            return null;
-        try {
-            // Decode the unicode string and trim the unicode zero "\0" from the end.
-            return new String(bytes, "UTF-16LE").trim();
-        } catch (UnsupportedEncodingException ex) {
-            return null;
-        }
-    }
-
-    @Nullable
-    public String getWindowsAuthorDescription()
-    {
-        return getUnicodeDescription(TAG_WIN_AUTHOR);
-    }
-
-    @Nullable
-    public String getWindowsCommentDescription()
-    {
-        return getUnicodeDescription(TAG_WIN_COMMENT);
-    }
-
-    @Nullable
-    public String getWindowsKeywordsDescription()
-    {
-        return getUnicodeDescription(TAG_WIN_KEYWORDS);
-    }
-
-    @Nullable
-    public String getWindowsTitleDescription()
-    {
-        return getUnicodeDescription(TAG_WIN_TITLE);
-    }
-
-    @Nullable
-    public String getWindowsSubjectDescription()
-    {
-        return getUnicodeDescription(TAG_WIN_SUBJECT);
-    }
-
-    @Nullable
-    public String getYCbCrSubsamplingDescription()
-    {
-        int[] positions = _directory.getIntArray(TAG_YCBCR_SUBSAMPLING);
-        if (positions == null || positions.length < 2)
-            return null;
-        if (positions[0] == 2 && positions[1] == 1) {
-            return "YCbCr4:2:2";
-        } else if (positions[0] == 2 && positions[1] == 2) {
-            return "YCbCr4:2:0";
-        } else {
-            return "(Unknown)";
-        }
-    }
-
-    @Nullable
-    public String getPlanarConfigurationDescription()
-    {
-        // When image format is no compression YCbCr, this value shows byte aligns of YCbCr
-        // data. If value is '1', Y/Cb/Cr value is chunky format, contiguous for each subsampling
-        // pixel. If value is '2', Y/Cb/Cr value is separated and stored to Y plane/Cb plane/Cr
-        // plane format.
-        return getIndexedDescription(TAG_PLANAR_CONFIGURATION,
-            1,
-            "Chunky (contiguous for each subsampling pixel)",
-            "Separate (Y-plane/Cb-plane/Cr-plane format)"
-        );
-    }
-
-    @Nullable
-    public String getSamplesPerPixelDescription()
-    {
-        String value = _directory.getString(TAG_SAMPLES_PER_PIXEL);
-        return value == null ? null : value + " samples/pixel";
-    }
-
-    @Nullable
-    public String getRowsPerStripDescription()
-    {
-        final String value = _directory.getString(TAG_ROWS_PER_STRIP);
-        return value == null ? null : value + " rows/strip";
-    }
-
-    @Nullable
-    public String getStripByteCountsDescription()
-    {
-        final String value = _directory.getString(TAG_STRIP_BYTE_COUNTS);
-        return value == null ? null : value + " bytes";
-    }
-
-    @Nullable
-    public String getPhotometricInterpretationDescription()
-    {
-        // Shows the color space of the image data components
-        Integer value = _directory.getInteger(TAG_PHOTOMETRIC_INTERPRETATION);
-        if (value == null)
-            return null;
-        switch (value) {
-            case 0: return "WhiteIsZero";
-            case 1: return "BlackIsZero";
-            case 2: return "RGB";
-            case 3: return "RGB Palette";
-            case 4: return "Transparency Mask";
-            case 5: return "CMYK";
-            case 6: return "YCbCr";
-            case 8: return "CIELab";
-            case 9: return "ICCLab";
-            case 10: return "ITULab";
-            case 32803: return "Color Filter Array";
-            case 32844: return "Pixar LogL";
-            case 32845: return "Pixar LogLuv";
-            case 32892: return "Linear Raw";
-            default:
-                return "Unknown colour space";
-        }
-    }
-
-    @Nullable
-    public String getBitsPerSampleDescription()
-    {
-        String value = _directory.getString(TAG_BITS_PER_SAMPLE);
-        return value == null ? null : value + " bits/component/pixel";
-    }
-
-    @Nullable
-    public String getImageWidthDescription()
-    {
-        String value = _directory.getString(TAG_IMAGE_WIDTH);
-        return value == null ? null : value + " pixels";
-    }
-
-    @Nullable
-    public String getImageHeightDescription()
-    {
-        String value = _directory.getString(TAG_IMAGE_HEIGHT);
-        return value == null ? null : value + " pixels";
-    }
-
-    @Nullable
-    public String getNewSubfileTypeDescription()
-    {
-        return getIndexedDescription(TAG_NEW_SUBFILE_TYPE, 0,
-            "Full-resolution image",
-            "Reduced-resolution image",
-            "Single page of multi-page image",
-            "Single page of multi-page reduced-resolution image",
-            "Transparency mask",
-            "Transparency mask of reduced-resolution image",
-            "Transparency mask of multi-page image",
-            "Transparency mask of reduced-resolution multi-page image"
-        );
-    }
-
-    @Nullable
-    public String getSubfileTypeDescription()
-    {
-        return getIndexedDescription(TAG_SUBFILE_TYPE, 1,
-            "Full-resolution image",
-            "Reduced-resolution image",
-            "Single page of multi-page image"
-        );
-    }
-
-    @Nullable
-    public String getThresholdingDescription()
-    {
-        return getIndexedDescription(TAG_THRESHOLDING, 1,
-            "No dithering or halftoning",
-            "Ordered dither or halftone",
-            "Randomized dither"
-        );
-    }
-
-    @Nullable
-    public String getFillOrderDescription()
-    {
-        return getIndexedDescription(TAG_FILL_ORDER, 1,
-            "Normal",
-            "Reversed"
-        );
-    }
-
-    @Nullable
-    public String getSubjectDistanceRangeDescription()
-    {
-        return getIndexedDescription(TAG_SUBJECT_DISTANCE_RANGE,
-            "Unknown",
-            "Macro",
-            "Close view",
-            "Distant view"
-        );
-    }
-
-    @Nullable
-    public String getSensitivityTypeRangeDescription()
-    {
-        return getIndexedDescription(TAG_SENSITIVITY_TYPE,
-            "Unknown",
-            "Standard Output Sensitivity",
-            "Recommended Exposure Index",
-            "ISO Speed",
-            "Standard Output Sensitivity and Recommended Exposure Index",
-            "Standard Output Sensitivity and ISO Speed",
-            "Recommended Exposure Index and ISO Speed",
-            "Standard Output Sensitivity, Recommended Exposure Index and ISO Speed"
-        );
-    }
-
-    @Nullable
-    public String getLensSpecificationDescription()
-    {
-        return getLensSpecificationDescription(TAG_LENS_SPECIFICATION);
-    }
-
-    @Nullable
-    public String getSharpnessDescription()
-    {
-        return getIndexedDescription(TAG_SHARPNESS,
-            "None",
-            "Low",
-            "Hard"
-        );
-    }
-
-    @Nullable
-    public String getSaturationDescription()
-    {
-        return getIndexedDescription(TAG_SATURATION,
-            "None",
-            "Low saturation",
-            "High saturation"
-        );
-    }
-
-    @Nullable
-    public String getContrastDescription()
-    {
-        return getIndexedDescription(TAG_CONTRAST,
-            "None",
-            "Soft",
-            "Hard"
-        );
-    }
-
-    @Nullable
-    public String getGainControlDescription()
-    {
-        return getIndexedDescription(TAG_GAIN_CONTROL,
-            "None",
-            "Low gain up",
-            "Low gain down",
-            "High gain up",
-            "High gain down"
-        );
-    }
-
-    @Nullable
-    public String getSceneCaptureTypeDescription()
-    {
-        return getIndexedDescription(TAG_SCENE_CAPTURE_TYPE,
-            "Standard",
-            "Landscape",
-            "Portrait",
-            "Night scene"
-        );
-    }
-
-    @Nullable
-    public String get35mmFilmEquivFocalLengthDescription()
-    {
-        Integer value = _directory.getInteger(TAG_35MM_FILM_EQUIV_FOCAL_LENGTH);
-        return value == null
-            ? null
-            : value == 0
-                ? "Unknown"
-                : getFocalLengthDescription(value);
-    }
-
-    @Nullable
-    public String getDigitalZoomRatioDescription()
-    {
-        Rational value = _directory.getRational(TAG_DIGITAL_ZOOM_RATIO);
-        return value == null
-            ? null
-            : value.getNumerator() == 0
-                ? "Digital zoom not used"
-                : new DecimalFormat("0.#").format(value.doubleValue());
-    }
-
-    @Nullable
-    public String getWhiteBalanceModeDescription()
-    {
-        return getIndexedDescription(TAG_WHITE_BALANCE_MODE,
-            "Auto white balance",
-            "Manual white balance"
-        );
-    }
-
-    @Nullable
-    public String getExposureModeDescription()
-    {
-        return getIndexedDescription(TAG_EXPOSURE_MODE,
-            "Auto exposure",
-            "Manual exposure",
-            "Auto bracket"
-        );
-    }
-
-    @Nullable
-    public String getCustomRenderedDescription()
-    {
-        return getIndexedDescription(TAG_CUSTOM_RENDERED,
-            "Normal process",
-            "Custom process"
-        );
-    }
-
-    @Nullable
-    public String getUserCommentDescription()
-    {
-        return getEncodedTextDescription(TAG_USER_COMMENT);
-    }
-
-    @Nullable
-    public String getIsoEquivalentDescription()
-    {
-        // Have seen an exception here from files produced by ACDSEE that stored an int[] here with two values
-        Integer isoEquiv = _directory.getInteger(TAG_ISO_EQUIVALENT);
-        // There used to be a check here that multiplied ISO values < 50 by 200.
-        // Issue 36 shows a smart-phone image from a Samsung Galaxy S2 with ISO-40.
-        return isoEquiv != null
-            ? Integer.toString(isoEquiv)
-            : null;
-    }
-
-    @Nullable
-    public String getExifVersionDescription()
-    {
-        return getVersionBytesDescription(TAG_EXIF_VERSION, 2);
-    }
-
-    @Nullable
-    public String getFlashPixVersionDescription()
-    {
-        return getVersionBytesDescription(TAG_FLASHPIX_VERSION, 2);
-    }
-
-    @Nullable
-    public String getSceneTypeDescription()
-    {
-        return getIndexedDescription(TAG_SCENE_TYPE,
-            1,
-            "Directly photographed image"
-        );
-    }
-
-    /// <summary>
-    /// String description of CFA Pattern
-    /// </summary>
-    /// <remarks>
-    /// Converted from Exiftool version 10.33 created by Phil Harvey
-    /// http://www.sno.phy.queensu.ca/~phil/exiftool/
-    /// lib\Image\ExifTool\Exif.pm
-    ///
-    /// Indicates the color filter array (CFA) geometric pattern of the image sensor when a one-chip color area sensor is used.
-    /// It does not apply to all sensing methods.
-    /// </remarks>
-    @Nullable
-    public String getCfaPatternDescription()
-    {
-        return formatCFAPattern(decodeCfaPattern(TAG_CFA_PATTERN));
     }
 
     /// <summary>
@@ -755,6 +598,515 @@ public abstract class ExifDescriptorBase<T extends Directory> extends TagDescrip
         return ret.toString();
     }
 
+    @Nullable
+    public String getExposureTimeDescription()
+    {
+        String value = _directory.getString(TAG_EXPOSURE_TIME);
+        return value == null ? null : value + " sec";
+    }
+
+    @Nullable
+    public String getFNumberDescription()
+    {
+        Rational value = _directory.getRational(TAG_FNUMBER);
+        if (value == null)
+            return null;
+        return getFStopDescription(value.doubleValue());
+    }
+
+    @Nullable
+    public String getExposureProgramDescription()
+    {
+        return getIndexedDescription(TAG_EXPOSURE_PROGRAM,
+            1,
+            "Manual control",
+            "Program normal",
+            "Aperture priority",
+            "Shutter priority",
+            "Program creative (slow program)",
+            "Program action (high-speed program)",
+            "Portrait mode",
+            "Landscape mode"
+        );
+    }
+
+    @Nullable
+    public String getIsoEquivalentDescription()
+    {
+        // Have seen an exception here from files produced by ACDSEE that stored an int[] here with two values
+        Integer isoEquiv = _directory.getInteger(TAG_ISO_EQUIVALENT);
+        // There used to be a check here that multiplied ISO values < 50 by 200.
+        // Issue 36 shows a smart-phone image from a Samsung Galaxy S2 with ISO-40.
+        return isoEquiv != null
+            ? Integer.toString(isoEquiv)
+            : null;
+    }
+
+    @Nullable
+    public String getSensitivityTypeRangeDescription()
+    {
+        return getIndexedDescription(TAG_SENSITIVITY_TYPE,
+            "Unknown",
+            "Standard Output Sensitivity",
+            "Recommended Exposure Index",
+            "ISO Speed",
+            "Standard Output Sensitivity and Recommended Exposure Index",
+            "Standard Output Sensitivity and ISO Speed",
+            "Recommended Exposure Index and ISO Speed",
+            "Standard Output Sensitivity, Recommended Exposure Index and ISO Speed"
+        );
+    }
+
+    @Nullable
+    public String getExifVersionDescription()
+    {
+        return getVersionBytesDescription(TAG_EXIF_VERSION, 2);
+    }
+
+    @Nullable
+    public String getComponentConfigurationDescription()
+    {
+        int[] components = _directory.getIntArray(TAG_COMPONENTS_CONFIGURATION);
+        if (components == null)
+            return null;
+        String[] componentStrings = {"", "Y", "Cb", "Cr", "R", "G", "B"};
+        StringBuilder componentConfig = new StringBuilder();
+        for (int i = 0; i < Math.min(4, components.length); i++) {
+            int j = components[i];
+            if (j > 0 && j < componentStrings.length) {
+                componentConfig.append(componentStrings[j]);
+            }
+        }
+        return componentConfig.toString();
+    }
+
+    @Nullable
+    public String getCompressedAverageBitsPerPixelDescription()
+    {
+        Rational value = _directory.getRational(TAG_COMPRESSED_AVERAGE_BITS_PER_PIXEL);
+        if (value == null)
+            return null;
+        String ratio = value.toSimpleString(_allowDecimalRepresentationOfRationals);
+        return value.isInteger() && value.intValue() == 1
+            ? ratio + " bit/pixel"
+            : ratio + " bits/pixel";
+    }
+
+    @Nullable
+    public String getShutterSpeedDescription()
+    {
+        return super.getShutterSpeedDescription(TAG_SHUTTER_SPEED);
+    }
+
+    @Nullable
+    public String getApertureValueDescription()
+    {
+        Double aperture = _directory.getDoubleObject(TAG_APERTURE);
+        if (aperture == null)
+            return null;
+        double fStop = PhotographicConversions.apertureToFStop(aperture);
+        return getFStopDescription(fStop);
+    }
+
+    @Nullable
+    public String getBrightnessValueDescription()
+    {
+        Rational value = _directory.getRational(TAG_BRIGHTNESS_VALUE);
+        if (value == null)
+            return null;
+        if (value.getNumerator() == 0xFFFFFFFFL)
+            return "Unknown";
+        DecimalFormat formatter = new DecimalFormat("0.0##");
+        return formatter.format(value.doubleValue());
+    }
+
+    @Nullable
+    public String getExposureBiasDescription()
+    {
+        Rational value = _directory.getRational(TAG_EXPOSURE_BIAS);
+        if (value == null)
+            return null;
+        return value.toSimpleString(true) + " EV";
+    }
+
+    @Nullable
+    public String getMaxApertureValueDescription()
+    {
+        Double aperture = _directory.getDoubleObject(TAG_MAX_APERTURE);
+        if (aperture == null)
+            return null;
+        double fStop = PhotographicConversions.apertureToFStop(aperture);
+        return getFStopDescription(fStop);
+    }
+
+    @Nullable
+    public String getSubjectDistanceDescription()
+    {
+        Rational value = _directory.getRational(TAG_SUBJECT_DISTANCE);
+        if (value == null)
+            return null;
+        if (value.getNumerator() == 0xFFFFFFFFL)
+            return "Infinity";
+        if (value.getNumerator() == 0)
+            return "Unknown";
+        DecimalFormat formatter = new DecimalFormat("0.0##");
+        return formatter.format(value.doubleValue()) + " metres";
+    }
+
+    @Nullable
+    public String getMeteringModeDescription()
+    {
+        // '0' means unknown, '1' average, '2' center weighted average, '3' spot
+        // '4' multi-spot, '5' multi-segment, '6' partial, '255' other
+        Integer value = _directory.getInteger(TAG_METERING_MODE);
+        if (value == null)
+            return null;
+        switch (value) {
+            case 0: return "Unknown";
+            case 1: return "Average";
+            case 2: return "Center weighted average";
+            case 3: return "Spot";
+            case 4: return "Multi-spot";
+            case 5: return "Multi-segment";
+            case 6: return "Partial";
+            case 255: return "(Other)";
+            default:
+                return "Unknown (" + value + ")";
+        }
+    }
+
+    @Nullable
+    public String getWhiteBalanceDescription()
+    {
+        // See http://web.archive.org/web/20131018091152/http://exif.org/Exif2-2.PDF page 35
+        final Integer value = _directory.getInteger(TAG_WHITE_BALANCE);
+        if (value == null)
+            return null;
+        switch (value) {
+            case 0: return "Unknown";
+            case 1: return "Daylight";
+            case 2: return "Florescent";
+            case 3: return "Tungsten";
+            case 4: return "Flash";
+            case 9: return "Fine Weather";
+            case 10: return "Cloudy";
+            case 11: return "Shade";
+            case 12: return "Daylight Fluorescent";
+            case 13: return "Day White Fluorescent";
+            case 14: return "Cool White Fluorescent";
+            case 15: return "White Fluorescent";
+            case 16: return "Warm White Fluorescent";
+            case 17: return "Standard light";
+            case 18: return "Standard light (B)";
+            case 19: return "Standard light (C)";
+            case 20: return "D55";
+            case 21: return "D65";
+            case 22: return "D75";
+            case 23: return "D50";
+            case 24: return "Studio Tungsten";
+            case 255: return "(Other)";
+            default:
+                return "Unknown (" + value + ")";
+        }
+    }
+
+    @Nullable
+    public String getFlashDescription()
+    {
+        /*
+         * This is a bit mask.
+         * 0 = flash fired
+         * 1 = return detected
+         * 2 = return able to be detected
+         * 3 = unknown
+         * 4 = auto used
+         * 5 = unknown
+         * 6 = red eye reduction used
+         */
+
+        final Integer value = _directory.getInteger(TAG_FLASH);
+
+        if (value == null)
+            return null;
+
+        StringBuilder sb = new StringBuilder();
+
+        if ((value & 0x1) != 0)
+            sb.append("Flash fired");
+        else
+            sb.append("Flash did not fire");
+
+        // check if we're able to detect a return, before we mention it
+        if ((value & 0x4) != 0) {
+            if ((value & 0x2) != 0)
+                sb.append(", return detected");
+            else
+                sb.append(", return not detected");
+        }
+
+        if ((value & 0x10) != 0)
+            sb.append(", auto");
+
+        if ((value & 0x40) != 0)
+            sb.append(", red-eye reduction");
+
+        return sb.toString();
+    }
+
+    @Nullable
+    public String getFocalLengthDescription()
+    {
+        Rational value = _directory.getRational(TAG_FOCAL_LENGTH);
+        return value == null ? null : getFocalLengthDescription(value.doubleValue());
+    }
+
+    @Nullable
+    public String getUserCommentDescription()
+    {
+        return getEncodedTextDescription(TAG_USER_COMMENT);
+    }
+
+    @Nullable
+    public String getTemperatureDescription()
+    {
+        Rational value = _directory.getRational(TAG_TEMPERATURE);
+        if (value == null)
+            return null;
+        if (value.getDenominator() == 0xFFFFFFFFL)
+            return "Unknown";
+        DecimalFormat formatter = new DecimalFormat("0.0");
+        return formatter.format(value.doubleValue()) + " °C";
+    }
+
+    @Nullable
+    public String getHumidityDescription()
+    {
+        Rational value = _directory.getRational(TAG_HUMIDITY);
+        if (value == null)
+            return null;
+        if (value.getDenominator() == 0xFFFFFFFFL)
+            return "Unknown";
+        DecimalFormat formatter = new DecimalFormat("0.0");
+        return formatter.format(value.doubleValue()) + " %";
+    }
+
+    @Nullable
+    public String getPressureDescription()
+    {
+        Rational value = _directory.getRational(TAG_PRESSURE);
+        if (value == null)
+            return null;
+        if (value.getDenominator() == 0xFFFFFFFFL)
+            return "Unknown";
+        DecimalFormat formatter = new DecimalFormat("0.0");
+        return formatter.format(value.doubleValue()) + " hPa";
+    }
+
+    @Nullable
+    public String getWaterDepthDescription()
+    {
+        Rational value = _directory.getRational(TAG_WATER_DEPTH);
+        if (value == null)
+            return null;
+        if (value.getDenominator() == 0xFFFFFFFFL)
+            return "Unknown";
+        DecimalFormat formatter = new DecimalFormat("0.0##");
+        return formatter.format(value.doubleValue()) + " metres";
+    }
+
+    @Nullable
+    public String getAccelerationDescription()
+    {
+        Rational value = _directory.getRational(TAG_ACCELERATION);
+        if (value == null)
+            return null;
+        if (value.getDenominator() == 0xFFFFFFFFL)
+            return "Unknown";
+        DecimalFormat formatter = new DecimalFormat("0.0##");
+        return formatter.format(value.doubleValue()) + " mGal";
+    }
+
+    @Nullable
+    public String getCameraElevationAngleDescription()
+    {
+        Rational value = _directory.getRational(TAG_CAMERA_ELEVATION_ANGLE);
+        if (value == null)
+            return null;
+        if (value.getDenominator() == 0xFFFFFFFFL)
+            return "Unknown";
+        DecimalFormat formatter = new DecimalFormat("0.##");
+        return formatter.format(value.doubleValue()) + " degrees";
+    }
+
+    /** The Windows specific tags uses plain Unicode. */
+    @Nullable
+    private String getUnicodeDescription(int tag)
+    {
+        byte[] bytes = _directory.getByteArray(tag);
+        if (bytes == null)
+            return null;
+        try {
+            // Decode the unicode string and trim the unicode zero "\0" from the end.
+            return new String(bytes, "UTF-16LE").trim();
+        } catch (UnsupportedEncodingException ex) {
+            return null;
+        }
+    }
+
+    @Nullable
+    public String getWindowsTitleDescription()
+    {
+        return getUnicodeDescription(TAG_WIN_TITLE);
+    }
+
+    @Nullable
+    public String getWindowsCommentDescription()
+    {
+        return getUnicodeDescription(TAG_WIN_COMMENT);
+    }
+
+    @Nullable
+    public String getWindowsAuthorDescription()
+    {
+        return getUnicodeDescription(TAG_WIN_AUTHOR);
+    }
+
+    @Nullable
+    public String getWindowsKeywordsDescription()
+    {
+        return getUnicodeDescription(TAG_WIN_KEYWORDS);
+    }
+
+    @Nullable
+    public String getWindowsSubjectDescription()
+    {
+        return getUnicodeDescription(TAG_WIN_SUBJECT);
+    }
+
+    @Nullable
+    public String getFlashPixVersionDescription()
+    {
+        return getVersionBytesDescription(TAG_FLASHPIX_VERSION, 2);
+    }
+
+    @Nullable
+    public String getColorSpaceDescription()
+    {
+        final Integer value = _directory.getInteger(TAG_COLOR_SPACE);
+        if (value == null)
+            return null;
+        if (value == 1)
+            return "sRGB";
+        if (value == 65535)
+            return "Undefined";
+        return "Unknown (" + value + ")";
+    }
+
+    @Nullable
+    public String getExifImageWidthDescription()
+    {
+        final Integer value = _directory.getInteger(TAG_EXIF_IMAGE_WIDTH);
+        return value == null ? null : value + " pixels";
+    }
+
+    @Nullable
+    public String getExifImageHeightDescription()
+    {
+        final Integer value = _directory.getInteger(TAG_EXIF_IMAGE_HEIGHT);
+        return value == null ? null : value + " pixels";
+    }
+
+    @Nullable
+    public String getFocalPlaneXResolutionDescription()
+    {
+        Rational rational = _directory.getRational(TAG_FOCAL_PLANE_X_RESOLUTION);
+        if (rational == null)
+            return null;
+        final String unit = getFocalPlaneResolutionUnitDescription();
+        return rational.getReciprocal().toSimpleString(_allowDecimalRepresentationOfRationals)
+            + (unit == null ? "" : " " + unit.toLowerCase());
+    }
+
+    @Nullable
+    public String getFocalPlaneYResolutionDescription()
+    {
+        Rational rational = _directory.getRational(TAG_FOCAL_PLANE_Y_RESOLUTION);
+        if (rational == null)
+            return null;
+        final String unit = getFocalPlaneResolutionUnitDescription();
+        return rational.getReciprocal().toSimpleString(_allowDecimalRepresentationOfRationals)
+            + (unit == null ? "" : " " + unit.toLowerCase());
+    }
+
+    @Nullable
+    public String getFocalPlaneResolutionUnitDescription()
+    {
+        // Unit of FocalPlaneXResolution/FocalPlaneYResolution.
+        // '1' means no-unit, '2' inch, '3' centimeter.
+        return getIndexedDescription(TAG_FOCAL_PLANE_RESOLUTION_UNIT,
+            1,
+            "(No unit)",
+            "Inches",
+            "cm"
+        );
+    }
+
+    @Nullable
+    public String getSensingMethodDescription()
+    {
+        // '1' Not defined, '2' One-chip color area sensor, '3' Two-chip color area sensor
+        // '4' Three-chip color area sensor, '5' Color sequential area sensor
+        // '7' Trilinear sensor '8' Color sequential linear sensor,  'Other' reserved
+        return getIndexedDescription(TAG_SENSING_METHOD,
+            1,
+            "(Not defined)",
+            "One-chip color area sensor",
+            "Two-chip color area sensor",
+            "Three-chip color area sensor",
+            "Color sequential area sensor",
+            null,
+            "Trilinear sensor",
+            "Color sequential linear sensor"
+        );
+    }
+
+    @Nullable
+    public String getFileSourceDescription()
+    {
+        return getIndexedDescription(TAG_FILE_SOURCE,
+            1,
+            "Film Scanner",
+            "Reflection Print Scanner",
+            "Digital Still Camera (DSC)"
+        );
+    }
+
+    @Nullable
+    public String getSceneTypeDescription()
+    {
+        return getIndexedDescription(TAG_SCENE_TYPE,
+            1,
+            "Directly photographed image"
+        );
+    }
+
+    /// <summary>
+    /// String description of CFA Pattern
+    /// </summary>
+    /// <remarks>
+    /// Converted from Exiftool version 10.33 created by Phil Harvey
+    /// http://www.sno.phy.queensu.ca/~phil/exiftool/
+    /// lib\Image\ExifTool\Exif.pm
+    ///
+    /// Indicates the color filter array (CFA) geometric pattern of the image sensor when a one-chip color area sensor is used.
+    /// It does not apply to all sensing methods.
+    /// </remarks>
+    @Nullable
+    public String getCfaPatternDescription()
+    {
+        return formatCFAPattern(decodeCfaPattern(TAG_CFA_PATTERN));
+    }
+
     /// <summary>
     /// Decode raw CFAPattern value
     /// </summary>
@@ -824,375 +1176,122 @@ public abstract class ExifDescriptorBase<T extends Directory> extends TagDescrip
     }
 
     @Nullable
-    public String getFileSourceDescription()
+    public String getCustomRenderedDescription()
     {
-        return getIndexedDescription(TAG_FILE_SOURCE,
-            1,
-            "Film Scanner",
-            "Reflection Print Scanner",
-            "Digital Still Camera (DSC)"
+        return getIndexedDescription(TAG_CUSTOM_RENDERED,
+            "Normal process",
+            "Custom process"
         );
     }
 
     @Nullable
-    public String getExposureBiasDescription()
+    public String getExposureModeDescription()
     {
-        Rational value = _directory.getRational(TAG_EXPOSURE_BIAS);
-        if (value == null)
-            return null;
-        return value.toSimpleString(true) + " EV";
-    }
-
-    @Nullable
-    public String getMaxApertureValueDescription()
-    {
-        Double aperture = _directory.getDoubleObject(TAG_MAX_APERTURE);
-        if (aperture == null)
-            return null;
-        double fStop = PhotographicConversions.apertureToFStop(aperture);
-        return getFStopDescription(fStop);
-    }
-
-    @Nullable
-    public String getApertureValueDescription()
-    {
-        Double aperture = _directory.getDoubleObject(TAG_APERTURE);
-        if (aperture == null)
-            return null;
-        double fStop = PhotographicConversions.apertureToFStop(aperture);
-        return getFStopDescription(fStop);
-    }
-
-    @Nullable
-    public String getExposureProgramDescription()
-    {
-        return getIndexedDescription(TAG_EXPOSURE_PROGRAM,
-            1,
-            "Manual control",
-            "Program normal",
-            "Aperture priority",
-            "Shutter priority",
-            "Program creative (slow program)",
-            "Program action (high-speed program)",
-            "Portrait mode",
-            "Landscape mode"
-        );
-    }
-
-
-    @Nullable
-    public String getFocalPlaneXResolutionDescription()
-    {
-        Rational rational = _directory.getRational(TAG_FOCAL_PLANE_X_RESOLUTION);
-        if (rational == null)
-            return null;
-        final String unit = getFocalPlaneResolutionUnitDescription();
-        return rational.getReciprocal().toSimpleString(_allowDecimalRepresentationOfRationals)
-            + (unit == null ? "" : " " + unit.toLowerCase());
-    }
-
-    @Nullable
-    public String getFocalPlaneYResolutionDescription()
-    {
-        Rational rational = _directory.getRational(TAG_FOCAL_PLANE_Y_RESOLUTION);
-        if (rational == null)
-            return null;
-        final String unit = getFocalPlaneResolutionUnitDescription();
-        return rational.getReciprocal().toSimpleString(_allowDecimalRepresentationOfRationals)
-            + (unit == null ? "" : " " + unit.toLowerCase());
-    }
-
-    @Nullable
-    public String getFocalPlaneResolutionUnitDescription()
-    {
-        // Unit of FocalPlaneXResolution/FocalPlaneYResolution.
-        // '1' means no-unit, '2' inch, '3' centimeter.
-        return getIndexedDescription(TAG_FOCAL_PLANE_RESOLUTION_UNIT,
-            1,
-            "(No unit)",
-            "Inches",
-            "cm"
+        return getIndexedDescription(TAG_EXPOSURE_MODE,
+            "Auto exposure",
+            "Manual exposure",
+            "Auto bracket"
         );
     }
 
     @Nullable
-    public String getExifImageWidthDescription()
+    public String getWhiteBalanceModeDescription()
     {
-        final Integer value = _directory.getInteger(TAG_EXIF_IMAGE_WIDTH);
-        return value == null ? null : value + " pixels";
-    }
-
-    @Nullable
-    public String getExifImageHeightDescription()
-    {
-        final Integer value = _directory.getInteger(TAG_EXIF_IMAGE_HEIGHT);
-        return value == null ? null : value + " pixels";
-    }
-
-    @Nullable
-    public String getColorSpaceDescription()
-    {
-        final Integer value = _directory.getInteger(TAG_COLOR_SPACE);
-        if (value == null)
-            return null;
-        if (value == 1)
-            return "sRGB";
-        if (value == 65535)
-            return "Undefined";
-        return "Unknown (" + value + ")";
-    }
-
-    @Nullable
-    public String getFocalLengthDescription()
-    {
-        Rational value = _directory.getRational(TAG_FOCAL_LENGTH);
-        return value == null ? null : getFocalLengthDescription(value.doubleValue());
-    }
-
-    @Nullable
-    public String getFlashDescription()
-    {
-        /*
-         * This is a bit mask.
-         * 0 = flash fired
-         * 1 = return detected
-         * 2 = return able to be detected
-         * 3 = unknown
-         * 4 = auto used
-         * 5 = unknown
-         * 6 = red eye reduction used
-         */
-
-        final Integer value = _directory.getInteger(TAG_FLASH);
-
-        if (value == null)
-            return null;
-
-        StringBuilder sb = new StringBuilder();
-
-        if ((value & 0x1) != 0)
-            sb.append("Flash fired");
-        else
-            sb.append("Flash did not fire");
-
-        // check if we're able to detect a return, before we mention it
-        if ((value & 0x4) != 0) {
-            if ((value & 0x2) != 0)
-                sb.append(", return detected");
-            else
-                sb.append(", return not detected");
-        }
-
-        if ((value & 0x10) != 0)
-            sb.append(", auto");
-
-        if ((value & 0x40) != 0)
-            sb.append(", red-eye reduction");
-
-        return sb.toString();
-    }
-
-    @Nullable
-    public String getWhiteBalanceDescription()
-    {
-        // See http://web.archive.org/web/20131018091152/http://exif.org/Exif2-2.PDF page 35
-        final Integer value = _directory.getInteger(TAG_WHITE_BALANCE);
-        if (value == null)
-            return null;
-        switch (value) {
-            case 0: return "Unknown";
-            case 1: return "Daylight";
-            case 2: return "Florescent";
-            case 3: return "Tungsten";
-            case 4: return "Flash";
-            case 9: return "Fine Weather";
-            case 10: return "Cloudy";
-            case 11: return "Shade";
-            case 12: return "Daylight Fluorescent";
-            case 13: return "Day White Fluorescent";
-            case 14: return "Cool White Fluorescent";
-            case 15: return "White Fluorescent";
-            case 16: return "Warm White Fluorescent";
-            case 17: return "Standard light";
-            case 18: return "Standard light (B)";
-            case 19: return "Standard light (C)";
-            case 20: return "D55";
-            case 21: return "D65";
-            case 22: return "D75";
-            case 23: return "D50";
-            case 24: return "Studio Tungsten";
-            case 255: return "(Other)";
-            default:
-                return "Unknown (" + value + ")";
-        }
-    }
-
-    @Nullable
-    public String getMeteringModeDescription()
-    {
-        // '0' means unknown, '1' average, '2' center weighted average, '3' spot
-        // '4' multi-spot, '5' multi-segment, '6' partial, '255' other
-        Integer value = _directory.getInteger(TAG_METERING_MODE);
-        if (value == null)
-            return null;
-        switch (value) {
-            case 0: return "Unknown";
-            case 1: return "Average";
-            case 2: return "Center weighted average";
-            case 3: return "Spot";
-            case 4: return "Multi-spot";
-            case 5: return "Multi-segment";
-            case 6: return "Partial";
-            case 255: return "(Other)";
-            default:
-                return "Unknown (" + value + ")";
-        }
-    }
-
-    @Nullable
-    public String getCompressionDescription()
-    {
-        Integer value = _directory.getInteger(TAG_COMPRESSION);
-        if (value == null)
-            return null;
-        switch (value) {
-            case 1: return "Uncompressed";
-            case 2: return "CCITT 1D";
-            case 3: return "T4/Group 3 Fax";
-            case 4: return "T6/Group 4 Fax";
-            case 5: return "LZW";
-            case 6: return "JPEG (old-style)";
-            case 7: return "JPEG";
-            case 8: return "Adobe Deflate";
-            case 9: return "JBIG B&W";
-            case 10: return "JBIG Color";
-            case 99: return "JPEG";
-            case 262: return "Kodak 262";
-            case 32766: return "Next";
-            case 32767: return "Sony ARW Compressed";
-            case 32769: return "Packed RAW";
-            case 32770: return "Samsung SRW Compressed";
-            case 32771: return "CCIRLEW";
-            case 32772: return "Samsung SRW Compressed 2";
-            case 32773: return "PackBits";
-            case 32809: return "Thunderscan";
-            case 32867: return "Kodak KDC Compressed";
-            case 32895: return "IT8CTPAD";
-            case 32896: return "IT8LW";
-            case 32897: return "IT8MP";
-            case 32898: return "IT8BL";
-            case 32908: return "PixarFilm";
-            case 32909: return "PixarLog";
-            case 32946: return "Deflate";
-            case 32947: return "DCS";
-            case 34661: return "JBIG";
-            case 34676: return "SGILog";
-            case 34677: return "SGILog24";
-            case 34712: return "JPEG 2000";
-            case 34713: return "Nikon NEF Compressed";
-            case 34715: return "JBIG2 TIFF FX";
-            case 34718: return "Microsoft Document Imaging (MDI) Binary Level Codec";
-            case 34719: return "Microsoft Document Imaging (MDI) Progressive Transform Codec";
-            case 34720: return "Microsoft Document Imaging (MDI) Vector";
-            case 34892: return "Lossy JPEG";
-            case 65000: return "Kodak DCR Compressed";
-            case 65535: return "Pentax PEF Compressed";
-            default:
-                return "Unknown (" + value + ")";
-        }
-    }
-
-    @Nullable
-    public String getSubjectDistanceDescription()
-    {
-        Rational value = _directory.getRational(TAG_SUBJECT_DISTANCE);
-        if (value == null)
-            return null;
-        DecimalFormat formatter = new DecimalFormat("0.0##");
-        return formatter.format(value.doubleValue()) + " metres";
-    }
-
-    @Nullable
-    public String getCompressedAverageBitsPerPixelDescription()
-    {
-        Rational value = _directory.getRational(TAG_COMPRESSED_AVERAGE_BITS_PER_PIXEL);
-        if (value == null)
-            return null;
-        String ratio = value.toSimpleString(_allowDecimalRepresentationOfRationals);
-        return value.isInteger() && value.intValue() == 1
-            ? ratio + " bit/pixel"
-            : ratio + " bits/pixel";
-    }
-
-    @Nullable
-    public String getExposureTimeDescription()
-    {
-        String value = _directory.getString(TAG_EXPOSURE_TIME);
-        return value == null ? null : value + " sec";
-    }
-
-    @Nullable
-    public String getShutterSpeedDescription()
-    {
-        return super.getShutterSpeedDescription(TAG_SHUTTER_SPEED);
-    }
-
-    @Nullable
-    public String getFNumberDescription()
-    {
-        Rational value = _directory.getRational(TAG_FNUMBER);
-        if (value == null)
-            return null;
-        return getFStopDescription(value.doubleValue());
-    }
-
-    @Nullable
-    public String getSensingMethodDescription()
-    {
-        // '1' Not defined, '2' One-chip color area sensor, '3' Two-chip color area sensor
-        // '4' Three-chip color area sensor, '5' Color sequential area sensor
-        // '7' Trilinear sensor '8' Color sequential linear sensor,  'Other' reserved
-        return getIndexedDescription(TAG_SENSING_METHOD,
-            1,
-            "(Not defined)",
-            "One-chip color area sensor",
-            "Two-chip color area sensor",
-            "Three-chip color area sensor",
-            "Color sequential area sensor",
-            null,
-            "Trilinear sensor",
-            "Color sequential linear sensor"
+        return getIndexedDescription(TAG_WHITE_BALANCE_MODE,
+            "Auto white balance",
+            "Manual white balance"
         );
     }
 
     @Nullable
-    public String getComponentConfigurationDescription()
+    public String getDigitalZoomRatioDescription()
     {
-        int[] components = _directory.getIntArray(TAG_COMPONENTS_CONFIGURATION);
-        if (components == null)
-            return null;
-        String[] componentStrings = {"", "Y", "Cb", "Cr", "R", "G", "B"};
-        StringBuilder componentConfig = new StringBuilder();
-        for (int i = 0; i < Math.min(4, components.length); i++) {
-            int j = components[i];
-            if (j > 0 && j < componentStrings.length) {
-                componentConfig.append(componentStrings[j]);
-            }
-        }
-        return componentConfig.toString();
+        Rational value = _directory.getRational(TAG_DIGITAL_ZOOM_RATIO);
+        return value == null
+            ? null
+            : value.getNumerator() == 0
+                ? "Digital zoom not used"
+                : new DecimalFormat("0.#").format(value.doubleValue());
     }
 
     @Nullable
-    public String getJpegProcDescription()
+    public String get35mmFilmEquivFocalLengthDescription()
     {
-        Integer value = _directory.getInteger(TAG_JPEG_PROC);
-        if (value == null)
-            return null;
-        switch (value) {
-            case 1: return "Baseline";
-            case 14: return "Lossless";
-            default:
-                return "Unknown (" + value + ")";
-        }
+        Integer value = _directory.getInteger(TAG_35MM_FILM_EQUIV_FOCAL_LENGTH);
+        return value == null
+            ? null
+            : value == 0
+                ? "Unknown"
+                : getFocalLengthDescription(value);
+    }
+
+    @Nullable
+    public String getSceneCaptureTypeDescription()
+    {
+        return getIndexedDescription(TAG_SCENE_CAPTURE_TYPE,
+            "Standard",
+            "Landscape",
+            "Portrait",
+            "Night scene"
+        );
+    }
+
+    @Nullable
+    public String getGainControlDescription()
+    {
+        return getIndexedDescription(TAG_GAIN_CONTROL,
+            "None",
+            "Low gain up",
+            "Low gain down",
+            "High gain up",
+            "High gain down"
+        );
+    }
+
+    @Nullable
+    public String getContrastDescription()
+    {
+        return getIndexedDescription(TAG_CONTRAST,
+            "None",
+            "Soft",
+            "Hard"
+        );
+    }
+
+    @Nullable
+    public String getSaturationDescription()
+    {
+        return getIndexedDescription(TAG_SATURATION,
+            "None",
+            "Low saturation",
+            "High saturation"
+        );
+    }
+
+    @Nullable
+    public String getSharpnessDescription()
+    {
+        return getIndexedDescription(TAG_SHARPNESS,
+            "None",
+            "Low",
+            "Hard"
+        );
+    }
+
+    @Nullable
+    public String getSubjectDistanceRangeDescription()
+    {
+        return getIndexedDescription(TAG_SUBJECT_DISTANCE_RANGE,
+            "Unknown",
+            "Macro",
+            "Close view",
+            "Distant view"
+        );
+    }
+
+    @Nullable
+    public String getLensSpecificationDescription()
+    {
+        return getLensSpecificationDescription(TAG_LENS_SPECIFICATION);
     }
 }

--- a/Source/com/drew/metadata/exif/ExifDirectoryBase.java
+++ b/Source/com/drew/metadata/exif/ExifDirectoryBase.java
@@ -230,6 +230,9 @@ public abstract class ExifDirectoryBase extends Directory
     public static final int TAG_SENSITIVITY_TYPE                  = 0x8830;
     public static final int TAG_STANDARD_OUTPUT_SENSITIVITY       = 0x8831;
     public static final int TAG_RECOMMENDED_EXPOSURE_INDEX        = 0x8832;
+    public static final int TAG_ISO_SPEED                         = 0x8833;
+    public static final int TAG_ISO_SPEED_LATITUDE_YYY            = 0x8834;
+    public static final int TAG_ISO_SPEED_LATITUDE_ZZZ            = 0x8835;
     /** Non-standard, but in use. */
     public static final int TAG_TIME_ZONE_OFFSET                  = 0x882A;
     public static final int TAG_SELF_TIMER_MODE                   = 0x882B;
@@ -237,6 +240,9 @@ public abstract class ExifDirectoryBase extends Directory
     public static final int TAG_EXIF_VERSION                      = 0x9000;
     public static final int TAG_DATETIME_ORIGINAL                 = 0x9003;
     public static final int TAG_DATETIME_DIGITIZED                = 0x9004;
+    public static final int TAG_OFFSET_TIME                       = 0x9010;
+    public static final int TAG_OFFSET_TIME_ORIGINAL              = 0x9011;
+    public static final int TAG_OFFSET_TIME_DIGITIZED             = 0x9012;
 
     public static final int TAG_COMPONENTS_CONFIGURATION          = 0x9101;
     /**
@@ -357,6 +363,13 @@ public abstract class ExifDirectoryBase extends Directory
     public static final int TAG_SUBSECOND_TIME                    = 0x9290;
     public static final int TAG_SUBSECOND_TIME_ORIGINAL           = 0x9291;
     public static final int TAG_SUBSECOND_TIME_DIGITIZED          = 0x9292;
+
+    public static final int TAG_TEMPERATURE                       = 0x9400;
+    public static final int TAG_HUMIDITY                          = 0x9401;
+    public static final int TAG_PRESSURE                          = 0x9402;
+    public static final int TAG_WATER_DEPTH                       = 0x9403;
+    public static final int TAG_ACCELERATION                      = 0x9404;
+    public static final int TAG_CAMERA_ELEVATION_ANGLE            = 0x9405;
 
     /** The image title, as used by Windows XP. */
     public static final int TAG_WIN_TITLE                         = 0x9C9B;
@@ -682,11 +695,17 @@ public abstract class ExifDirectoryBase extends Directory
         map.put(TAG_SENSITIVITY_TYPE, "Sensitivity Type");
         map.put(TAG_STANDARD_OUTPUT_SENSITIVITY, "Standard Output Sensitivity");
         map.put(TAG_RECOMMENDED_EXPOSURE_INDEX, "Recommended Exposure Index");
+        map.put(TAG_ISO_SPEED, "ISO Speed");
+        map.put(TAG_ISO_SPEED_LATITUDE_YYY, "ISO Speed Latitude yyy");
+        map.put(TAG_ISO_SPEED_LATITUDE_ZZZ, "ISO Speed Latitude zzz");
         map.put(TAG_TIME_ZONE_OFFSET, "Time Zone Offset");
         map.put(TAG_SELF_TIMER_MODE, "Self Timer Mode");
         map.put(TAG_EXIF_VERSION, "Exif Version");
         map.put(TAG_DATETIME_ORIGINAL, "Date/Time Original");
         map.put(TAG_DATETIME_DIGITIZED, "Date/Time Digitized");
+        map.put(TAG_OFFSET_TIME, "Offset Time");
+        map.put(TAG_OFFSET_TIME_ORIGINAL, "Offset Time Original");
+        map.put(TAG_OFFSET_TIME_DIGITIZED, "Offset Time Digitized");
         map.put(TAG_COMPONENTS_CONFIGURATION, "Components Configuration");
         map.put(TAG_COMPRESSED_AVERAGE_BITS_PER_PIXEL, "Compressed Bits Per Pixel");
         map.put(TAG_SHUTTER_SPEED, "Shutter Speed Value");
@@ -715,6 +734,12 @@ public abstract class ExifDirectoryBase extends Directory
         map.put(TAG_SUBSECOND_TIME, "Sub-Sec Time");
         map.put(TAG_SUBSECOND_TIME_ORIGINAL, "Sub-Sec Time Original");
         map.put(TAG_SUBSECOND_TIME_DIGITIZED, "Sub-Sec Time Digitized");
+        map.put(TAG_TEMPERATURE, "Temperature");
+        map.put(TAG_HUMIDITY, "Humidity");
+        map.put(TAG_PRESSURE, "Pressure");
+        map.put(TAG_WATER_DEPTH, "Water Depth");
+        map.put(TAG_ACCELERATION, "Acceleration");
+        map.put(TAG_CAMERA_ELEVATION_ANGLE, "Camera Elevation Angle");
         map.put(TAG_WIN_TITLE, "Windows XP Title");
         map.put(TAG_WIN_COMMENT, "Windows XP Comment");
         map.put(TAG_WIN_AUTHOR, "Windows XP Author");

--- a/Source/com/drew/metadata/exif/ExifSubIFDDirectory.java
+++ b/Source/com/drew/metadata/exif/ExifSubIFDDirectory.java
@@ -66,9 +66,10 @@ public class ExifSubIFDDirectory extends ExifDirectoryBase
     }
 
     /**
-     * Parses the date/time tag and the subsecond tag to obtain a single Date object with milliseconds
-     * representing the date and time when this image was captured.  Attempts will be made to parse the
-     * values as though it is in the GMT {@link TimeZone}.
+     * Parses the date/time tag, the subsecond tag and the time offset tag to obtain a single Date
+     * object with milliseconds representing the date and time when this image was captured.  If
+     * the time offset tag does not exist, attempts will be made to parse the values as though it is
+     * in the GMT {@link TimeZone}.
      *
      * @return A Date object representing when this image was captured, if possible, otherwise null
      */
@@ -79,10 +80,10 @@ public class ExifSubIFDDirectory extends ExifDirectoryBase
     }
 
     /**
-     * Parses the date/time tag and the subsecond tag to obtain a single Date object with milliseconds
-     * representing the date and time when this image was captured.  Attempts will be made to parse the
-     * values as though it is in the {@link TimeZone} represented by the {@code timeZone} parameter
-     * (if it is non-null).
+     * Parses the date/time tag, the subsecond tag and the time offset tag to obtain a single Date
+     * object with milliseconds representing the date and time when this image was captured.  If
+     * the time offset tag does not exist, attempts will be made to parse the values as though it is
+     * in the {@link TimeZone} represented by the {@code timeZone} parameter (if it is non-null).
      *
      * @param timeZone the time zone to use
      * @return A Date object representing when this image was captured, if possible, otherwise null
@@ -90,13 +91,18 @@ public class ExifSubIFDDirectory extends ExifDirectoryBase
     @Nullable
     public Date getDateOriginal(@Nullable TimeZone timeZone)
     {
+        String timeOffset = getString(TAG_OFFSET_TIME_ORIGINAL);
+        if (timeOffset != null && timeOffset.matches("[\\+\\-]\\d\\d:\\d\\d")) {
+            timeZone = TimeZone.getTimeZone("GMT" + timeOffset);
+        }
         return getDate(TAG_DATETIME_ORIGINAL, getString(TAG_SUBSECOND_TIME_ORIGINAL), timeZone);
     }
 
     /**
-     * Parses the date/time tag and the subsecond tag to obtain a single Date object with milliseconds
-     * representing the date and time when this image was digitized.  Attempts will be made to parse the
-     * values as though it is in the GMT {@link TimeZone}.
+     * Parses the date/time tag, the subsecond tag and the time offset tag to obtain a single Date
+     * object with milliseconds representing the date and time when this image was digitized.  If
+     * the time offset tag does not exist, attempts will be made to parse the values as though it is
+     * in the GMT {@link TimeZone}.
      *
      * @return A Date object representing when this image was digitized, if possible, otherwise null
      */
@@ -107,10 +113,10 @@ public class ExifSubIFDDirectory extends ExifDirectoryBase
     }
 
     /**
-     * Parses the date/time tag and the subsecond tag to obtain a single Date object with milliseconds
-     * representing the date and time when this image was digitized.  Attempts will be made to parse the
-     * values as though it is in the {@link TimeZone} represented by the {@code timeZone} parameter
-     * (if it is non-null).
+     * Parses the date/time tag, the subsecond tag and the time offset tag to obtain a single Date
+     * object with milliseconds representing the date and time when this image was digitized.  If
+     * the time offset tag does not exist, attempts will be made to parse the values as though it is
+     * in the {@link TimeZone} represented by the {@code timeZone} parameter (if it is non-null).
      *
      * @param timeZone the time zone to use
      * @return A Date object representing when this image was digitized, if possible, otherwise null
@@ -118,6 +124,10 @@ public class ExifSubIFDDirectory extends ExifDirectoryBase
     @Nullable
     public Date getDateDigitized(@Nullable TimeZone timeZone)
     {
+        String timeOffset = getString(TAG_OFFSET_TIME_DIGITIZED);
+        if (timeOffset != null && timeOffset.matches("[\\+\\-]\\d\\d:\\d\\d")) {
+            timeZone = TimeZone.getTimeZone("GMT" + timeOffset);
+        }
         return getDate(TAG_DATETIME_DIGITIZED, getString(TAG_SUBSECOND_TIME_DIGITIZED), timeZone);
     }
 }


### PR DESCRIPTION
- Add the following tags defined in [the Exif Version 2.31 specification](http://www.cipa.jp/std/documents/e/DC-008-Translation-2016-E.pdf):
  - `TAG_ISO_SPEED` (0x8833)
  - `TAG_ISO_SPEED_LATITUDE_YYY` (0x8834)
  - `TAG_ISO_SPEED_LATITUDE_ZZZ` (0x8835)
  - `TAG_OFFSET_TIME` (0x9010)
  - `TAG_OFFSET_TIME_ORIGINAL` (0x9011)
  - `TAG_OFFSET_TIME_DIGITIZED` (0x9012)
  - `TAG_TEMPERATURE` (0x9400)
  - `TAG_HUMIDITY` (0x9401)
  - `TAG_PRESSURE` (0x9402)
  - `TAG_WATER_DEPTH` (0x9403)
  - `TAG_ACCELERATION` (0x9404)
  - `TAG_CAMERA_ELEVATION_ANGLE` (0x9405)
- Add the following description methods:
  - `ExifDescriptorBase.getBrightnessValueDescription()`
  - `ExifDescriptorBase.getTemperatureDescription()`
  - `ExifDescriptorBase.getHumidityDescription()`
  - `ExifDescriptorBase.getPressureDescription()`
  - `ExifDescriptorBase.getWaterDepthDescription()`
  - `ExifDescriptorBase.getAccelerationDescription()`
  - `ExifDescriptorBase.getCameraElevationAngleDescription()`
- Check exceptional values (`0` and `0xFFFFFFFFL`) in `ExifDescriptorBase.getSubjectDistanceDescription()`
- In `ExifDescriptorBase`, order case blocks and corresponding methods in the same order as the `TAG_*` values are defined.
- Modify `ExifSubIFDDirectory.getDateOriginal()` and `ExifSubIFDDirectory.getDateDigitized()` to support reading `TAG_OFFSET_TIME_ORIGINAL` tag and `TAG_OFFSET_TIME_DIGITIZED` tag respectively.