### PR TITLE
ThumbnailWrite method with storing the JpegSegments offset

### DIFF
--- a/Source/com/drew/imaging/jpeg/JpegMetadataReader.java
+++ b/Source/com/drew/imaging/jpeg/JpegMetadataReader.java
@@ -131,7 +131,7 @@ public class JpegMetadataReader
         // Pass the appropriate byte arrays to each reader.
         for (JpegSegmentMetadataReader reader : readers) {
             for (JpegSegmentType segmentType : reader.getSegmentTypes()) {
-                reader.readJpegSegments(segmentData.getSegments(segmentType), metadata, segmentType);
+                reader.readJpegSegments(segmentData.getSegmentsInfo(segmentType), metadata, segmentType);
             }
         }
     }

--- a/Source/com/drew/imaging/jpeg/JpegSegmentInfo.java
+++ b/Source/com/drew/imaging/jpeg/JpegSegmentInfo.java
@@ -1,0 +1,20 @@
+package com.drew.imaging.jpeg;
+
+public class JpegSegmentInfo {
+    public byte[] bytes;
+    public long fileOffset;
+
+    public JpegSegmentInfo() {
+
+    }
+
+    public JpegSegmentInfo(byte[] bytes) {
+        this.bytes = bytes;
+        this.fileOffset = 0;
+    }
+
+    public JpegSegmentInfo(byte[] bytes, long fileOffset) {
+        this.bytes = bytes;
+        this.fileOffset = fileOffset;
+    }
+}

--- a/Source/com/drew/imaging/jpeg/JpegSegmentMetadataReader.java
+++ b/Source/com/drew/imaging/jpeg/JpegSegmentMetadataReader.java
@@ -22,5 +22,5 @@ public interface JpegSegmentMetadataReader
      * @param metadata The {@link Metadata} object into which extracted values should be merged.
      * @param segmentType The {@link JpegSegmentType} being read.
      */
-    void readJpegSegments(@NotNull final Iterable<byte[]> segments, @NotNull final Metadata metadata, @NotNull final JpegSegmentType segmentType);
+    void readJpegSegments(@NotNull final Iterable<JpegSegmentInfo> segments, @NotNull final Metadata metadata, @NotNull final JpegSegmentType segmentType);
 }

