### PR TITLE
Fix frame rate calculation using handler duration

### DIFF
--- a/Source/com/drew/metadata/mp4/boxes/TimeToSampleBox.java
+++ b/Source/com/drew/metadata/mp4/boxes/TimeToSampleBox.java
@@ -49,7 +49,14 @@ public class TimeToSampleBox extends FullBox
 
     public void addMetadata(Mp4VideoDirectory directory)
     {
-        float frameRate = (float) Mp4HandlerFactory.HANDLER_PARAM_TIME_SCALE/(float)entries.get(0).sampleDelta;
+        float sampleCount = 0;
+
+        for (EntryCount ec : entries) {
+            sampleCount += ec.sampleCount;
+        }
+
+        float frameRate = (float) Mp4HandlerFactory.HANDLER_PARAM_TIME_SCALE/((float) Mp4HandlerFactory.HANDLER_PARAM_DURATION / sampleCount);
+
         directory.setFloat(Mp4VideoDirectory.TAG_FRAME_RATE, frameRate);
     }
 


### PR DESCRIPTION
Fixes #386 

After fix, new frame rates as shown below (with sample file provided in corresponding issue):

| Metadata-Extractor        | VLC           | Exiftool  | ffmpeg |
| :-------------: |:-------------:| :-----:|:--------:|
| 30.051      | 30.050836 | 30.051 | 30.05 |

All frame rates in metadata-extractor-images remain the same.