### PR TITLE
Fix of the Flash description for Flash == OFF

### DIFF
--- a/Source/com/drew/metadata/exif/ExifDescriptorBase.java
+++ b/Source/com/drew/metadata/exif/ExifDescriptorBase.java
@@ -844,7 +844,8 @@ public abstract class ExifDescriptorBase<T extends Directory> extends TagDescrip
                 sb.append(", return not detected");
         }
 
-        if ((value & 0x10) != 0)
+        // If 0x10 is set and the lowest byte is not zero - then flash is Auto
+        if ((value & 0x10) != 0 && (value & 0x0F) != 0)
             sb.append(", auto");
 
         if ((value & 0x40) != 0)


### PR DESCRIPTION
For the case mentioned in #354
The case when the value is 0x10 - the description should say no Auto - as it is enforced to be OFF