### PR TITLE
Remove static state from MP4/QuickTime handlers

### DIFF
--- a/Source/com/drew/imaging/mp4/Mp4Handler.java
+++ b/Source/com/drew/imaging/mp4/Mp4Handler.java
@@ -23,6 +23,7 @@ package com.drew.imaging.mp4;
 import com.drew.lang.annotations.NotNull;
 import com.drew.lang.annotations.Nullable;
 import com.drew.metadata.Metadata;
+import com.drew.metadata.mp4.Mp4Context;
 import com.drew.metadata.mp4.Mp4Directory;
 import com.drew.metadata.mp4.boxes.Box;
 
@@ -50,11 +51,11 @@ public abstract class Mp4Handler<T extends Mp4Directory>
 
     protected abstract boolean shouldAcceptContainer(@NotNull Box box);
 
-    protected abstract Mp4Handler processBox(@NotNull Box box, @Nullable byte[] payload) throws IOException;
+    protected abstract Mp4Handler processBox(@NotNull Box box, @Nullable byte[] payload, Mp4Context context) throws IOException;
 
-    protected Mp4Handler processContainer(@NotNull Box box) throws IOException
+    protected Mp4Handler processContainer(@NotNull Box box, @NotNull Mp4Context context) throws IOException
     {
-        return processBox(box, null);
+        return processBox(box, null, context);
     }
 
     public void addError(@NotNull String message)

--- a/Source/com/drew/imaging/mp4/Mp4Reader.java
+++ b/Source/com/drew/imaging/mp4/Mp4Reader.java
@@ -22,6 +22,7 @@ package com.drew.imaging.mp4;
 
 import com.drew.lang.StreamReader;
 import com.drew.lang.annotations.NotNull;
+import com.drew.metadata.mp4.Mp4Context;
 import com.drew.metadata.mp4.boxes.Box;
 
 import java.io.IOException;
@@ -39,10 +40,12 @@ public class Mp4Reader
         StreamReader reader = new StreamReader(inputStream);
         reader.setMotorolaByteOrder(true);
 
-        processBoxes(reader, -1, handler);
+        Mp4Context context = new Mp4Context();
+
+        processBoxes(reader, -1, handler, context);
     }
 
