### PR TITLE
Ignore invalid GIF XMP blocks

### DIFF
--- a/Source/com/drew/metadata/gif/GifReader.java
+++ b/Source/com/drew/metadata/gif/GifReader.java
@@ -272,7 +272,11 @@ public class GifReader
         {
             // XMP data extension
             byte[] xmpBytes = gatherBytes(reader);
-            new XmpReader().extract(xmpBytes, 0, xmpBytes.length - 257, metadata, null);
+            int xmpLengh = xmpBytes.length - 257; // Exclude the "magic trailer", see XMP Specification Part 3, 1.1.2 GIF
+            if (xmpLengh > 0) {
+                // Only extract valid blocks
+                new XmpReader().extract(xmpBytes, 0, xmpBytes.length - 257, metadata, null);
+            }
         }
         else if (extensionType.equals("ICCRGBG1012"))
         {


### PR DESCRIPTION
I've made `GitReader` ignore too short XMP blocks instead of failing with a `NegativeArraySizeException`. This fixes #351.

Below is the diff from processing the image database before and after this PR with https://github.com/drewnoakes/metadata-extractor-images/pull/23 included:
```diff
 gif/metadata/pbar-ani-invalid-XMP.gif.txt | 370 +++++++++++++++++++++++++++++-
 1 file changed, 369 insertions(+), 1 deletion(-)

diff --git a/gif/metadata/pbar-ani-invalid-XMP.gif.txt b/gif/metadata/pbar-ani-invalid-XMP.gif.txt
index db6aea5..3aafc7d 100644
--- a/gif/metadata/pbar-ani-invalid-XMP.gif.txt
+++ b/gif/metadata/pbar-ani-invalid-XMP.gif.txt
@@ -1,7 +1,375 @@
 FILE: pbar-ani-invalid-XMP.gif
 TYPE: GIF
 
-EXCEPTION: null
+[GIF Header - 0x0001] GIF Format Version = 89a
+[GIF Header - 0x0002] Image Width = 48
+[GIF Header - 0x0003] Image Height = 22
+[GIF Header - 0x0004] Color Table Size = 16
+[GIF Header - 0x0005] Is Color Table Sorted = false
+[GIF Header - 0x0006] Bits per Pixel = 8
+[GIF Header - 0x0007] Has Global Color Table = true
+[GIF Header - 0x0008] Background Color Index = 15
+
+[GIF Animation - 0x0001] Iteration Count = Infinite
+
+[GIF Control - 0x0002] Disposal Method = Don't Dispose
+[GIF Control - 0x0003] User Input Flag = false
+[GIF Control - 0x0004] Transparent Color Flag = true
+[GIF Control - 0x0001] Delay = 7
+[GIF Control - 0x0005] Transparent Color Index = 15
+
+[GIF Image - 0x0001] Left = 0
+[GIF Image - 0x0002] Top = 0
+[GIF Image - 0x0003] Width = 48
+[GIF Image - 0x0004] Height = 22
+[GIF Image - 0x0005] Has Local Colour Table = false
+[GIF Image - 0x0006] Is Interlaced = false
+
+[GIF Control - 0x0002] Disposal Method = Don't Dispose
+[GIF Control - 0x0003] User Input Flag = false
+[GIF Control - 0x0004] Transparent Color Flag = true
+[GIF Control - 0x0001] Delay = 7
+[GIF Control - 0x0005] Transparent Color Index = 15
+
+[GIF Image - 0x0001] Left = 0
+[GIF Image - 0x0002] Top = 0
+[GIF Image - 0x0003] Width = 48
+[GIF Image - 0x0004] Height = 22
+[GIF Image - 0x0005] Has Local Colour Table = false
+[GIF Image - 0x0006] Is Interlaced = false
+
+[GIF Control - 0x0002] Disposal Method = Don't Dispose
+[GIF Control - 0x0003] User Input Flag = false
+[GIF Control - 0x0004] Transparent Color Flag = true
+[GIF Control - 0x0001] Delay = 7
+[GIF Control - 0x0005] Transparent Color Index = 15
+
+[GIF Image - 0x0001] Left = 0
+[GIF Image - 0x0002] Top = 0
+[GIF Image - 0x0003] Width = 48
+[GIF Image - 0x0004] Height = 22
+[GIF Image - 0x0005] Has Local Colour Table = false
+[GIF Image - 0x0006] Is Interlaced = false
+
+[GIF Control - 0x0002] Disposal Method = Don't Dispose
+[GIF Control - 0x0003] User Input Flag = false
+[GIF Control - 0x0004] Transparent Color Flag = true
+[GIF Control - 0x0001] Delay = 7
+[GIF Control - 0x0005] Transparent Color Index = 15
+
+[GIF Image - 0x0001] Left = 0
+[GIF Image - 0x0002] Top = 0
+[GIF Image - 0x0003] Width = 48
+[GIF Image - 0x0004] Height = 22
+[GIF Image - 0x0005] Has Local Colour Table = false
+[GIF Image - 0x0006] Is Interlaced = false
+
+[GIF Control - 0x0002] Disposal Method = Don't Dispose
+[GIF Control - 0x0003] User Input Flag = false
+[GIF Control - 0x0004] Transparent Color Flag = true
+[GIF Control - 0x0001] Delay = 7
+[GIF Control - 0x0005] Transparent Color Index = 15
+
+[GIF Image - 0x0001] Left = 0
+[GIF Image - 0x0002] Top = 0
+[GIF Image - 0x0003] Width = 48
+[GIF Image - 0x0004] Height = 22
+[GIF Image - 0x0005] Has Local Colour Table = false
+[GIF Image - 0x0006] Is Interlaced = false
+
+[GIF Control - 0x0002] Disposal Method = Don't Dispose
+[GIF Control - 0x0003] User Input Flag = false
+[GIF Control - 0x0004] Transparent Color Flag = true
+[GIF Control - 0x0001] Delay = 7
+[GIF Control - 0x0005] Transparent Color Index = 15
+
+[GIF Image - 0x0001] Left = 0
+[GIF Image - 0x0002] Top = 0
+[GIF Image - 0x0003] Width = 48
+[GIF Image - 0x0004] Height = 22
+[GIF Image - 0x0005] Has Local Colour Table = false
+[GIF Image - 0x0006] Is Interlaced = false
+
+[GIF Control - 0x0002] Disposal Method = Don't Dispose
+[GIF Control - 0x0003] User Input Flag = false
+[GIF Control - 0x0004] Transparent Color Flag = true
+[GIF Control - 0x0001] Delay = 7
+[GIF Control - 0x0005] Transparent Color Index = 15
+
+[GIF Image - 0x0001] Left = 0
+[GIF Image - 0x0002] Top = 0
+[GIF Image - 0x0003] Width = 48
+[GIF Image - 0x0004] Height = 22
+[GIF Image - 0x0005] Has Local Colour Table = false
+[GIF Image - 0x0006] Is Interlaced = false
+
+[GIF Control - 0x0002] Disposal Method = Don't Dispose
+[GIF Control - 0x0003] User Input Flag = false
+[GIF Control - 0x0004] Transparent Color Flag = true
+[GIF Control - 0x0001] Delay = 7
+[GIF Control - 0x0005] Transparent Color Index = 15
+
+[GIF Image - 0x0001] Left = 0
+[GIF Image - 0x0002] Top = 0
+[GIF Image - 0x0003] Width = 48
+[GIF Image - 0x0004] Height = 22
+[GIF Image - 0x0005] Has Local Colour Table = false
+[GIF Image - 0x0006] Is Interlaced = false
+
+[GIF Control - 0x0002] Disposal Method = Don't Dispose
+[GIF Control - 0x0003] User Input Flag = false
+[GIF Control - 0x0004] Transparent Color Flag = true
+[GIF Control - 0x0001] Delay = 7
+[GIF Control - 0x0005] Transparent Color Index = 15
+
+[GIF Image - 0x0001] Left = 0
+[GIF Image - 0x0002] Top = 0
+[GIF Image - 0x0003] Width = 48
+[GIF Image - 0x0004] Height = 22
+[GIF Image - 0x0005] Has Local Colour Table = false
+[GIF Image - 0x0006] Is Interlaced = false
+
+[GIF Control - 0x0002] Disposal Method = Don't Dispose
+[GIF Control - 0x0003] User Input Flag = false
+[GIF Control - 0x0004] Transparent Color Flag = true
+[GIF Control - 0x0001] Delay = 7
+[GIF Control - 0x0005] Transparent Color Index = 15
+
+[GIF Image - 0x0001] Left = 0
+[GIF Image - 0x0002] Top = 0
+[GIF Image - 0x0003] Width = 48
+[GIF Image - 0x0004] Height = 22
+[GIF Image - 0x0005] Has Local Colour Table = false
+[GIF Image - 0x0006] Is Interlaced = false
+
+[GIF Control - 0x0002] Disposal Method = Don't Dispose
+[GIF Control - 0x0003] User Input Flag = false
+[GIF Control - 0x0004] Transparent Color Flag = true
+[GIF Control - 0x0001] Delay = 7
+[GIF Control - 0x0005] Transparent Color Index = 15
+
+[GIF Image - 0x0001] Left = 0
+[GIF Image - 0x0002] Top = 0
+[GIF Image - 0x0003] Width = 48
+[GIF Image - 0x0004] Height = 22
+[GIF Image - 0x0005] Has Local Colour Table = false
+[GIF Image - 0x0006] Is Interlaced = false
+
+[GIF Control - 0x0002] Disposal Method = Don't Dispose
+[GIF Control - 0x0003] User Input Flag = false
+[GIF Control - 0x0004] Transparent Color Flag = true
+[GIF Control - 0x0001] Delay = 7
+[GIF Control - 0x0005] Transparent Color Index = 15
+
+[GIF Image - 0x0001] Left = 0
+[GIF Image - 0x0002] Top = 0
+[GIF Image - 0x0003] Width = 48
+[GIF Image - 0x0004] Height = 22
+[GIF Image - 0x0005] Has Local Colour Table = false
+[GIF Image - 0x0006] Is Interlaced = false
+
+[GIF Control - 0x0002] Disposal Method = Don't Dispose
+[GIF Control - 0x0003] User Input Flag = false
+[GIF Control - 0x0004] Transparent Color Flag = true
+[GIF Control - 0x0001] Delay = 7
+[GIF Control - 0x0005] Transparent Color Index = 15
+
+[GIF Image - 0x0001] Left = 0
+[GIF Image - 0x0002] Top = 0
+[GIF Image - 0x0003] Width = 48
+[GIF Image - 0x0004] Height = 22
+[GIF Image - 0x0005] Has Local Colour Table = false
+[GIF Image - 0x0006] Is Interlaced = false
+
+[GIF Control - 0x0002] Disposal Method = Don't Dispose
+[GIF Control - 0x0003] User Input Flag = false
+[GIF Control - 0x0004] Transparent Color Flag = true
+[GIF Control - 0x0001] Delay = 7
+[GIF Control - 0x0005] Transparent Color Index = 15
+
+[GIF Image - 0x0001] Left = 0
+[GIF Image - 0x0002] Top = 0
+[GIF Image - 0x0003] Width = 48
+[GIF Image - 0x0004] Height = 22
+[GIF Image - 0x0005] Has Local Colour Table = false
+[GIF Image - 0x0006] Is Interlaced = false
+
+[GIF Control - 0x0002] Disposal Method = Don't Dispose
+[GIF Control - 0x0003] User Input Flag = false
+[GIF Control - 0x0004] Transparent Color Flag = true
+[GIF Control - 0x0001] Delay = 7
+[GIF Control - 0x0005] Transparent Color Index = 15
+
+[GIF Image - 0x0001] Left = 0
+[GIF Image - 0x0002] Top = 0
+[GIF Image - 0x0003] Width = 48
+[GIF Image - 0x0004] Height = 22
+[GIF Image - 0x0005] Has Local Colour Table = false
+[GIF Image - 0x0006] Is Interlaced = false
+
+[GIF Control - 0x0002] Disposal Method = Don't Dispose
+[GIF Control - 0x0003] User Input Flag = false
+[GIF Control - 0x0004] Transparent Color Flag = true
+[GIF Control - 0x0001] Delay = 7
+[GIF Control - 0x0005] Transparent Color Index = 15
+
+[GIF Image - 0x0001] Left = 0
+[GIF Image - 0x0002] Top = 0
+[GIF Image - 0x0003] Width = 48
+[GIF Image - 0x0004] Height = 22
+[GIF Image - 0x0005] Has Local Colour Table = false
+[GIF Image - 0x0006] Is Interlaced = false
+
+[GIF Control - 0x0002] Disposal Method = Don't Dispose
+[GIF Control - 0x0003] User Input Flag = false
+[GIF Control - 0x0004] Transparent Color Flag = true
+[GIF Control - 0x0001] Delay = 7
+[GIF Control - 0x0005] Transparent Color Index = 15
+
+[GIF Image - 0x0001] Left = 0
+[GIF Image - 0x0002] Top = 0
+[GIF Image - 0x0003] Width = 48
+[GIF Image - 0x0004] Height = 22
+[GIF Image - 0x0005] Has Local Colour Table = false
+[GIF Image - 0x0006] Is Interlaced = false
+
+[GIF Control - 0x0002] Disposal Method = Don't Dispose
+[GIF Control - 0x0003] User Input Flag = false
+[GIF Control - 0x0004] Transparent Color Flag = true
+[GIF Control - 0x0001] Delay = 7
+[GIF Control - 0x0005] Transparent Color Index = 15
+
+[GIF Image - 0x0001] Left = 0
+[GIF Image - 0x0002] Top = 0
+[GIF Image - 0x0003] Width = 48
+[GIF Image - 0x0004] Height = 22
+[GIF Image - 0x0005] Has Local Colour Table = false
+[GIF Image - 0x0006] Is Interlaced = false
+
+[GIF Control - 0x0002] Disposal Method = Don't Dispose
+[GIF Control - 0x0003] User Input Flag = false
+[GIF Control - 0x0004] Transparent Color Flag = true
+[GIF Control - 0x0001] Delay = 7
+[GIF Control - 0x0005] Transparent Color Index = 15
+
+[GIF Image - 0x0001] Left = 0
+[GIF Image - 0x0002] Top = 0
+[GIF Image - 0x0003] Width = 48
+[GIF Image - 0x0004] Height = 22
+[GIF Image - 0x0005] Has Local Colour Table = false
+[GIF Image - 0x0006] Is Interlaced = false
+
+[GIF Control - 0x0002] Disposal Method = Don't Dispose
+[GIF Control - 0x0003] User Input Flag = false
+[GIF Control - 0x0004] Transparent Color Flag = true
+[GIF Control - 0x0001] Delay = 7
+[GIF Control - 0x0005] Transparent Color Index = 15
+
+[GIF Image - 0x0001] Left = 0
+[GIF Image - 0x0002] Top = 0
+[GIF Image - 0x0003] Width = 48
+[GIF Image - 0x0004] Height = 22
+[GIF Image - 0x0005] Has Local Colour Table = false
+[GIF Image - 0x0006] Is Interlaced = false
+
+[GIF Control - 0x0002] Disposal Method = Don't Dispose
+[GIF Control - 0x0003] User Input Flag = false
+[GIF Control - 0x0004] Transparent Color Flag = true
+[GIF Control - 0x0001] Delay = 7
+[GIF Control - 0x0005] Transparent Color Index = 15
+
+[GIF Image - 0x0001] Left = 0
+[GIF Image - 0x0002] Top = 0
+[GIF Image - 0x0003] Width = 48
+[GIF Image - 0x0004] Height = 22
+[GIF Image - 0x0005] Has Local Colour Table = false
+[GIF Image - 0x0006] Is Interlaced = false
+
+[GIF Control - 0x0002] Disposal Method = Don't Dispose
+[GIF Control - 0x0003] User Input Flag = false
+[GIF Control - 0x0004] Transparent Color Flag = true
+[GIF Control - 0x0001] Delay = 7
+[GIF Control - 0x0005] Transparent Color Index = 15
+
+[GIF Image - 0x0001] Left = 0
+[GIF Image - 0x0002] Top = 0
+[GIF Image - 0x0003] Width = 48
+[GIF Image - 0x0004] Height = 22
+[GIF Image - 0x0005] Has Local Colour Table = false
+[GIF Image - 0x0006] Is Interlaced = false
+
+[GIF Control - 0x0002] Disposal Method = Don't Dispose
+[GIF Control - 0x0003] User Input Flag = false
+[GIF Control - 0x0004] Transparent Color Flag = true
+[GIF Control - 0x0001] Delay = 7
+[GIF Control - 0x0005] Transparent Color Index = 15
+
+[GIF Image - 0x0001] Left = 0
+[GIF Image - 0x0002] Top = 0
+[GIF Image - 0x0003] Width = 48
+[GIF Image - 0x0004] Height = 22
+[GIF Image - 0x0005] Has Local Colour Table = false
+[GIF Image - 0x0006] Is Interlaced = false
+
+[File Type - 0x0001] Detected File Type Name = GIF
+[File Type - 0x0002] Detected File Type Long Name = Graphics Interchange Format
+[File Type - 0x0003] Detected MIME Type = image/gif
+[File Type - 0x0004] Expected File Name Extension = gif
+
+[File - 0x0001] File Name = pbar-ani-invalid-XMP.gif
+[File - 0x0002] File Size = 7970 bytes
+[File - 0x0003] File Modified Date = <omitted for regression testing as checkout dependent>
+
+- GIF Header
+- GIF Animation
+- GIF Control
+- GIF Image
+- GIF Control
+- GIF Image
+- GIF Control
+- GIF Image
+- GIF Control
+- GIF Image
+- GIF Control
+- GIF Image
+- GIF Control
+- GIF Image
+- GIF Control
+- GIF Image
+- GIF Control
+- GIF Image
+- GIF Control
+- GIF Image
+- GIF Control
+- GIF Image
+- GIF Control
+- GIF Image
+- GIF Control
+- GIF Image
+- GIF Control
+- GIF Image
+- GIF Control
+- GIF Image
+- GIF Control
+- GIF Image
+- GIF Control
+- GIF Image
+- GIF Control
+- GIF Image
+- GIF Control
+- GIF Image
+- GIF Control
+- GIF Image
+- GIF Control
+- GIF Image
+- GIF Control
+- GIF Image
+- GIF Control
+- GIF Image
+- GIF Control
+- GIF Image
+- File Type
+- File
 
 Generated using metadata-extractor
 https://drewnoakes.com/code/exif/
```