### PR TITLE
Improve file type detection

### DIFF
--- a/Source/com/drew/imaging/FileTypeDetector.java
+++ b/Source/com/drew/imaging/FileTypeDetector.java
@@ -156,7 +156,7 @@ public class FileTypeDetector
      * <p>
      * Requires the stream to contain at least eight bytes.
      *
-     * @throws IOException if an IO error occurred or the input stream ended unexpectedly.
+     * @throws IOException if the stream does not support mark/reset.
      */
     @NotNull
     public static FileType detectFileType(@NotNull final FilterInputStream inputStream) throws IOException
@@ -169,14 +169,19 @@ public class FileTypeDetector
         inputStream.mark(maxByteCount);
 
         byte[] bytes = new byte[maxByteCount];
-        int bytesRead = inputStream.read(bytes);
-
-        if (bytesRead == -1)
-            throw new IOException("Stream ended before file's magic number could be determined.");
+        int offset = 0;
+        int count = maxByteCount;
+        while (count != 0) {
+            int bytesRead = inputStream.read(bytes, offset, count);
+            if (bytesRead == -1)
+                break;
+            count -= bytesRead;
+            offset += bytesRead;
+        }
 
         inputStream.reset();
 
-        FileType fileType = _root.find(bytes);
+        FileType fileType = _root.find(bytes, 0, offset);
 
         assert(fileType != null);
 

--- a/Source/com/drew/lang/ByteTrie.java
+++ b/Source/com/drew/lang/ByteTrie.java
@@ -57,9 +57,25 @@ public class ByteTrie<T>
     @Nullable
     public T find(byte[] bytes)
     {
+        return find(bytes, 0, bytes.length);
+    }
+
+    /**
+     * Return the most specific value stored for this byte sequence.
+     * If not found, returns <code>null</code> or a default values as specified by
+     * calling {@link ByteTrie#setDefaultValue}.
+     */
+    @Nullable
+    public T find(byte[] bytes, int offset, int count)
+    {
+        int maxIndex = offset + count;
+        if (maxIndex > bytes.length)
+            throw new IndexOutOfBoundsException();
+
         ByteTrieNode<T> node = _root;
         T value = node._value;
-        for (byte b : bytes) {
+        for (int i = offset; i < maxIndex; i++) {
+            byte b = bytes[i];
             ByteTrieNode<T> child = node._children.get(b);
             if (child == null)
                 break;


### PR DESCRIPTION
Fixes #449.

Fixes a bug where stream reading code would not loop if fewer than requested bytes were read, resulting in an array of zeroes being used for classification.

~Also adds an extra byte to the pattern used for MP3 detection.~