--- a/Source/com/drew/imaging/jpeg/JpegSegmentReader.java
+++ b/Source/com/drew/imaging/jpeg/JpegSegmentReader.java
@@ -148,9 +148,10 @@ public class JpegSegmentReader
 
             // Check whether we are interested in this segment
             if (segmentTypeBytes == null || segmentTypeBytes.contains(segmentType)) {
+                long fileOffset =  reader.getPosition();
                 byte[] segmentBytes = reader.getBytes(segmentLength);
                 assert (segmentLength == segmentBytes.length);
-                segmentData.addSegment(segmentType, segmentBytes);
+                segmentData.addSegment(segmentType, fileOffset, segmentBytes);
             } else {
                 // Skip this segment
                 if (!reader.trySkip(segmentLength)) {

--- a/Source/com/drew/imaging/tiff/TiffReader.java
+++ b/Source/com/drew/imaging/tiff/TiffReader.java
@@ -23,6 +23,8 @@ package com.drew.imaging.tiff;
 import com.drew.lang.RandomAccessReader;
 import com.drew.lang.Rational;
 import com.drew.lang.annotations.NotNull;
+import com.drew.metadata.Directory;
+import com.drew.metadata.tiff.DirectoryTiffHandler;
 
 import java.io.IOException;
 import java.util.HashSet;
@@ -63,6 +65,13 @@ public class TiffReader
         // Check the next two values for correctness.
         final int tiffMarker = reader.getUInt16(2 + tiffHeaderOffset);
         handler.setTiffMarker(tiffMarker);
+
+        if (handler instanceof DirectoryTiffHandler) {
+            Directory currentDirectory = ((DirectoryTiffHandler) handler).getCurrentDirectory();
+            if (currentDirectory != null) {
+                currentDirectory.setFileDataOffset(reader.getOriginOffset());
+            }
+        }
 
         int firstIfdOffset = reader.getInt32(4 + tiffHeaderOffset) + tiffHeaderOffset;
 

--- a/Source/com/drew/lang/RandomAccessReader.java
+++ b/Source/com/drew/lang/RandomAccessReader.java
@@ -46,6 +46,16 @@ import java.nio.charset.Charset;
 public abstract class RandomAccessReader
 {
     private boolean _isMotorolaByteOrder = true;
+    private long _originOffset = 0;
+
+    public RandomAccessReader originOffset(long _originOffset) {
+        this._originOffset = _originOffset;
+        return this;
+    }
+
+    public long getOriginOffset() {
+        return _originOffset;
+    }
 
     public abstract int toUnshiftedOffset(int localOffset);
 

--- a/Source/com/drew/metadata/Directory.java
+++ b/Source/com/drew/metadata/Directory.java
@@ -67,6 +67,8 @@ public abstract class Directory
     @Nullable
     private Directory _parent;
 
+    private long fileDataOffset = 0;
+
 // ABSTRACT METHODS
 
     /**
@@ -89,6 +91,15 @@ public abstract class Directory
     {}
 
 // VARIOUS METHODS
+
+    public long getFileDataOffset() {
+        return fileDataOffset +
+            (_parent == null ? 0 : _parent.getFileDataOffset());
+    }
+
+    public void setFileDataOffset(long fileDataOffset) {
+        this.fileDataOffset = fileDataOffset;
+    }
 
     /**
      * Gets a value indicating whether the directory is empty, meaning it contains no errors and no tag values.

--- a/Source/com/drew/metadata/adobe/AdobeJpegReader.java
+++ b/Source/com/drew/metadata/adobe/AdobeJpegReader.java
@@ -21,6 +21,7 @@
 
 package com.drew.metadata.adobe;
 
+import com.drew.imaging.jpeg.JpegSegmentInfo;
 import com.drew.imaging.jpeg.JpegSegmentMetadataReader;
 import com.drew.imaging.jpeg.JpegSegmentType;
 import com.drew.lang.SequentialByteArrayReader;
@@ -49,11 +50,11 @@ public class AdobeJpegReader implements JpegSegmentMetadataReader
         return Collections.singletonList(JpegSegmentType.APPE);
     }
 
-    public void readJpegSegments(@NotNull Iterable<byte[]> segments, @NotNull Metadata metadata, @NotNull JpegSegmentType segmentType)
+    public void readJpegSegments(@NotNull Iterable<JpegSegmentInfo> segments, @NotNull Metadata metadata, @NotNull JpegSegmentType segmentType)
     {
-        for (byte[] bytes : segments) {
-            if (bytes.length == 12 && PREAMBLE.equalsIgnoreCase(new String(bytes, 0, PREAMBLE.length())))
-                extract(new SequentialByteArrayReader(bytes), metadata);
+        for (JpegSegmentInfo info : segments) {
+            if (info.bytes.length == 12 && PREAMBLE.equalsIgnoreCase(new String(info.bytes, 0, PREAMBLE.length())))
+                extract(new SequentialByteArrayReader(info.bytes), metadata);
         }
     }
 

--- a/Source/com/drew/metadata/exif/ExifReader.java
+++ b/Source/com/drew/metadata/exif/ExifReader.java
@@ -20,6 +20,7 @@
  */
 package com.drew.metadata.exif;
 
+import com.drew.imaging.jpeg.JpegSegmentInfo;
 import com.drew.imaging.jpeg.JpegSegmentMetadataReader;
 import com.drew.imaging.jpeg.JpegSegmentType;
 import com.drew.imaging.tiff.TiffProcessingException;
@@ -53,15 +54,15 @@ public class ExifReader implements JpegSegmentMetadataReader
         return Collections.singletonList(JpegSegmentType.APP1);
     }
 
-    public void readJpegSegments(@NotNull final Iterable<byte[]> segments, @NotNull final Metadata metadata, @NotNull final JpegSegmentType segmentType)
+    public void readJpegSegments(@NotNull final Iterable<JpegSegmentInfo> segments, @NotNull final Metadata metadata, @NotNull final JpegSegmentType segmentType)
     {
         assert(segmentType == JpegSegmentType.APP1);
 
-        for (byte[] segmentBytes : segments) {
+        for (JpegSegmentInfo info: segments) {
             // Filter any segments containing unexpected preambles
-            if (segmentBytes.length < JPEG_SEGMENT_PREAMBLE.length() || !new String(segmentBytes, 0, JPEG_SEGMENT_PREAMBLE.length()).equals(JPEG_SEGMENT_PREAMBLE))
+            if (info.bytes.length < JPEG_SEGMENT_PREAMBLE.length() || !new String(info.bytes, 0, JPEG_SEGMENT_PREAMBLE.length()).equals(JPEG_SEGMENT_PREAMBLE))
                 continue;
-            extract(new ByteArrayReader(segmentBytes), metadata, JPEG_SEGMENT_PREAMBLE.length());
+            extract(new ByteArrayReader(info.bytes).originOffset(info.fileOffset), metadata, JPEG_SEGMENT_PREAMBLE.length());
         }
     }
 

--- a/Source/com/drew/metadata/icc/IccReader.java
+++ b/Source/com/drew/metadata/icc/IccReader.java
@@ -20,6 +20,7 @@
  */
 package com.drew.metadata.icc;
 
+import com.drew.imaging.jpeg.JpegSegmentInfo;
 import com.drew.imaging.jpeg.JpegSegmentMetadataReader;
 import com.drew.imaging.jpeg.JpegSegmentType;
 import com.drew.lang.ByteArrayReader;
@@ -57,7 +58,7 @@ public class IccReader implements JpegSegmentMetadataReader, MetadataReader
         return Collections.singletonList(JpegSegmentType.APP2);
     }
 
-    public void readJpegSegments(@NotNull Iterable<byte[]> segments, @NotNull Metadata metadata, @NotNull JpegSegmentType segmentType)
+    public void readJpegSegments(@NotNull Iterable<JpegSegmentInfo> segments, @NotNull Metadata metadata, @NotNull JpegSegmentType segmentType)
     {
         final int preambleLength = JPEG_SEGMENT_PREAMBLE.length();
 
@@ -65,22 +66,22 @@ public class IccReader implements JpegSegmentMetadataReader, MetadataReader
         // We concat them together in this buffer for later processing.
         byte[] buffer = null;
 
-        for (byte[] segmentBytes : segments) {
+        for (JpegSegmentInfo info : segments) {
             // Skip any segments that do not contain the required preamble
-            if (segmentBytes.length < preambleLength || !JPEG_SEGMENT_PREAMBLE.equalsIgnoreCase(new String(segmentBytes, 0, preambleLength)))
+            if (info.bytes.length < preambleLength || !JPEG_SEGMENT_PREAMBLE.equalsIgnoreCase(new String(info.bytes, 0, preambleLength)))
                 continue;
 
             // NOTE we ignore three bytes here -- are they useful for anything?
 
             // Grow the buffer
             if (buffer == null) {
-                buffer = new byte[segmentBytes.length - 14];
+                buffer = new byte[info.bytes.length - 14];
                 // skip the first 14 bytes
-                System.arraycopy(segmentBytes, 14, buffer, 0, segmentBytes.length - 14);
+                System.arraycopy(info.bytes, 14, buffer, 0, info.bytes.length - 14);
             } else {
-                byte[] newBuffer = new byte[buffer.length + segmentBytes.length - 14];
+                byte[] newBuffer = new byte[buffer.length + info.bytes.length - 14];
                 System.arraycopy(buffer, 0, newBuffer, 0, buffer.length);
-                System.arraycopy(segmentBytes, 14, newBuffer, buffer.length, segmentBytes.length - 14);
+                System.arraycopy(info.bytes, 14, newBuffer, buffer.length, info.bytes.length - 14);
                 buffer = newBuffer;
             }
         }

--- a/Source/com/drew/metadata/iptc/IptcReader.java
+++ b/Source/com/drew/metadata/iptc/IptcReader.java
@@ -20,6 +20,7 @@
  */
 package com.drew.metadata.iptc;
 
+import com.drew.imaging.jpeg.JpegSegmentInfo;
 import com.drew.imaging.jpeg.JpegSegmentMetadataReader;
 import com.drew.imaging.jpeg.JpegSegmentType;
 import com.drew.lang.SequentialByteArrayReader;
@@ -65,12 +66,12 @@ public class IptcReader implements JpegSegmentMetadataReader
         return Collections.singletonList(JpegSegmentType.APPD);
     }
 
-    public void readJpegSegments(@NotNull Iterable<byte[]> segments, @NotNull Metadata metadata, @NotNull JpegSegmentType segmentType)
+    public void readJpegSegments(@NotNull Iterable<JpegSegmentInfo> segments, @NotNull Metadata metadata, @NotNull JpegSegmentType segmentType)
     {
-        for (byte[] segmentBytes : segments) {
+        for (JpegSegmentInfo info : segments) {
             // Ensure data starts with the IPTC marker byte
-            if (segmentBytes.length != 0 && segmentBytes[0] == IptcMarkerByte) {
-                extract(new SequentialByteArrayReader(segmentBytes), metadata, segmentBytes.length);
+            if (info.bytes.length != 0 && info.bytes[0] == IptcMarkerByte) {
+                extract(new SequentialByteArrayReader(info.bytes), metadata, info.bytes.length);
             }
         }
     }

--- a/Source/com/drew/metadata/jfif/JfifReader.java
+++ b/Source/com/drew/metadata/jfif/JfifReader.java
@@ -20,6 +20,7 @@
  */
 package com.drew.metadata.jfif;
 
+import com.drew.imaging.jpeg.JpegSegmentInfo;
 import com.drew.imaging.jpeg.JpegSegmentMetadataReader;
 import com.drew.imaging.jpeg.JpegSegmentType;
 import com.drew.lang.ByteArrayReader;
@@ -51,12 +52,12 @@ public class JfifReader implements JpegSegmentMetadataReader, MetadataReader
         return Collections.singletonList(JpegSegmentType.APP0);
     }
 
-    public void readJpegSegments(@NotNull Iterable<byte[]> segments, @NotNull Metadata metadata, @NotNull JpegSegmentType segmentType)
+    public void readJpegSegments(@NotNull Iterable<JpegSegmentInfo> segments, @NotNull Metadata metadata, @NotNull JpegSegmentType segmentType)
     {
-        for (byte[] segmentBytes : segments) {
+        for (JpegSegmentInfo info : segments) {
             // Skip segments not starting with the required header
-            if (segmentBytes.length >= PREAMBLE.length() && PREAMBLE.equals(new String(segmentBytes, 0, PREAMBLE.length())))
-                extract(new ByteArrayReader(segmentBytes), metadata);
+            if (info.bytes.length >= PREAMBLE.length() && PREAMBLE.equals(new String(info.bytes, 0, PREAMBLE.length())))
+                extract(new ByteArrayReader(info.bytes), metadata);
         }
     }
 

--- a/Source/com/drew/metadata/jfxx/JfxxReader.java
+++ b/Source/com/drew/metadata/jfxx/JfxxReader.java
@@ -20,6 +20,7 @@
  */
 package com.drew.metadata.jfxx;
 
+import com.drew.imaging.jpeg.JpegSegmentInfo;
 import com.drew.imaging.jpeg.JpegSegmentMetadataReader;
 import com.drew.imaging.jpeg.JpegSegmentType;
 import com.drew.lang.ByteArrayReader;
@@ -51,12 +52,12 @@ public class JfxxReader implements JpegSegmentMetadataReader, MetadataReader
         return Collections.singletonList(JpegSegmentType.APP0);
     }
 
-    public void readJpegSegments(@NotNull Iterable<byte[]> segments, @NotNull Metadata metadata, @NotNull JpegSegmentType segmentType)
+    public void readJpegSegments(@NotNull Iterable<JpegSegmentInfo> segments, @NotNull Metadata metadata, @NotNull JpegSegmentType segmentType)
     {
-        for (byte[] segmentBytes : segments) {
+        for (JpegSegmentInfo info : segments) {
             // Skip segments not starting with the required header
-            if (segmentBytes.length >= PREAMBLE.length() && PREAMBLE.equals(new String(segmentBytes, 0, PREAMBLE.length())))
-                extract(new ByteArrayReader(segmentBytes), metadata);
+            if (info.bytes.length >= PREAMBLE.length() && PREAMBLE.equals(new String(info.bytes, 0, PREAMBLE.length())))
+                extract(new ByteArrayReader(info.bytes), metadata);
         }
     }
 

--- a/Source/com/drew/metadata/jpeg/JpegCommentReader.java
+++ b/Source/com/drew/metadata/jpeg/JpegCommentReader.java
@@ -20,6 +20,7 @@
  */
 package com.drew.metadata.jpeg;
 
+import com.drew.imaging.jpeg.JpegSegmentInfo;
 import com.drew.imaging.jpeg.JpegSegmentMetadataReader;
 import com.drew.imaging.jpeg.JpegSegmentType;
 import com.drew.lang.annotations.NotNull;
@@ -42,14 +43,14 @@ public class JpegCommentReader implements JpegSegmentMetadataReader
         return Collections.singletonList(JpegSegmentType.COM);
     }
 
-    public void readJpegSegments(@NotNull Iterable<byte[]> segments, @NotNull Metadata metadata, @NotNull JpegSegmentType segmentType)
+    public void readJpegSegments(@NotNull Iterable<JpegSegmentInfo> segments, @NotNull Metadata metadata, @NotNull JpegSegmentType segmentType)
     {
-        for (byte[] segmentBytes : segments) {
+        for (JpegSegmentInfo info: segments) {
             JpegCommentDirectory directory = new JpegCommentDirectory();
             metadata.addDirectory(directory);
 
             // The entire contents of the directory are the comment
-            directory.setStringValue(JpegCommentDirectory.TAG_COMMENT, new StringValue(segmentBytes, null));
+            directory.setStringValue(JpegCommentDirectory.TAG_COMMENT, new StringValue(info.bytes, null));
         }
     }
 }

--- a/Source/com/drew/metadata/jpeg/JpegDhtReader.java
+++ b/Source/com/drew/metadata/jpeg/JpegDhtReader.java
@@ -20,6 +20,7 @@
  */
 package com.drew.metadata.jpeg;
 
+import com.drew.imaging.jpeg.JpegSegmentInfo;
 import com.drew.imaging.jpeg.JpegSegmentMetadataReader;
 import com.drew.imaging.jpeg.JpegSegmentType;
 import com.drew.lang.SequentialByteArrayReader;
@@ -44,10 +45,10 @@ public class JpegDhtReader implements JpegSegmentMetadataReader
         return Collections.singletonList(JpegSegmentType.DHT);
     }
 
-    public void readJpegSegments(@NotNull Iterable<byte[]> segments, @NotNull Metadata metadata, @NotNull JpegSegmentType segmentType)
+    public void readJpegSegments(@NotNull Iterable<JpegSegmentInfo> segments, @NotNull Metadata metadata, @NotNull JpegSegmentType segmentType)
     {
-        for (byte[] segmentBytes : segments) {
-            extract(new SequentialByteArrayReader(segmentBytes), metadata);
+        for (JpegSegmentInfo info : segments) {
+            extract(new SequentialByteArrayReader(info.bytes), metadata);
         }
     }
 

--- a/Source/com/drew/metadata/jpeg/JpegDnlReader.java
+++ b/Source/com/drew/metadata/jpeg/JpegDnlReader.java
@@ -20,6 +20,7 @@
  */
 package com.drew.metadata.jpeg;
 
+import com.drew.imaging.jpeg.JpegSegmentInfo;
 import com.drew.imaging.jpeg.JpegSegmentMetadataReader;
 import com.drew.imaging.jpeg.JpegSegmentType;
 import com.drew.lang.SequentialByteArrayReader;
@@ -44,10 +45,10 @@ public class JpegDnlReader implements JpegSegmentMetadataReader
         return Collections.singletonList(JpegSegmentType.DNL);
     }
 
-    public void readJpegSegments(@NotNull Iterable<byte[]> segments, @NotNull Metadata metadata, @NotNull JpegSegmentType segmentType)
+    public void readJpegSegments(@NotNull Iterable<JpegSegmentInfo> segments, @NotNull Metadata metadata, @NotNull JpegSegmentType segmentType)
     {
-        for (byte[] segmentBytes : segments) {
-            extract(segmentBytes, metadata, segmentType);
+        for (JpegSegmentInfo info : segments) {
+            extract(info.bytes, metadata, segmentType);
         }
     }
 

--- a/Source/com/drew/metadata/jpeg/JpegReader.java
+++ b/Source/com/drew/metadata/jpeg/JpegReader.java
@@ -20,6 +20,7 @@
  */
 package com.drew.metadata.jpeg;
 
+import com.drew.imaging.jpeg.JpegSegmentInfo;
 import com.drew.imaging.jpeg.JpegSegmentMetadataReader;
 import com.drew.imaging.jpeg.JpegSegmentType;
 import com.drew.lang.SequentialByteArrayReader;
@@ -62,10 +63,10 @@ public class JpegReader implements JpegSegmentMetadataReader
         );
     }
 
-    public void readJpegSegments(@NotNull Iterable<byte[]> segments, @NotNull Metadata metadata, @NotNull JpegSegmentType segmentType)
+    public void readJpegSegments(@NotNull Iterable<JpegSegmentInfo> segments, @NotNull Metadata metadata, @NotNull JpegSegmentType segmentType)
     {
-        for (byte[] segmentBytes : segments) {
-            extract(segmentBytes, metadata, segmentType);
+        for (JpegSegmentInfo info : segments) {
+            extract(info.bytes, metadata, segmentType);
         }
     }
 

--- a/Source/com/drew/metadata/photoshop/DuckyReader.java
+++ b/Source/com/drew/metadata/photoshop/DuckyReader.java
@@ -20,6 +20,7 @@
  */
 package com.drew.metadata.photoshop;
 
+import com.drew.imaging.jpeg.JpegSegmentInfo;
 import com.drew.imaging.jpeg.JpegSegmentMetadataReader;
 import com.drew.imaging.jpeg.JpegSegmentType;
 import com.drew.lang.Charsets;
@@ -48,17 +49,17 @@ public class DuckyReader implements JpegSegmentMetadataReader
         return Collections.singletonList(JpegSegmentType.APPC);
     }
 
-    public void readJpegSegments(@NotNull Iterable<byte[]> segments, @NotNull Metadata metadata, @NotNull JpegSegmentType segmentType)
+    public void readJpegSegments(@NotNull Iterable<JpegSegmentInfo> segments, @NotNull Metadata metadata, @NotNull JpegSegmentType segmentType)
     {
         final int preambleLength = JPEG_SEGMENT_PREAMBLE.length();
 
-        for (byte[] segmentBytes : segments) {
+        for (JpegSegmentInfo info : segments) {
             // Ensure data starts with the necessary preamble
-            if (segmentBytes.length < preambleLength || !JPEG_SEGMENT_PREAMBLE.equals(new String(segmentBytes, 0, preambleLength)))
+            if (info.bytes.length < preambleLength || !JPEG_SEGMENT_PREAMBLE.equals(new String(info.bytes, 0, preambleLength)))
                 continue;
 
             extract(
-                new SequentialByteArrayReader(segmentBytes, preambleLength),
+                new SequentialByteArrayReader(info.bytes, preambleLength),
                 metadata);
         }
     }

--- a/Source/com/drew/metadata/photoshop/PhotoshopReader.java
+++ b/Source/com/drew/metadata/photoshop/PhotoshopReader.java
@@ -21,6 +21,7 @@
 package com.drew.metadata.photoshop;
 
 import com.drew.imaging.ImageProcessingException;
+import com.drew.imaging.jpeg.JpegSegmentInfo;
 import com.drew.imaging.jpeg.JpegSegmentMetadataReader;
 import com.drew.imaging.jpeg.JpegSegmentType;
 import com.drew.lang.ByteArrayReader;
@@ -56,18 +57,18 @@ public class PhotoshopReader implements JpegSegmentMetadataReader
         return Collections.singletonList(JpegSegmentType.APPD);
     }
 
-    public void readJpegSegments(@NotNull Iterable<byte[]> segments, @NotNull Metadata metadata, @NotNull JpegSegmentType segmentType)
+    public void readJpegSegments(@NotNull Iterable<JpegSegmentInfo> segments, @NotNull Metadata metadata, @NotNull JpegSegmentType segmentType)
     {
         final int preambleLength = JPEG_SEGMENT_PREAMBLE.length();
 
-        for (byte[] segmentBytes : segments) {
+        for (JpegSegmentInfo info : segments) {
             // Ensure data starts with the necessary preamble
-            if (segmentBytes.length < preambleLength + 1 || !JPEG_SEGMENT_PREAMBLE.equals(new String(segmentBytes, 0, preambleLength)))
+            if (info.bytes.length < preambleLength + 1 || !JPEG_SEGMENT_PREAMBLE.equals(new String(info.bytes, 0, preambleLength)))
                 continue;
 
             extract(
-                new SequentialByteArrayReader(segmentBytes, preambleLength + 1),
-                segmentBytes.length - preambleLength - 1,
+                new SequentialByteArrayReader(info.bytes, preambleLength + 1),
+                info.bytes.length - preambleLength - 1,
                 metadata);
         }
     }

--- a/Source/com/drew/metadata/tiff/DirectoryTiffHandler.java
+++ b/Source/com/drew/metadata/tiff/DirectoryTiffHandler.java
@@ -96,6 +96,11 @@ public abstract class DirectoryTiffHandler implements TiffHandler
     }
 
     @NotNull
+    public Directory getCurrentDirectory() {
+        return _currentDirectory;
+    }
+
+    @NotNull
     private Directory getCurrentOrErrorDirectory()
     {
         if (_currentDirectory != null)

--- a/Tests/com/drew/metadata/exif/ExifReaderTest.java
+++ b/Tests/com/drew/metadata/exif/ExifReaderTest.java
@@ -20,6 +20,7 @@
  */
 package com.drew.metadata.exif;
 
+import com.drew.imaging.jpeg.JpegSegmentInfo;
 import com.drew.imaging.jpeg.JpegSegmentType;
 import com.drew.lang.ByteArrayReader;
 import com.drew.lang.Rational;
@@ -87,8 +88,8 @@ public class ExifReaderTest
     {
         byte[] badExifData = new byte[]{ 1,2,3,4,5,6,7,8,9,10 };
         Metadata metadata = new Metadata();
-        ArrayList<byte[]> segments = new ArrayList<byte[]>();
-        segments.add(badExifData);
+        ArrayList<JpegSegmentInfo> segments = new ArrayList<JpegSegmentInfo>();
+        segments.add(new JpegSegmentInfo(badExifData));
         new ExifReader().readJpegSegments(segments, metadata, JpegSegmentType.APP1);
         assertEquals(0, metadata.getDirectoryCount());
         assertFalse(metadata.hasErrors());

--- a/Tests/com/drew/metadata/icc/IccReaderTest.java
+++ b/Tests/com/drew/metadata/icc/IccReaderTest.java
@@ -21,6 +21,7 @@
 
 package com.drew.metadata.icc;
 
+import com.drew.imaging.jpeg.JpegSegmentInfo;
 import com.drew.imaging.jpeg.JpegSegmentType;
 import com.drew.lang.ByteArrayReader;
 import com.drew.metadata.Metadata;
@@ -62,7 +63,7 @@ public class IccReaderTest
         byte[] app2Bytes = FileUtil.readBytes("Tests/Data/iccDataInvalid1.jpg.app2");
 
         Metadata metadata = new Metadata();
-        new IccReader().readJpegSegments(Arrays.asList(app2Bytes), metadata, JpegSegmentType.APP2);
+        new IccReader().readJpegSegments(Arrays.asList(new JpegSegmentInfo(app2Bytes)), metadata, JpegSegmentType.APP2);
 
         IccDirectory directory = metadata.getFirstDirectoryOfType(IccDirectory.class);
 
@@ -76,7 +77,7 @@ public class IccReaderTest
         byte[] app2Bytes = FileUtil.readBytes("Tests/Data/withExifAndIptc.jpg.app2");
 
         Metadata metadata = new Metadata();
-        new IccReader().readJpegSegments(Arrays.asList(app2Bytes), metadata, JpegSegmentType.APP2);
+        new IccReader().readJpegSegments(Arrays.asList(new JpegSegmentInfo(app2Bytes)), metadata, JpegSegmentType.APP2);
 
         IccDirectory directory = metadata.getFirstDirectoryOfType(IccDirectory.class);
 

--- a/Tests/com/drew/metadata/xmp/XmpReaderTest.java
+++ b/Tests/com/drew/metadata/xmp/XmpReaderTest.java
@@ -20,6 +20,7 @@
  */
 package com.drew.metadata.xmp;
 
+import com.drew.imaging.jpeg.JpegSegmentInfo;
 import com.drew.imaging.jpeg.JpegSegmentType;
 import com.drew.metadata.Metadata;
 import com.drew.tools.FileUtil;
@@ -41,8 +42,8 @@ public class XmpReaderTest
     public void setUp() throws Exception
     {
         Metadata metadata = new Metadata();
-        List<byte[]> jpegSegments = new ArrayList<byte[]>();
-        jpegSegments.add(FileUtil.readBytes("Tests/Data/withXmpAndIptc.jpg.app1.1"));
+        List<JpegSegmentInfo> jpegSegments = new ArrayList<JpegSegmentInfo>();
+        jpegSegments.add(new JpegSegmentInfo(FileUtil.readBytes("Tests/Data/withXmpAndIptc.jpg.app1.1")));
         new XmpReader().readJpegSegments(jpegSegments, metadata, JpegSegmentType.APP1);
 
         Collection<XmpDirectory> xmpDirectories = metadata.getDirectoriesOfType(XmpDirectory.class);


### PR DESCRIPTION
This PR re-implements the method to write the Thumbnail into file without loading the bytes into memory during each image parsing.