### PR TITLE
Fix NikonType2 getPowerUpTimeDescription

### DIFF
--- a/Source/com/drew/metadata/exif/makernotes/NikonType2MakernoteDescriptor.java
+++ b/Source/com/drew/metadata/exif/makernotes/NikonType2MakernoteDescriptor.java
@@ -25,6 +25,7 @@ import com.drew.lang.annotations.NotNull;
 import com.drew.lang.annotations.Nullable;
 import com.drew.metadata.TagDescriptor;
 
+import java.nio.ByteBuffer;
 import java.text.DecimalFormat;
 
 import static com.drew.metadata.exif.makernotes.NikonType2MakernoteDirectory.*;
@@ -104,7 +105,15 @@ public class NikonType2MakernoteDescriptor extends TagDescriptor<NikonType2Maker
     @Nullable
     public String getPowerUpTimeDescription()
     {
-        return getEpochTimeDescription(TAG_POWER_UP_TIME);
+        // this is generally a byte[] of length 8 directly representing a date and time.
+        // the format is : first 2 bytes together are the year, and then each byte after
+        //                 is month, day, hour, minute, second with the eighth byte unused
+        // e.g., 2011:04:25 01:54:58
+
+        byte[] values = _directory.getByteArray(TAG_POWER_UP_TIME);
+        short year = ByteBuffer.wrap(new byte[]{values[0], values[1]}).getShort();
+        return String.format("%04d:%02d:%02d %02d:%02d:%02d", year, values[2], values[3], 
+                                                        values[4], values[5], values[6]);
     }
 
     @Nullable


### PR DESCRIPTION
With help from Exiftool sources - this value isn't a unix-style int64. The bytes directly describe the date and time.