### PR TITLE
Added support of standard ISO-8859-1 encoding

### DIFF
--- a/Source/com/drew/metadata/iptc/Iso2022Converter.java
+++ b/Source/com/drew/metadata/iptc/Iso2022Converter.java
@@ -37,6 +37,7 @@ public final class Iso2022Converter
     private static final int DOT = 0xe280a2;
     private static final byte LATIN_CAPITAL_G = 0x47;
     private static final byte PERCENT_SIGN = 0x25;
+    private static final byte DOT_SIGN = 0x2E;
     private static final byte ESC = 0x1B;
 
     /**
@@ -50,6 +51,9 @@ public final class Iso2022Converter
     {
         if (bytes.length > 2 && bytes[0] == ESC && bytes[1] == PERCENT_SIGN && bytes[2] == LATIN_CAPITAL_G)
             return UTF_8;
+
+        if (bytes.length > 2 && bytes[0] == ESC && bytes[1] == DOT_SIGN && bytes[2] == LATIN_CAPITAL_A)
+            return ISO_8859_1;
 
         if (bytes.length > 3 && bytes[0] == ESC && (bytes[3] & 0xFF | ((bytes[2] & 0xFF) << 8) | ((bytes[1] & 0xFF) << 16)) == DOT && bytes[4] == LATIN_CAPITAL_A)
             return ISO_8859_1;

--- a/Source/com/drew/metadata/iptc/Iso2022Converter.java
+++ b/Source/com/drew/metadata/iptc/Iso2022Converter.java
@@ -42,6 +42,7 @@ public final class Iso2022Converter
 
     /**
      * Converts the given ISO2022 char set to a Java charset name.
+     * A reference of valid charsets can be found here: http://nozer0.github.io/en/technology/system/character-encoding/#ISO/IEC%202022
      *
      * @param bytes string data encoded using ISO2022
      * @return the Java charset name as a string, or <code>null</code> if the conversion was not possible

--- a/Tests/com/drew/metadata/iptc/Iso2022ConverterTest.java
+++ b/Tests/com/drew/metadata/iptc/Iso2022ConverterTest.java
@@ -30,6 +30,7 @@ public class Iso2022ConverterTest
     public void testConvertISO2022CharsetToJavaCharset() throws Exception
     {
         assertEquals("UTF-8", Iso2022Converter.convertISO2022CharsetToJavaCharset(new byte[]{0x1B, 0x25, 0x47}));
+        assertEquals("ISO-8859-1", Iso2022Converter.convertISO2022CharsetToJavaCharset(new byte[]{0x1B, 0x2E, 0x41}));
         assertEquals("ISO-8859-1", Iso2022Converter.convertISO2022CharsetToJavaCharset(new byte[]{0x1B, (byte)0xE2, (byte)0x80, (byte)0xA2, 0x41}));
     }
 }


### PR DESCRIPTION
Fixes #437

Hey guys, we are using your framework in our company and face a situation where the encoding of our images can not be determined.

According to this page, the "1B 2E 41" which can be found in our "CodedCharacterSet" belongs to the ISO-8859-1 encoding.

http://nozer0.github.io/en/technology/system/character-encoding/