### PR TITLE
Update xmpcore to 6.0.6

### DIFF
--- a/Source/com/drew/metadata/xmp/XmpDirectory.java
+++ b/Source/com/drew/metadata/xmp/XmpDirectory.java
@@ -20,11 +20,11 @@
  */
 package com.drew.metadata.xmp;
 
-import com.adobe.xmp.XMPException;
-import com.adobe.xmp.XMPMeta;
-import com.adobe.xmp.impl.XMPMetaImpl;
-import com.adobe.xmp.options.IteratorOptions;
-import com.adobe.xmp.properties.XMPPropertyInfo;
+import com.adobe.internal.xmp.XMPException;
+import com.adobe.internal.xmp.XMPMeta;
+import com.adobe.internal.xmp.impl.XMPMetaImpl;
+import com.adobe.internal.xmp.options.IteratorOptions;
+import com.adobe.internal.xmp.properties.XMPPropertyInfo;
 import com.drew.lang.annotations.NotNull;
 import com.drew.lang.annotations.Nullable;
 import com.drew.metadata.Directory;

--- a/Source/com/drew/metadata/xmp/XmpReader.java
+++ b/Source/com/drew/metadata/xmp/XmpReader.java
@@ -20,12 +20,12 @@
  */
 package com.drew.metadata.xmp;
 
-import com.adobe.xmp.XMPException;
-import com.adobe.xmp.XMPIterator;
-import com.adobe.xmp.XMPMeta;
-import com.adobe.xmp.XMPMetaFactory;
-import com.adobe.xmp.impl.ByteBuffer;
-import com.adobe.xmp.properties.XMPPropertyInfo;
+import com.adobe.internal.xmp.XMPException;
+import com.adobe.internal.xmp.XMPIterator;
+import com.adobe.internal.xmp.XMPMeta;
+import com.adobe.internal.xmp.XMPMetaFactory;
+import com.adobe.internal.xmp.impl.ByteBuffer;
+import com.adobe.internal.xmp.properties.XMPPropertyInfo;
 import com.drew.imaging.jpeg.JpegSegmentMetadataReader;
 import com.drew.imaging.jpeg.JpegSegmentType;
 import com.drew.lang.SequentialByteArrayReader;

--- a/Source/com/drew/metadata/xmp/XmpWriter.java
+++ b/Source/com/drew/metadata/xmp/XmpWriter.java
@@ -2,10 +2,10 @@ package com.drew.metadata.xmp;
 
 import java.io.OutputStream;
 
-import com.adobe.xmp.XMPException;
-import com.adobe.xmp.XMPMeta;
-import com.adobe.xmp.XMPMetaFactory;
-import com.adobe.xmp.options.SerializeOptions;
+import com.adobe.internal.xmp.XMPException;
+import com.adobe.internal.xmp.XMPMeta;
+import com.adobe.internal.xmp.XMPMetaFactory;
+import com.adobe.internal.xmp.options.SerializeOptions;
 import com.drew.metadata.Metadata;
 
 public class XmpWriter

--- a/Source/com/drew/tools/ProcessAllImagesInFolderUtility.java
+++ b/Source/com/drew/tools/ProcessAllImagesInFolderUtility.java
@@ -21,11 +21,11 @@
 
 package com.drew.tools;
 
-import com.adobe.xmp.XMPException;
-import com.adobe.xmp.XMPIterator;
-import com.adobe.xmp.XMPMeta;
-import com.adobe.xmp.options.IteratorOptions;
-import com.adobe.xmp.properties.XMPPropertyInfo;
+import com.adobe.internal.xmp.XMPException;
+import com.adobe.internal.xmp.XMPIterator;
+import com.adobe.internal.xmp.XMPMeta;
+import com.adobe.internal.xmp.options.IteratorOptions;
+import com.adobe.internal.xmp.properties.XMPPropertyInfo;
 import com.drew.imaging.FileType;
 import com.drew.imaging.FileTypeDetector;
 import com.drew.imaging.ImageMetadataReader;

--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,7 @@
         <dependency>
             <groupId>com.adobe.xmp</groupId>
             <artifactId>xmpcore</artifactId>
-            <version>5.1.3</version>
+            <version>6.0.6</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>


### PR DESCRIPTION
This updates `com.adobe.xmp:xmpcore` to 6.0.6. It's required for fixing extremely slow parsing when `photoshop:DocumentAncestors` node reaches over 100000 items. I will send the fix in another PR.