### PR TITLE
Fixes unit tests on Windows

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,6 +31,10 @@ compileJava {
     options.encoding = 'UTF-8'
 }
 
+compileTestJava {
+    options.encoding = 'UTF-8'
+}
+
 dependencies {
     compile 'com.adobe.xmp:xmpcore:6.0.6'
     testCompile 'junit:junit:4.12'


### PR DESCRIPTION
This fixes unit tests on Windows due to encoding issues.

P.S. If you're interested, I created a Kotlin port over the weekend in my master branch which allows for even finer grained null safety and the removal of a lot of utility methods. Feel free to check it out if that sounds cool.