-    private static void processBoxes(StreamReader reader, long atomEnd, Mp4Handler handler)
+    private static void processBoxes(StreamReader reader, long atomEnd, Mp4Handler handler, Mp4Context context)
     {
         try {
             while (atomEnd == -1 || reader.getPosition() < atomEnd) {
@@ -53,9 +56,9 @@ public class Mp4Reader
                 // Unknown atoms will be skipped
 
                 if (handler.shouldAcceptContainer(box)) {
-                    processBoxes(reader, box.size + reader.getPosition() - 8, handler.processContainer(box));
+                    processBoxes(reader, box.size + reader.getPosition() - 8, handler.processContainer(box, context), context);
                 } else if (handler.shouldAcceptBox(box)) {
-                    handler = handler.processBox(box, reader.getBytes((int)box.size - 8));
+                    handler = handler.processBox(box, reader.getBytes((int)box.size - 8), context);
                 } else if (box.usertype != null) {
                     reader.skip(box.size - 24);
                 } else if (box.size > 1) {

--- a/Source/com/drew/imaging/quicktime/QuickTimeHandler.java
+++ b/Source/com/drew/imaging/quicktime/QuickTimeHandler.java
@@ -23,6 +23,7 @@ package com.drew.imaging.quicktime;
 import com.drew.lang.annotations.NotNull;
 import com.drew.lang.annotations.Nullable;
 import com.drew.metadata.Metadata;
+import com.drew.metadata.mov.QuickTimeContext;
 import com.drew.metadata.mov.QuickTimeDirectory;
 import com.drew.metadata.mov.atoms.Atom;
 
@@ -50,11 +51,11 @@ public abstract class QuickTimeHandler<T extends QuickTimeDirectory>
 
     protected abstract boolean shouldAcceptContainer(@NotNull Atom atom);
 
-    protected abstract QuickTimeHandler processAtom(@NotNull Atom atom, @Nullable byte[] payload) throws IOException;
+    protected abstract QuickTimeHandler processAtom(@NotNull Atom atom, @Nullable byte[] payload, QuickTimeContext context) throws IOException;
 
-    protected QuickTimeHandler processContainer(@NotNull Atom atom) throws IOException
+    protected QuickTimeHandler processContainer(@NotNull Atom atom, QuickTimeContext context) throws IOException
     {
-        return processAtom(atom, null);
+        return processAtom(atom, null, context);
     }
 
     public void addError(@NotNull String message)

--- a/Source/com/drew/imaging/quicktime/QuickTimeReader.java
+++ b/Source/com/drew/imaging/quicktime/QuickTimeReader.java
@@ -22,8 +22,7 @@ package com.drew.imaging.quicktime;
 
 import com.drew.lang.StreamReader;
 import com.drew.lang.annotations.NotNull;
-import com.drew.metadata.Metadata;
-import com.drew.metadata.mov.QuickTimeDirectory;
+import com.drew.metadata.mov.QuickTimeContext;
 import com.drew.metadata.mov.atoms.Atom;
 
 import java.io.IOException;
@@ -41,10 +40,12 @@ public class QuickTimeReader
         StreamReader reader = new StreamReader(inputStream);
         reader.setMotorolaByteOrder(true);
 
-        processAtoms(reader, -1, handler);
+        QuickTimeContext context = new QuickTimeContext();
+
+        processAtoms(reader, -1, handler, context);
     }
 
-    private static void processAtoms(StreamReader reader, long atomEnd, QuickTimeHandler handler)
+    private static void processAtoms(StreamReader reader, long atomEnd, QuickTimeHandler handler, QuickTimeContext context)
     {
         try {
             while (atomEnd == -1 || reader.getPosition() < atomEnd) {
@@ -55,9 +56,9 @@ public class QuickTimeReader
                 // Unknown atoms will be skipped
 
                 if (handler.shouldAcceptContainer(atom)) {
-                    processAtoms(reader, atom.size + reader.getPosition() - 8, handler.processContainer(atom));
+                    processAtoms(reader, atom.size + reader.getPosition() - 8, handler.processContainer(atom, context), context);
                 } else if (handler.shouldAcceptAtom(atom)) {
-                    handler = handler.processAtom(atom, reader.getBytes((int)atom.size - 8));
+                    handler = handler.processAtom(atom, reader.getBytes((int)atom.size - 8), context);
                 } else if (atom.size > 1) {
                     reader.skip(atom.size - 8);
                 } else if (atom.size == -1) {

--- a/Source/com/drew/metadata/mov/QuickTimeAtomHandler.java
+++ b/Source/com/drew/metadata/mov/QuickTimeAtomHandler.java
@@ -71,7 +71,7 @@ public class QuickTimeAtomHandler extends QuickTimeHandler<QuickTimeDirectory>
     }
 
     @Override
-    public QuickTimeHandler processAtom(@NotNull Atom atom, @Nullable byte[] payload) throws IOException
+    public QuickTimeHandler processAtom(@NotNull Atom atom, @Nullable byte[] payload, QuickTimeContext context) throws IOException
     {
         if (payload != null) {
             SequentialReader reader = new SequentialByteArrayReader(payload);
@@ -84,9 +84,9 @@ public class QuickTimeAtomHandler extends QuickTimeHandler<QuickTimeDirectory>
                 fileTypeCompatibilityAtom.addMetadata(directory);
             } else if (atom.type.equals(QuickTimeAtomTypes.ATOM_HANDLER)) {
                 HandlerReferenceAtom handlerReferenceAtom = new HandlerReferenceAtom(reader, atom);
-                return handlerFactory.getHandler(handlerReferenceAtom.getComponentType(), metadata);
+                return handlerFactory.getHandler(handlerReferenceAtom.getComponentType(), metadata, context);
             } else if (atom.type.equals(QuickTimeAtomTypes.ATOM_MEDIA_HEADER)) {
-                new MediaHeaderAtom(reader, atom);
+                new MediaHeaderAtom(reader, atom, context);
             } else if (atom.type.equals(QuickTimeAtomTypes.ATOM_CANON_THUMBNAIL)) {
                 CanonThumbnailAtom canonThumbnailAtom = new CanonThumbnailAtom(reader);
                 canonThumbnailAtom.addMetadata(directory);

--- a/Source/com/drew/metadata/mov/QuickTimeContext.java
+++ b/Source/com/drew/metadata/mov/QuickTimeContext.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2002-2019 Drew Noakes and contributors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ * More information about this project is available at:
+ *
+ *    https://drewnoakes.com/code/exif/
+ *    https://github.com/drewnoakes/metadata-extractor
+ */
+package com.drew.metadata.mov;
+
+public class QuickTimeContext
+{
+    public Long creationTime;
+    public Long modificationTime;
+    public Long timeScale;
+    public Long duration;
+}

--- a/Source/com/drew/metadata/mov/QuickTimeHandlerFactory.java
+++ b/Source/com/drew/metadata/mov/QuickTimeHandlerFactory.java
@@ -42,34 +42,29 @@ public class QuickTimeHandlerFactory
 
     private QuickTimeHandler caller;
 
-    public static Long HANDLER_PARAM_TIME_SCALE              = null;
-    public static Long HANDLER_PARAM_CREATION_TIME           = null;
-    public static Long HANDLER_PARAM_MODIFICATION_TIME       = null;
-    public static Long HANDLER_PARAM_DURATION                = null;
-
     public QuickTimeHandlerFactory(QuickTimeHandler caller)
     {
         this.caller = caller;
     }
 
-    public QuickTimeHandler getHandler(String type, Metadata metadata)
+    public QuickTimeHandler getHandler(String type, Metadata metadata, QuickTimeContext context)
     {
         if (type.equals(HANDLER_METADATA_DIRECTORY)) {
             return new QuickTimeDirectoryHandler(metadata);
         } else if (type.equals(HANDLER_METADATA_DATA)) {
             return new QuickTimeDataHandler(metadata);
         } else if (type.equals(HANDLER_SOUND_MEDIA)) {
-            return new QuickTimeSoundHandler(metadata);
+            return new QuickTimeSoundHandler(metadata, context);
         } else if (type.equals(HANDLER_VIDEO_MEDIA)) {
-            return new QuickTimeVideoHandler(metadata);
+            return new QuickTimeVideoHandler(metadata, context);
         } else if (type.equals(HANDLER_TIMECODE_MEDIA)) {
-            return new QuickTimeTimecodeHandler(metadata);
+            return new QuickTimeTimecodeHandler(metadata, context);
         } else if (type.equals(HANDLER_TEXT_MEDIA)) {
-            return new QuickTimeTextHandler(metadata);
+            return new QuickTimeTextHandler(metadata, context);
         } else if (type.equals(HANDLER_SUBTITLE_MEDIA)) {
-            return new QuickTimeSubtitleHandler(metadata);
+            return new QuickTimeSubtitleHandler(metadata, context);
         } else if (type.equals(HANDLER_MUSIC_MEDIA)) {
-            return new QuickTimeMusicHandler(metadata);
+            return new QuickTimeMusicHandler(metadata, context);
         }
         return caller;
     }

--- a/Source/com/drew/metadata/mov/QuickTimeMediaHandler.java
+++ b/Source/com/drew/metadata/mov/QuickTimeMediaHandler.java
@@ -39,19 +39,19 @@ import java.io.IOException;
  */
 public abstract class QuickTimeMediaHandler<T extends QuickTimeDirectory> extends QuickTimeHandler<T>
 {
-    public QuickTimeMediaHandler(Metadata metadata)
+    public QuickTimeMediaHandler(Metadata metadata, QuickTimeContext context)
     {
         super(metadata);
 
-        if (QuickTimeHandlerFactory.HANDLER_PARAM_CREATION_TIME != null && QuickTimeHandlerFactory.HANDLER_PARAM_MODIFICATION_TIME != null) {
+        if (context.creationTime != null && context.modificationTime != null) {
             // Get creation/modification times
             directory.setDate(
                 QuickTimeMediaDirectory.TAG_CREATION_TIME,
-                DateUtil.get1Jan1904EpochDate(QuickTimeHandlerFactory.HANDLER_PARAM_CREATION_TIME)
+                DateUtil.get1Jan1904EpochDate(context.creationTime)
             );
             directory.setDate(
                 QuickTimeMediaDirectory.TAG_MODIFICATION_TIME,
-                DateUtil.get1Jan1904EpochDate(QuickTimeHandlerFactory.HANDLER_PARAM_MODIFICATION_TIME)
+                DateUtil.get1Jan1904EpochDate(context.modificationTime)
             );
         }
     }
@@ -74,7 +74,7 @@ public abstract class QuickTimeMediaHandler<T extends QuickTimeDirectory> extend
     }
 
     @Override
-    public QuickTimeMediaHandler processAtom(@NotNull Atom atom, @Nullable byte[] payload) throws IOException
+    public QuickTimeMediaHandler processAtom(@NotNull Atom atom, @Nullable byte[] payload, QuickTimeContext context) throws IOException
     {
         if (payload != null) {
             SequentialReader reader = new SequentialByteArrayReader(payload);
@@ -83,7 +83,7 @@ public abstract class QuickTimeMediaHandler<T extends QuickTimeDirectory> extend
             } else if (atom.type.equals(QuickTimeAtomTypes.ATOM_SAMPLE_DESCRIPTION)) {
                 processSampleDescription(reader, atom);
             } else if (atom.type.equals(QuickTimeAtomTypes.ATOM_TIME_TO_SAMPLE)) {
-                processTimeToSample(reader, atom);
+                processTimeToSample(reader, atom, context);
             }
         }
         return this;
@@ -95,5 +95,5 @@ public abstract class QuickTimeMediaHandler<T extends QuickTimeDirectory> extend
 
     protected abstract void processMediaInformation(@NotNull SequentialReader reader, @NotNull Atom atom) throws IOException;
 
-    protected abstract void processTimeToSample(@NotNull SequentialReader reader, @NotNull Atom atom) throws IOException;
+    protected abstract void processTimeToSample(@NotNull SequentialReader reader, @NotNull Atom atom, QuickTimeContext context) throws IOException;
 }

--- a/Source/com/drew/metadata/mov/QuickTimeMetadataHandler.java
+++ b/Source/com/drew/metadata/mov/QuickTimeMetadataHandler.java
@@ -62,7 +62,7 @@ public abstract class QuickTimeMetadataHandler extends QuickTimeHandler
     }
 
     @Override
-    protected QuickTimeHandler processAtom(@NotNull Atom atom, @Nullable byte[] payload) throws IOException
+    protected QuickTimeHandler processAtom(@NotNull Atom atom, @Nullable byte[] payload, QuickTimeContext context) throws IOException
     {
         if (payload != null) {
             SequentialByteArrayReader reader = new SequentialByteArrayReader(payload);

--- a/Source/com/drew/metadata/mov/atoms/MediaHeaderAtom.java
+++ b/Source/com/drew/metadata/mov/atoms/MediaHeaderAtom.java
@@ -21,6 +21,7 @@
 package com.drew.metadata.mov.atoms;
 
 import com.drew.lang.SequentialReader;
+import com.drew.metadata.mov.QuickTimeContext;
 import com.drew.metadata.mov.QuickTimeHandlerFactory;
 
 import java.io.IOException;
@@ -32,28 +33,15 @@ import java.io.IOException;
  */
 public class MediaHeaderAtom extends FullAtom
 {
-    long creationTime;
-    long modificationTime;
-    long timescale;
-    long duration;
-    int language;
-    int quality;
-
-    public MediaHeaderAtom(SequentialReader reader, Atom atom) throws IOException
+    public MediaHeaderAtom(SequentialReader reader, Atom atom, QuickTimeContext context) throws IOException
     {
         super(reader, atom);
 
-        creationTime = reader.getUInt32();
-        modificationTime = reader.getUInt32();
-        timescale = reader.getUInt32();
-        duration = reader.getUInt32();
-        language = reader.getUInt16();
-        quality = reader.getUInt16();
-
-        // TODO can't use static fields here as it breaks concurrency
-        QuickTimeHandlerFactory.HANDLER_PARAM_CREATION_TIME = creationTime;
-        QuickTimeHandlerFactory.HANDLER_PARAM_MODIFICATION_TIME = modificationTime;
-        QuickTimeHandlerFactory.HANDLER_PARAM_TIME_SCALE = timescale;
-        QuickTimeHandlerFactory.HANDLER_PARAM_DURATION = duration;
+        context.creationTime = reader.getUInt32();
+        context.modificationTime = reader.getUInt32();
+        context.timeScale = reader.getUInt32();
+        context.duration = reader.getUInt32();
+        int language = reader.getUInt16();
+        int quality = reader.getUInt16();
     }
 }

--- a/Source/com/drew/metadata/mov/atoms/TimeToSampleAtom.java
+++ b/Source/com/drew/metadata/mov/atoms/TimeToSampleAtom.java
@@ -21,6 +21,7 @@
 package com.drew.metadata.mov.atoms;
 
 import com.drew.lang.SequentialReader;
+import com.drew.metadata.mov.QuickTimeContext;
 import com.drew.metadata.mov.QuickTimeHandlerFactory;
 import com.drew.metadata.mov.media.QuickTimeVideoDirectory;
 
@@ -36,8 +37,6 @@ public class TimeToSampleAtom extends FullAtom
 {
     long numberOfEntries;
     ArrayList<Entry> entries;
-    long sampleCount;
-    long sampleDuration;
 
     public TimeToSampleAtom(SequentialReader reader, Atom atom) throws IOException
     {
@@ -62,9 +61,9 @@ public class TimeToSampleAtom extends FullAtom
         }
     }
 
-    public void addMetadata(QuickTimeVideoDirectory directory)
+    public void addMetadata(QuickTimeVideoDirectory directory, QuickTimeContext context)
     {
-        float frameRate = (float) QuickTimeHandlerFactory.HANDLER_PARAM_TIME_SCALE/(float)entries.get(0).sampleDuration;
+        float frameRate = (float) context.timeScale / (float)entries.get(0).sampleDuration;
         directory.setFloat(QuickTimeVideoDirectory.TAG_FRAME_RATE, frameRate);
     }
 }

--- a/Source/com/drew/metadata/mov/media/QuickTimeMusicHandler.java
+++ b/Source/com/drew/metadata/mov/media/QuickTimeMusicHandler.java
@@ -23,6 +23,7 @@ package com.drew.metadata.mov.media;
 import com.drew.lang.SequentialReader;
 import com.drew.lang.annotations.NotNull;
 import com.drew.metadata.Metadata;
+import com.drew.metadata.mov.QuickTimeContext;
 import com.drew.metadata.mov.QuickTimeMediaHandler;
 import com.drew.metadata.mov.atoms.Atom;
 import com.drew.metadata.mov.atoms.MusicSampleDescriptionAtom;
@@ -34,9 +35,9 @@ import java.io.IOException;
  */
 public class QuickTimeMusicHandler extends QuickTimeMediaHandler<QuickTimeMusicDirectory>
 {
-    public QuickTimeMusicHandler(Metadata metadata)
+    public QuickTimeMusicHandler(Metadata metadata, QuickTimeContext context)
     {
-        super(metadata);
+        super(metadata, context);
     }
 
     @NotNull
@@ -66,7 +67,7 @@ public class QuickTimeMusicHandler extends QuickTimeMediaHandler<QuickTimeMusicD
     }
 
     @Override
-    protected void processTimeToSample(@NotNull SequentialReader reader, @NotNull Atom atom) throws IOException
+    protected void processTimeToSample(@NotNull SequentialReader reader, @NotNull Atom atom, QuickTimeContext context) throws IOException
     {
         // Not yet implemented
     }

--- a/Source/com/drew/metadata/mov/media/QuickTimeSoundHandler.java
+++ b/Source/com/drew/metadata/mov/media/QuickTimeSoundHandler.java
@@ -35,9 +35,9 @@ import java.io.IOException;
  */
 public class QuickTimeSoundHandler extends QuickTimeMediaHandler<QuickTimeSoundDirectory>
 {
-    public QuickTimeSoundHandler(Metadata metadata)
+    public QuickTimeSoundHandler(Metadata metadata, QuickTimeContext context)
     {
-        super(metadata);
+        super(metadata, context);
     }
 
     @NotNull
@@ -68,8 +68,8 @@ public class QuickTimeSoundHandler extends QuickTimeMediaHandler<QuickTimeSoundD
     }
 
     @Override
-    protected void processTimeToSample(@NotNull SequentialReader reader, @NotNull Atom atom) throws IOException
+    protected void processTimeToSample(@NotNull SequentialReader reader, @NotNull Atom atom, QuickTimeContext context) throws IOException
     {
-        directory.setDouble(QuickTimeSoundDirectory.TAG_AUDIO_SAMPLE_RATE, QuickTimeHandlerFactory.HANDLER_PARAM_TIME_SCALE);
+        directory.setDouble(QuickTimeSoundDirectory.TAG_AUDIO_SAMPLE_RATE, context.timeScale);
     }
 }

--- a/Source/com/drew/metadata/mov/media/QuickTimeSubtitleHandler.java
+++ b/Source/com/drew/metadata/mov/media/QuickTimeSubtitleHandler.java
@@ -23,6 +23,7 @@ package com.drew.metadata.mov.media;
 import com.drew.lang.SequentialReader;
 import com.drew.lang.annotations.NotNull;
 import com.drew.metadata.Metadata;
+import com.drew.metadata.mov.QuickTimeContext;
 import com.drew.metadata.mov.QuickTimeMediaHandler;
 import com.drew.metadata.mov.atoms.Atom;
 import com.drew.metadata.mov.atoms.SubtitleSampleDescriptionAtom;
@@ -34,9 +35,9 @@ import java.io.IOException;
  */
 public class QuickTimeSubtitleHandler extends QuickTimeMediaHandler<QuickTimeSubtitleDirectory>
 {
-    public QuickTimeSubtitleHandler(Metadata metadata)
+    public QuickTimeSubtitleHandler(Metadata metadata, QuickTimeContext context)
     {
-        super(metadata);
+        super(metadata, context);
     }
 
     @NotNull
@@ -67,7 +68,7 @@ public class QuickTimeSubtitleHandler extends QuickTimeMediaHandler<QuickTimeSub
     }
 
     @Override
-    protected void processTimeToSample(@NotNull SequentialReader reader, @NotNull Atom atom) throws IOException
+    protected void processTimeToSample(@NotNull SequentialReader reader, @NotNull Atom atom, QuickTimeContext context) throws IOException
     {
         // Not yet implemented
     }

--- a/Source/com/drew/metadata/mov/media/QuickTimeTextHandler.java
+++ b/Source/com/drew/metadata/mov/media/QuickTimeTextHandler.java
@@ -24,6 +24,7 @@ import com.drew.lang.SequentialReader;
 import com.drew.lang.annotations.NotNull;
 import com.drew.metadata.Metadata;
 import com.drew.metadata.mov.QuickTimeAtomTypes;
+import com.drew.metadata.mov.QuickTimeContext;
 import com.drew.metadata.mov.QuickTimeMediaHandler;
 import com.drew.metadata.mov.atoms.Atom;
 import com.drew.metadata.mov.atoms.TextSampleDescriptionAtom;
@@ -35,9 +36,9 @@ import java.io.IOException;
  */
 public class QuickTimeTextHandler extends QuickTimeMediaHandler<QuickTimeTextDirectory>
 {
-    public QuickTimeTextHandler(Metadata metadata)
+    public QuickTimeTextHandler(Metadata metadata, QuickTimeContext context)
     {
-        super(metadata);
+        super(metadata, context);
     }
 
     @NotNull
@@ -67,7 +68,7 @@ public class QuickTimeTextHandler extends QuickTimeMediaHandler<QuickTimeTextDir
     }
 
     @Override
-    protected void processTimeToSample(@NotNull SequentialReader reader, @NotNull Atom atom) throws IOException
+    protected void processTimeToSample(@NotNull SequentialReader reader, @NotNull Atom atom, QuickTimeContext context) throws IOException
     {
         // Not yet implemented
     }

--- a/Source/com/drew/metadata/mov/media/QuickTimeTimecodeHandler.java
+++ b/Source/com/drew/metadata/mov/media/QuickTimeTimecodeHandler.java
@@ -24,6 +24,7 @@ import com.drew.lang.SequentialReader;
 import com.drew.lang.annotations.NotNull;
 import com.drew.metadata.Metadata;
 import com.drew.metadata.mov.QuickTimeAtomTypes;
+import com.drew.metadata.mov.QuickTimeContext;
 import com.drew.metadata.mov.QuickTimeMediaHandler;
 import com.drew.metadata.mov.atoms.Atom;
 import com.drew.metadata.mov.atoms.TimecodeInformationMediaAtom;
@@ -36,9 +37,9 @@ import java.io.IOException;
  */
 public class QuickTimeTimecodeHandler extends QuickTimeMediaHandler<QuickTimeTimecodeDirectory>
 {
-    public QuickTimeTimecodeHandler(Metadata metadata)
+    public QuickTimeTimecodeHandler(Metadata metadata, QuickTimeContext context)
     {
-        super(metadata);
+        super(metadata, context);
     }
 
     @NotNull
@@ -69,7 +70,7 @@ public class QuickTimeTimecodeHandler extends QuickTimeMediaHandler<QuickTimeTim
     }
 
     @Override
-    protected void processTimeToSample(@NotNull SequentialReader reader, @NotNull Atom atom) throws IOException
+    protected void processTimeToSample(@NotNull SequentialReader reader, @NotNull Atom atom, QuickTimeContext context) throws IOException
     {
         // Do nothing
     }

--- a/Source/com/drew/metadata/mov/media/QuickTimeVideoHandler.java
+++ b/Source/com/drew/metadata/mov/media/QuickTimeVideoHandler.java
@@ -24,6 +24,7 @@ import com.drew.lang.SequentialReader;
 import com.drew.lang.annotations.NotNull;
 import com.drew.metadata.Metadata;
 import com.drew.metadata.mov.QuickTimeAtomTypes;
+import com.drew.metadata.mov.QuickTimeContext;
 import com.drew.metadata.mov.QuickTimeMediaHandler;
 import com.drew.metadata.mov.atoms.Atom;
 import com.drew.metadata.mov.atoms.TimeToSampleAtom;
@@ -37,9 +38,9 @@ import java.io.IOException;
  */
 public class QuickTimeVideoHandler extends QuickTimeMediaHandler<QuickTimeVideoDirectory>
 {
-    public QuickTimeVideoHandler(Metadata metadata)
+    public QuickTimeVideoHandler(Metadata metadata, QuickTimeContext context)
     {
-        super(metadata);
+        super(metadata, context);
     }
 
     @Override
@@ -70,9 +71,9 @@ public class QuickTimeVideoHandler extends QuickTimeMediaHandler<QuickTimeVideoD
     }
 
     @Override
-    public void processTimeToSample(@NotNull SequentialReader reader, @NotNull Atom atom) throws IOException
+    public void processTimeToSample(@NotNull SequentialReader reader, @NotNull Atom atom, QuickTimeContext context) throws IOException
     {
         TimeToSampleAtom timeToSampleAtom = new TimeToSampleAtom(reader, atom);
-        timeToSampleAtom.addMetadata(directory);
+        timeToSampleAtom.addMetadata(directory, context);
     }
 }

--- a/Source/com/drew/metadata/mov/metadata/QuickTimeDataHandler.java
+++ b/Source/com/drew/metadata/mov/metadata/QuickTimeDataHandler.java
@@ -28,6 +28,7 @@ import com.drew.lang.annotations.Nullable;
 import com.drew.metadata.Metadata;
 import com.drew.metadata.mov.QuickTimeAtomTypes;
 import com.drew.metadata.mov.QuickTimeContainerTypes;
+import com.drew.metadata.mov.QuickTimeContext;
 import com.drew.metadata.mov.QuickTimeMetadataHandler;
 import com.drew.metadata.mov.atoms.Atom;
 
@@ -63,7 +64,7 @@ public class QuickTimeDataHandler extends QuickTimeMetadataHandler
     }
 
     @Override
-    protected QuickTimeHandler processAtom(@NotNull Atom atom, @Nullable byte[] payload) throws IOException
+    protected QuickTimeHandler processAtom(@NotNull Atom atom, @Nullable byte[] payload, QuickTimeContext context) throws IOException
     {
         if (payload != null) {
             SequentialByteArrayReader reader = new SequentialByteArrayReader(payload);

--- a/Source/com/drew/metadata/mov/metadata/QuickTimeDirectoryHandler.java
+++ b/Source/com/drew/metadata/mov/metadata/QuickTimeDirectoryHandler.java
@@ -27,6 +27,7 @@ import com.drew.lang.annotations.Nullable;
 import com.drew.metadata.Metadata;
 import com.drew.metadata.mov.QuickTimeAtomTypes;
 import com.drew.metadata.mov.QuickTimeContainerTypes;
+import com.drew.metadata.mov.QuickTimeContext;
 import com.drew.metadata.mov.QuickTimeMetadataHandler;
 import com.drew.metadata.mov.atoms.Atom;
 
@@ -58,7 +59,7 @@ public class QuickTimeDirectoryHandler extends QuickTimeMetadataHandler
     }
 
     @Override
-    protected QuickTimeHandler processAtom(@NotNull Atom atom, @Nullable byte[] payload) throws IOException
+    protected QuickTimeHandler processAtom(@NotNull Atom atom, @Nullable byte[] payload, QuickTimeContext context) throws IOException
     {
         if (payload != null) {
             SequentialByteArrayReader reader = new SequentialByteArrayReader(payload);

--- a/Source/com/drew/metadata/mp4/Mp4BoxHandler.java
+++ b/Source/com/drew/metadata/mp4/Mp4BoxHandler.java
@@ -69,7 +69,7 @@ public class Mp4BoxHandler extends Mp4Handler<Mp4Directory>
     }
 
     @Override
-    public Mp4Handler processBox(@NotNull Box box, @Nullable byte[] payload) throws IOException
+    public Mp4Handler processBox(@NotNull Box box, @Nullable byte[] payload, Mp4Context context) throws IOException
     {
         if (payload != null) {
             SequentialReader reader = new SequentialByteArrayReader(payload);
@@ -79,9 +79,9 @@ public class Mp4BoxHandler extends Mp4Handler<Mp4Directory>
                 processFileType(reader, box);
             } else if (box.type.equals(Mp4BoxTypes.BOX_HANDLER)) {
                 HandlerBox handlerBox = new HandlerBox(reader, box);
-                return handlerFactory.getHandler(handlerBox, metadata);
+                return handlerFactory.getHandler(handlerBox, metadata, context);
             } else if (box.type.equals(Mp4BoxTypes.BOX_MEDIA_HEADER)) {
-                processMediaHeader(reader, box);
+                processMediaHeader(reader, box, context);
             } else if (box.type.equals(Mp4BoxTypes.BOX_TRACK_HEADER)) {
                 processTrackHeader(reader, box);
             }
@@ -105,9 +105,9 @@ public class Mp4BoxHandler extends Mp4Handler<Mp4Directory>
         movieHeaderBox.addMetadata(directory);
     }
 
-    private void processMediaHeader(@NotNull SequentialReader reader, @NotNull Box box) throws IOException
+    private void processMediaHeader(@NotNull SequentialReader reader, @NotNull Box box, Mp4Context context) throws IOException
     {
-        MediaHeaderBox mediaHeaderBox = new MediaHeaderBox(reader, box);
+        new MediaHeaderBox(reader, box, context);
     }
 
     private void processTrackHeader(@NotNull SequentialReader reader, @NotNull Box box) throws IOException

--- a/Source/com/drew/metadata/mp4/Mp4Context.java
+++ b/Source/com/drew/metadata/mp4/Mp4Context.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2002-2019 Drew Noakes and contributors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ * More information about this project is available at:
+ *
+ *    https://drewnoakes.com/code/exif/
+ *    https://github.com/drewnoakes/metadata-extractor
+ */
+package com.drew.metadata.mp4;
+
+public class Mp4Context
+{
+    public Long creationTime;
+    public Long modificationTime;
+    public Long timeScale;
+    public Long duration;
+    public String language;
+}

--- a/Source/com/drew/metadata/mp4/Mp4HandlerFactory.java
+++ b/Source/com/drew/metadata/mp4/Mp4HandlerFactory.java
@@ -35,30 +35,24 @@ public class Mp4HandlerFactory
 
     private Mp4Handler caller;
 
-    public static Long HANDLER_PARAM_TIME_SCALE              = null;
-    public static Long HANDLER_PARAM_CREATION_TIME           = null;
-    public static Long HANDLER_PARAM_MODIFICATION_TIME       = null;
-    public static Long HANDLER_PARAM_DURATION                = null;
-    public static String HANDLER_PARAM_LANGUAGE              = null;
-
     public Mp4HandlerFactory(Mp4Handler caller)
     {
         this.caller = caller;
     }
 
-    public Mp4Handler getHandler(HandlerBox box, Metadata metadata)
+    public Mp4Handler getHandler(HandlerBox box, Metadata metadata, Mp4Context context)
     {
         String type = box.getHandlerType();
         if (type.equals(HANDLER_SOUND_MEDIA)) {
-            return new Mp4SoundHandler(metadata);
+            return new Mp4SoundHandler(metadata, context);
         } else if (type.equals(HANDLER_VIDEO_MEDIA)) {
-            return new Mp4VideoHandler(metadata);
+            return new Mp4VideoHandler(metadata, context);
         } else if (type.equals(HANDLER_HINT_MEDIA)) {
-            return new Mp4HintHandler(metadata);
+            return new Mp4HintHandler(metadata, context);
         } else if (type.equals(HANDLER_TEXT_MEDIA)) {
-            return new Mp4TextHandler(metadata);
+            return new Mp4TextHandler(metadata, context);
         } else if (type.equals(HANDLER_META_MEDIA)) {
-            return new Mp4MetaHandler(metadata);
+            return new Mp4MetaHandler(metadata, context);
         }
         return caller;
     }

--- a/Source/com/drew/metadata/mp4/Mp4MediaHandler.java
+++ b/Source/com/drew/metadata/mp4/Mp4MediaHandler.java
@@ -34,20 +34,20 @@ import java.io.IOException;
 
 public abstract class Mp4MediaHandler<T extends Mp4MediaDirectory> extends Mp4Handler<T>
 {
-    public Mp4MediaHandler(Metadata metadata)
+    public Mp4MediaHandler(Metadata metadata, Mp4Context context)
     {
         super(metadata);
-        if (Mp4HandlerFactory.HANDLER_PARAM_CREATION_TIME != null && Mp4HandlerFactory.HANDLER_PARAM_MODIFICATION_TIME != null) {
+        if (context.creationTime != null && context.modificationTime != null) {
             // Get creation/modification times
             directory.setDate(
                 Mp4MediaDirectory.TAG_CREATION_TIME,
-                DateUtil.get1Jan1904EpochDate(Mp4HandlerFactory.HANDLER_PARAM_CREATION_TIME)
+                DateUtil.get1Jan1904EpochDate(context.creationTime)
             );
             directory.setDate(
                 Mp4MediaDirectory.TAG_MODIFICATION_TIME,
-                DateUtil.get1Jan1904EpochDate(Mp4HandlerFactory.HANDLER_PARAM_MODIFICATION_TIME)
+                DateUtil.get1Jan1904EpochDate(context.modificationTime)
             );
-            directory.setString(Mp4MediaDirectory.TAG_LANGUAGE_CODE, Mp4HandlerFactory.HANDLER_PARAM_LANGUAGE);
+            directory.setString(Mp4MediaDirectory.TAG_LANGUAGE_CODE, context.language);
         }
     }
 
@@ -67,7 +67,7 @@ public abstract class Mp4MediaHandler<T extends Mp4MediaDirectory> extends Mp4Ha
     }
 
     @Override
-    public Mp4Handler processBox(@NotNull Box box, @Nullable byte[] payload) throws IOException
+    public Mp4Handler processBox(@NotNull Box box, @Nullable byte[] payload, Mp4Context context) throws IOException
     {
         if (payload != null) {
             SequentialReader reader = new SequentialByteArrayReader(payload);
@@ -76,7 +76,7 @@ public abstract class Mp4MediaHandler<T extends Mp4MediaDirectory> extends Mp4Ha
             } else if (box.type.equals(Mp4BoxTypes.BOX_SAMPLE_DESCRIPTION)) {
                 processSampleDescription(reader, box);
             } else if (box.type.equals(Mp4BoxTypes.BOX_TIME_TO_SAMPLE)) {
-                processTimeToSample(reader, box);
+                processTimeToSample(reader, box, context);
             }
         }
         return this;
@@ -88,5 +88,5 @@ public abstract class Mp4MediaHandler<T extends Mp4MediaDirectory> extends Mp4Ha
 
     protected abstract void processMediaInformation(@NotNull SequentialReader reader, @NotNull Box box) throws IOException;
 
-    protected abstract void processTimeToSample(@NotNull SequentialReader reader, @NotNull Box box) throws IOException;
+    protected abstract void processTimeToSample(@NotNull SequentialReader reader, @NotNull Box box, Mp4Context context) throws IOException;
 }

--- a/Source/com/drew/metadata/mp4/boxes/MediaHeaderBox.java
+++ b/Source/com/drew/metadata/mp4/boxes/MediaHeaderBox.java
@@ -21,6 +21,7 @@
 package com.drew.metadata.mp4.boxes;
 
 import com.drew.lang.SequentialReader;
+import com.drew.metadata.mp4.Mp4Context;
 import com.drew.metadata.mp4.Mp4HandlerFactory;
 
 import java.io.IOException;
@@ -30,36 +31,29 @@ import java.io.IOException;
  */
 public class MediaHeaderBox extends FullBox
 {
-    long creationTime;
-    long modificationTime;
-    long timescale;
-    long duration;
-    String language;
-
-    public MediaHeaderBox(SequentialReader reader, Box box) throws IOException
+    public MediaHeaderBox(SequentialReader reader, Box box, Mp4Context context) throws IOException
     {
         super(reader, box);
 
         if (version == 1) {
-            creationTime = reader.getInt64();
-            modificationTime = reader.getInt64();
-            timescale = reader.getInt32();
-            duration = reader.getInt64();
+            context.creationTime = reader.getInt64();
+            context.modificationTime = reader.getInt64();
+            context.timeScale = (long)reader.getInt32();
+            context.duration = reader.getInt64();
         } else {
-            creationTime = reader.getUInt32();
-            modificationTime = reader.getUInt32();
-            timescale = reader.getUInt32();
-            duration = reader.getUInt32();
+            context.creationTime = reader.getUInt32();
+            context.modificationTime = reader.getUInt32();
+            context.timeScale = reader.getUInt32();
+            context.duration = reader.getUInt32();
         }
-        int languageBits = reader.getInt16();
-        language = new String(new char[]{(char)(((languageBits & 0x7C00) >> 10) + 0x60),
-            (char)(((languageBits & 0x03E0) >> 5) + 0x60),
-            (char)((languageBits & 0x001F) + 0x60)});
 
-        Mp4HandlerFactory.HANDLER_PARAM_CREATION_TIME = creationTime;
-        Mp4HandlerFactory.HANDLER_PARAM_MODIFICATION_TIME = modificationTime;
-        Mp4HandlerFactory.HANDLER_PARAM_TIME_SCALE = timescale;
-        Mp4HandlerFactory.HANDLER_PARAM_DURATION = duration;
-        Mp4HandlerFactory.HANDLER_PARAM_LANGUAGE = language;
+        int languageBits = reader.getInt16();
+
+        context.language = new String(new char[]
+            {
+                (char)(((languageBits & 0x7C00) >> 10) + 0x60),
+                (char)(((languageBits & 0x03E0) >> 5) + 0x60),
+                (char)((languageBits & 0x001F) + 0x60)
+            });
     }
 }

--- a/Source/com/drew/metadata/mp4/boxes/TimeToSampleBox.java
+++ b/Source/com/drew/metadata/mp4/boxes/TimeToSampleBox.java
@@ -21,6 +21,7 @@
 package com.drew.metadata.mp4.boxes;
 
 import com.drew.lang.SequentialReader;
+import com.drew.metadata.mp4.Mp4Context;
 import com.drew.metadata.mp4.Mp4HandlerFactory;
 import com.drew.metadata.mp4.media.Mp4SoundDirectory;
 import com.drew.metadata.mp4.media.Mp4VideoDirectory;
@@ -33,8 +34,8 @@ import java.util.ArrayList;
  */
 public class TimeToSampleBox extends FullBox
 {
-    long entryCount;
-    ArrayList<EntryCount> entries;
+    private long entryCount;
+    private ArrayList<EntryCount> entries;
 
     public TimeToSampleBox(SequentialReader reader, Box box) throws IOException
     {
@@ -47,7 +48,7 @@ public class TimeToSampleBox extends FullBox
         }
     }
 
-    public void addMetadata(Mp4VideoDirectory directory)
+    public void addMetadata(Mp4VideoDirectory directory, Mp4Context context)
     {
         float sampleCount = 0;
 
@@ -55,14 +56,14 @@ public class TimeToSampleBox extends FullBox
             sampleCount += ec.sampleCount;
         }
 
-        float frameRate = (float) Mp4HandlerFactory.HANDLER_PARAM_TIME_SCALE/((float) Mp4HandlerFactory.HANDLER_PARAM_DURATION / sampleCount);
+        float frameRate = (float) context.timeScale/((float) context.duration / sampleCount);
 
         directory.setFloat(Mp4VideoDirectory.TAG_FRAME_RATE, frameRate);
     }
 
-    public void addMetadata(Mp4SoundDirectory directory)
+    public void addMetadata(Mp4SoundDirectory directory, Mp4Context context)
     {
-        directory.setDouble(Mp4SoundDirectory.TAG_AUDIO_SAMPLE_RATE, Mp4HandlerFactory.HANDLER_PARAM_TIME_SCALE);
+        directory.setDouble(Mp4SoundDirectory.TAG_AUDIO_SAMPLE_RATE, context.timeScale);
     }
 
     static class EntryCount

--- a/Source/com/drew/metadata/mp4/media/Mp4HintHandler.java
+++ b/Source/com/drew/metadata/mp4/media/Mp4HintHandler.java
@@ -24,6 +24,7 @@ import com.drew.lang.SequentialReader;
 import com.drew.lang.annotations.NotNull;
 import com.drew.metadata.Metadata;
 import com.drew.metadata.mp4.Mp4BoxTypes;
+import com.drew.metadata.mp4.Mp4Context;
 import com.drew.metadata.mp4.Mp4MediaHandler;
 import com.drew.metadata.mp4.boxes.Box;
 import com.drew.metadata.mp4.boxes.HintMediaHeaderBox;
@@ -32,9 +33,9 @@ import java.io.IOException;
 
 public class Mp4HintHandler extends Mp4MediaHandler<Mp4HintDirectory>
 {
-    public Mp4HintHandler(Metadata metadata)
+    public Mp4HintHandler(Metadata metadata, Mp4Context context)
     {
-        super(metadata);
+        super(metadata, context);
     }
 
     @NotNull
@@ -53,7 +54,6 @@ public class Mp4HintHandler extends Mp4MediaHandler<Mp4HintDirectory>
     @Override
     protected void processSampleDescription(@NotNull SequentialReader reader, @NotNull Box box) throws IOException
     {
-
     }
 
     @Override
@@ -64,8 +64,7 @@ public class Mp4HintHandler extends Mp4MediaHandler<Mp4HintDirectory>
     }
 
     @Override
-    protected void processTimeToSample(@NotNull SequentialReader reader, @NotNull Box box) throws IOException
+    protected void processTimeToSample(@NotNull SequentialReader reader, @NotNull Box box, Mp4Context context) throws IOException
     {
-
     }
 }

--- a/Source/com/drew/metadata/mp4/media/Mp4MetaHandler.java
+++ b/Source/com/drew/metadata/mp4/media/Mp4MetaHandler.java
@@ -24,6 +24,7 @@ import com.drew.lang.SequentialReader;
 import com.drew.lang.annotations.NotNull;
 import com.drew.metadata.Metadata;
 import com.drew.metadata.mp4.Mp4ContainerTypes;
+import com.drew.metadata.mp4.Mp4Context;
 import com.drew.metadata.mp4.Mp4MediaHandler;
 import com.drew.metadata.mp4.boxes.Box;
 
@@ -31,9 +32,9 @@ import java.io.IOException;
 
 public class Mp4MetaHandler extends Mp4MediaHandler<Mp4MetaDirectory>
 {
-    public Mp4MetaHandler(Metadata metadata)
+    public Mp4MetaHandler(Metadata metadata, Mp4Context context)
     {
-        super(metadata);
+        super(metadata, context);
     }
 
     @NotNull
@@ -52,18 +53,15 @@ public class Mp4MetaHandler extends Mp4MediaHandler<Mp4MetaDirectory>
     @Override
     protected void processSampleDescription(@NotNull SequentialReader reader, @NotNull Box box) throws IOException
     {
-
     }
 
     @Override
     protected void processMediaInformation(@NotNull SequentialReader reader, @NotNull Box box) throws IOException
     {
-
     }
 
     @Override
-    protected void processTimeToSample(@NotNull SequentialReader reader, @NotNull Box box) throws IOException
+    protected void processTimeToSample(@NotNull SequentialReader reader, @NotNull Box box, Mp4Context context) throws IOException
     {
-
     }
 }

--- a/Source/com/drew/metadata/mp4/media/Mp4SoundHandler.java
+++ b/Source/com/drew/metadata/mp4/media/Mp4SoundHandler.java
@@ -24,6 +24,7 @@ import com.drew.lang.SequentialReader;
 import com.drew.lang.annotations.NotNull;
 import com.drew.metadata.Metadata;
 import com.drew.metadata.mp4.Mp4BoxTypes;
+import com.drew.metadata.mp4.Mp4Context;
 import com.drew.metadata.mp4.Mp4MediaHandler;
 import com.drew.metadata.mp4.boxes.AudioSampleEntry;
 import com.drew.metadata.mp4.boxes.Box;
@@ -34,9 +35,9 @@ import java.io.IOException;
 
 public class Mp4SoundHandler extends Mp4MediaHandler<Mp4SoundDirectory>
 {
-    public Mp4SoundHandler(Metadata metadata)
+    public Mp4SoundHandler(Metadata metadata, Mp4Context context)
     {
-        super(metadata);
+        super(metadata, context);
     }
 
     @NotNull
@@ -67,9 +68,9 @@ public class Mp4SoundHandler extends Mp4MediaHandler<Mp4SoundDirectory>
     }
 
     @Override
-    protected void processTimeToSample(@NotNull SequentialReader reader, @NotNull Box box) throws IOException
+    protected void processTimeToSample(@NotNull SequentialReader reader, @NotNull Box box, Mp4Context context) throws IOException
     {
         TimeToSampleBox timeToSampleBox = new TimeToSampleBox(reader, box);
-        timeToSampleBox.addMetadata(directory);
+        timeToSampleBox.addMetadata(directory, context);
     }
 }

--- a/Source/com/drew/metadata/mp4/media/Mp4TextHandler.java
+++ b/Source/com/drew/metadata/mp4/media/Mp4TextHandler.java
@@ -24,6 +24,7 @@ import com.drew.lang.SequentialReader;
 import com.drew.lang.annotations.NotNull;
 import com.drew.metadata.Metadata;
 import com.drew.metadata.mp4.Mp4ContainerTypes;
+import com.drew.metadata.mp4.Mp4Context;
 import com.drew.metadata.mp4.Mp4MediaHandler;
 import com.drew.metadata.mp4.boxes.Box;
 
@@ -31,9 +32,9 @@ import java.io.IOException;
 
 public class Mp4TextHandler extends Mp4MediaHandler<Mp4TextDirectory>
 {
-    public Mp4TextHandler(Metadata metadata)
+    public Mp4TextHandler(Metadata metadata, Mp4Context context)
     {
-        super(metadata);
+        super(metadata, context);
     }
 
     @NotNull
@@ -52,18 +53,15 @@ public class Mp4TextHandler extends Mp4MediaHandler<Mp4TextDirectory>
     @Override
     protected void processSampleDescription(@NotNull SequentialReader reader, @NotNull Box box) throws IOException
     {
-
     }
 
     @Override
     protected void processMediaInformation(@NotNull SequentialReader reader, @NotNull Box box) throws IOException
     {
-
     }
 
     @Override
-    protected void processTimeToSample(@NotNull SequentialReader reader, @NotNull Box box) throws IOException
+    protected void processTimeToSample(@NotNull SequentialReader reader, @NotNull Box box, Mp4Context context) throws IOException
     {
-
     }
 }

--- a/Source/com/drew/metadata/mp4/media/Mp4VideoHandler.java
+++ b/Source/com/drew/metadata/mp4/media/Mp4VideoHandler.java
@@ -24,6 +24,7 @@ import com.drew.lang.SequentialReader;
 import com.drew.lang.annotations.NotNull;
 import com.drew.metadata.Metadata;
 import com.drew.metadata.mp4.Mp4BoxTypes;
+import com.drew.metadata.mp4.Mp4Context;
 import com.drew.metadata.mp4.Mp4MediaHandler;
 import com.drew.metadata.mp4.boxes.Box;
 import com.drew.metadata.mp4.boxes.TimeToSampleBox;
@@ -34,9 +35,9 @@ import java.io.IOException;
 
 public class Mp4VideoHandler extends Mp4MediaHandler<Mp4VideoDirectory>
 {
-    public Mp4VideoHandler(Metadata metadata)
+    public Mp4VideoHandler(Metadata metadata, Mp4Context context)
     {
-        super(metadata);
+        super(metadata, context);
     }
 
     @Override
@@ -67,9 +68,9 @@ public class Mp4VideoHandler extends Mp4MediaHandler<Mp4VideoDirectory>
     }
 
     @Override
-    public void processTimeToSample(@NotNull SequentialReader reader, @NotNull Box box) throws IOException
+    public void processTimeToSample(@NotNull SequentialReader reader, @NotNull Box box, Mp4Context context) throws IOException
     {
         TimeToSampleBox timeToSampleBox = new TimeToSampleBox(reader, box);
-        timeToSampleBox.addMetadata(directory);
+        timeToSampleBox.addMetadata(directory, context);
     }
 }


### PR DESCRIPTION
These static fields were not threadsafe and create invalid data in concurrent environments.

There may be a better design for this, but for now these new context classes just move shared state to the stack.

Fixes #421.