### PR TITLE
for compiling with java 11 or greater

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -158,6 +158,7 @@
                 <version>3.1.0</version>
                 <configuration>
                     <additionalJOption>${javadoc.opts}</additionalJOption>
+                    <source>1.6</source>
                     <stylesheetfile>${basedir}/src/main/javadoc/stylesheet.css</stylesheetfile>
                     <show>public</show>
                     <windowtitle>metadata-extractor - Javadoc - Extracts Exif, IPTC, XMP, ICC and other metadata from image and video files</windowtitle>


### PR DESCRIPTION
Without this on Java 11 results in ...

> [ERROR] Failed to execute goal org.apache.maven.plugins:maven-javadoc-plugin:3.1.0:jar (attach-javadocs) on project metadata-extractor: MavenReportException: Error while generating Javadoc: 
[ERROR] Exit code: 1 - javadoc: error - The code being documented uses modules but the packages defined in https://docs.oracle.com/javase/6/docs/api/ are in the unnamed module.
