### PR TITLE
Improve MP3 detection

### DIFF
--- a/Source/com/drew/imaging/FileTypeDetector.java
+++ b/Source/com/drew/imaging/FileTypeDetector.java
@@ -73,7 +73,7 @@ public class FileTypeDetector
         _root.addPath(FileType.Rw2, "II".getBytes(), new byte[]{0x55, 0x00});
         _root.addPath(FileType.Eps, "%!PS".getBytes());
         _root.addPath(FileType.Eps, new byte[]{(byte)0xC5, (byte)0xD0, (byte)0xD3, (byte)0xC6});
-        _root.addPath(FileType.Mp3, new byte[]{(byte)0xFF});
+        _root.addPath(FileType.Mp3, new byte[]{(byte)0xFF, (byte)0xFB});
 
         _ftypMap = new HashMap<String, FileType>();
 

--- a/Source/com/drew/imaging/FileTypeDetector.java
+++ b/Source/com/drew/imaging/FileTypeDetector.java
@@ -43,6 +43,7 @@ public class FileTypeDetector
         _fixedCheckers = new TypeChecker[] {
             new QuickTimeTypeChecker(),
             new RiffTypeChecker(),
+            new MpegAudioTypeChecker()
         };
 
         _root = new ByteTrie<FileType>();
@@ -80,7 +81,6 @@ public class FileTypeDetector
         _root.addPath(FileType.Rw2, "II".getBytes(), new byte[]{0x55, 0x00});
         _root.addPath(FileType.Eps, "%!PS".getBytes());
         _root.addPath(FileType.Eps, new byte[]{(byte)0xC5, (byte)0xD0, (byte)0xD3, (byte)0xC6});
-        _root.addPath(FileType.Mp3, new byte[]{(byte)0xFF, (byte)0xFB});
 
         // Only file detection
         _root.addPath(FileType.Aac, new byte[]{(byte)0xFF, (byte)0xF1});

--- a/Source/com/drew/imaging/TypeChecker.java
+++ b/Source/com/drew/imaging/TypeChecker.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2002-2019 Drew Noakes and contributors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ * More information about this project is available at:
+ *
+ *    https://drewnoakes.com/code/exif/
+ *    https://github.com/drewnoakes/metadata-extractor
+ */
+package com.drew.imaging;
+
+/**
+ * Used by {@link FileTypeDetector} for file types that cannot be identified by a simple byte-prefix analysis.
+ */
+public interface TypeChecker
+{
+    /**
+     * Gets the number of bytes this type checker needs in order to identify its file type.
+     */
+    int getByteCount();
+
+    /**
+     * Returns the file type identified within 'bytes', otherwise 'Unknown'.
+     */
+    FileType checkType(byte[] bytes);
+}

--- a/Source/com/drew/imaging/mp3/MpegAudioTypeChecker.java
+++ b/Source/com/drew/imaging/mp3/MpegAudioTypeChecker.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2002-2019 Drew Noakes and contributors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ * More information about this project is available at:
+ *
+ *    https://drewnoakes.com/code/exif/
+ *    https://github.com/drewnoakes/metadata-extractor
+ */
+package com.drew.imaging.mp3;
+
+import com.drew.imaging.FileType;
+import com.drew.imaging.TypeChecker;
+
+public class MpegAudioTypeChecker implements TypeChecker
+{
+    /*
+        MPEG Audio http://www.mp3-tech.org/programmer/frame_header.html
+
+        Bits
+        11  Frame sync (all bits must be set)
+        2   MPEG Audio version ID
+            00 - MPEG Version 2.5 (later extension of MPEG 2)
+            01 - Reserved
+            10 - MPEG Version 2 (ISO/IEC 13818-3)
+            11 - MPEG Version 1 (ISO/IEC 11172-3)
+        2   Layer description
+            00 - Reserved
+            01 - Layer III
+            10 - Layer II
+            11 - Layer I
+
+        Additional bits contain more information, but are not required for file type identification.
+     */
+    @Override
+    public int getByteCount()
+    {
+        return 3;
+    }
+
+    @Override
+    public FileType checkType(byte[] bytes)
+    {
+        // MPEG audio requires the first 11 bits to be set
+        if (bytes[0] != (byte)0xFF || (bytes[1] & 0xE0) != 0xE0)
+            return FileType.Unknown;
+
+        // The MPEG Audio version ID value of 01 is reserved
+        int version = (bytes[1] >> 3) & 3;
+        if (version == 1)
+            return FileType.Unknown;
+
+        // The layer description value of 00 is reserved
+        int layerDescription = (bytes[1] >> 1) & 3;
+        if (layerDescription == 0)
+            return FileType.Unknown;
+
+        // The bitrate index value of 1111 is disallowed
+        int bitrateIndex = bytes[2] >> 4;
+        if (bitrateIndex == 0x0F)
+            return FileType.Unknown;
+
+        return FileType.Mp3;
+    }
+}

