### PR TITLE
Add getDateModified() methods to get composite values from multiple Exif tags

### DIFF
--- a/Tests/com/drew/metadata/exif/ExifDirectoryTest.java
+++ b/Tests/com/drew/metadata/exif/ExifDirectoryTest.java
@@ -88,6 +88,9 @@ public class ExifDirectoryTest
             exifSubIFDDirectory.getString(ExifSubIFDDirectory.TAG_SUBSECOND_TIME),
             TimeZone.getTimeZone("GMT+0100")
         ).getTime());
+
+        assertEquals(1066214228800L, exifSubIFDDirectory.getDateModified().getTime());
+        assertEquals(1066210628800L, exifSubIFDDirectory.getDateModified(TimeZone.getTimeZone("GMT+0100")).getTime());
         assertEquals(1066214228800L, exifSubIFDDirectory.getDateOriginal().getTime());
         assertEquals(1066210628800L, exifSubIFDDirectory.getDateOriginal(TimeZone.getTimeZone("GMT+0100")).getTime());
         assertEquals(1066214228800L, exifSubIFDDirectory.getDateDigitized().getTime());


### PR DESCRIPTION
This is an extension of #158.
- Add the following new methods to get composite values from `TAG_DATETIME`, `TAG_SUBSECOND_TIME` and `TAG_OFFSET_TIME`  tags
  - `ExifSubIFDDirectory.getDateModified()`
  - `ExifSubIFDDirectory.getDateModified(TimeZone timeZone)`
- Add `ExifSubIFDDirectory.getTimeZone()` common method
- Add corresponding tests