--- a/Source/com/drew/imaging/quicktime/QuickTimeTypeChecker.java
+++ b/Source/com/drew/imaging/quicktime/QuickTimeTypeChecker.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2002-2019 Drew Noakes and contributors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ * More information about this project is available at:
+ *
+ *    https://drewnoakes.com/code/exif/
+ *    https://github.com/drewnoakes/metadata-extractor
+ */
+package com.drew.imaging.quicktime;
+
+import com.drew.imaging.FileType;
+import com.drew.imaging.TypeChecker;
+
+import java.util.HashMap;
+
+public class QuickTimeTypeChecker implements TypeChecker
+{
+    private static final HashMap<String, FileType> _ftypMap;
+
+    static
+    {
+        _ftypMap = new HashMap<String, FileType>();
+
+        // http://www.ftyps.com
+
+        // QuickTime Mov
+        _ftypMap.put("ftypmoov", FileType.Mov);
+        _ftypMap.put("ftypwide", FileType.Mov);
+        _ftypMap.put("ftypmdat", FileType.Mov);
+        _ftypMap.put("ftypfree", FileType.Mov);
+        _ftypMap.put("ftypqt  ", FileType.Mov);
+
+        // MP4
+        _ftypMap.put("ftypavc1", FileType.Mp4);
+        _ftypMap.put("ftypiso2", FileType.Mp4);
+        _ftypMap.put("ftypisom", FileType.Mp4);
+        _ftypMap.put("ftypM4A ", FileType.Mp4);
+        _ftypMap.put("ftypM4B ", FileType.Mp4);
+        _ftypMap.put("ftypM4P ", FileType.Mp4);
+        _ftypMap.put("ftypM4V ", FileType.Mp4);
+        _ftypMap.put("ftypM4VH", FileType.Mp4);
+        _ftypMap.put("ftypM4VP", FileType.Mp4);
+        _ftypMap.put("ftypmmp4", FileType.Mp4);
+        _ftypMap.put("ftypmp41", FileType.Mp4);
+        _ftypMap.put("ftypmp42", FileType.Mp4);
+        _ftypMap.put("ftypmp71", FileType.Mp4);
+        _ftypMap.put("ftypMSNV", FileType.Mp4);
+        _ftypMap.put("ftypNDAS", FileType.Mp4);
+        _ftypMap.put("ftypNDSC", FileType.Mp4);
+        _ftypMap.put("ftypNDSH", FileType.Mp4);
+        _ftypMap.put("ftypNDSM", FileType.Mp4);
+        _ftypMap.put("ftypNDSP", FileType.Mp4);
+        _ftypMap.put("ftypNDSS", FileType.Mp4);
+        _ftypMap.put("ftypNDXC", FileType.Mp4);
+        _ftypMap.put("ftypNDXH", FileType.Mp4);
+        _ftypMap.put("ftypNDXM", FileType.Mp4);
+        _ftypMap.put("ftypNDXP", FileType.Mp4);
+        _ftypMap.put("ftypNDXS", FileType.Mp4);
+
+        // HEIF
+        _ftypMap.put("ftypmif1", FileType.Heif);
+        _ftypMap.put("ftypmsf1", FileType.Heif);
+        _ftypMap.put("ftypheic", FileType.Heif);
+        _ftypMap.put("ftypheix", FileType.Heif);
+        _ftypMap.put("ftyphevc", FileType.Heif);
+        _ftypMap.put("ftyphevx", FileType.Heif);
+    }
+
+    @Override
+    public int getByteCount()
+    {
+        return 12;
+    }
+
+    @Override
+    public FileType checkType(byte[] bytes)
+    {
+        String eightCC = new String(bytes, 4, 8);
+
+        // Test at offset 4 for Base Media Format (i.e. QuickTime, MP4, etc...) identifier "ftyp" plus four identifying characters
+        FileType t = _ftypMap.get(eightCC);
+        if (t != null)
+            return t;
+
+        return FileType.Unknown;
+    }
+}

--- a/Source/com/drew/imaging/riff/RiffTypeChecker.java
+++ b/Source/com/drew/imaging/riff/RiffTypeChecker.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2002-2019 Drew Noakes and contributors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ * More information about this project is available at:
+ *
+ *    https://drewnoakes.com/code/exif/
+ *    https://github.com/drewnoakes/metadata-extractor
+ */
+package com.drew.imaging.riff;
+
+import com.drew.imaging.FileType;
+import com.drew.imaging.TypeChecker;
+
+public class RiffTypeChecker implements TypeChecker
+{
+    @Override
+    public int getByteCount()
+    {
+        return 12;
+    }
+
+    @Override
+    public FileType checkType(byte[] bytes)
+    {
+        String firstFour = new String(bytes, 0, 4);
+        if (!firstFour.equals("RIFF"))
+            return FileType.Unknown;
+
+        String fourCC = new String(bytes, 8, 4);
+        if (fourCC.equals("WAVE"))
+            return FileType.Wav;
+        if (fourCC.equals("AVI "))
+            return FileType.Avi;
+        if (fourCC.equals("WEBP"))
+            return FileType.WebP;
+
+        return FileType.Riff;
+    }
+}


### PR DESCRIPTION
Relates to #328 and #450.

MP3 headers cannot be reliably detected using the prefix-tree approach. This PR ports part of drewnoakes/metadata-extractor-dotnet#233, which introduced an interface for custom type check logic.

It then uses that extension point to add enhanced MP3 detection.