### PR TITLE
Timezone parsing fix and mov rotation extraction

### DIFF
--- a/Source/com/drew/metadata/Directory.java
+++ b/Source/com/drew/metadata/Directory.java
@@ -896,7 +896,7 @@ public abstract class Directory
             }
 
             // if the date string has time zone information, it supersedes the timeZone parameter
-            Pattern timeZonePattern = Pattern.compile("(Z|[+-]\\d\\d:\\d\\d)$");
+            Pattern timeZonePattern = Pattern.compile("(Z|[+-]\\d\\d:\\d\\d|[+-]\\d\\d\\d\\d)$");
             Matcher timeZoneMatcher = timeZonePattern.matcher(dateString);
             if (timeZoneMatcher.find()) {
                 timeZone = TimeZone.getTimeZone("GMT" + timeZoneMatcher.group().replaceAll("Z", ""));

--- a/Source/com/drew/metadata/mov/QuickTimeAtomHandler.java
+++ b/Source/com/drew/metadata/mov/QuickTimeAtomHandler.java
@@ -59,7 +59,8 @@ public class QuickTimeAtomHandler extends QuickTimeHandler<QuickTimeDirectory>
             || atom.type.equals(QuickTimeAtomTypes.ATOM_HANDLER)
             || atom.type.equals(QuickTimeAtomTypes.ATOM_MEDIA_HEADER)
             || atom.type.equals(QuickTimeAtomTypes.ATOM_CANON_THUMBNAIL)
-            || atom.type.equals(QuickTimeAtomTypes.ATOM_ADOBE_XMP);
+            || atom.type.equals(QuickTimeAtomTypes.ATOM_ADOBE_XMP)
+            || atom.type.equals(QuickTimeAtomTypes.ATOM_TRACK_HEADER);
     }
 
     @Override
@@ -94,6 +95,9 @@ public class QuickTimeAtomHandler extends QuickTimeHandler<QuickTimeDirectory>
                 canonThumbnailAtom.addMetadata(directory);
             } else if (atom.type.equals(QuickTimeAtomTypes.ATOM_ADOBE_XMP)) {
                 new XmpReader().extract(payload, metadata, directory);
+            } else if (atom.type.equals(QuickTimeAtomTypes.ATOM_TRACK_HEADER)) {
+                TrackHeaderAtom trackHeaderAtom = new TrackHeaderAtom(reader, atom);
+                trackHeaderAtom.addMetadata(directory);
             }
         } else {
             if (atom.type.equals(QuickTimeContainerTypes.ATOM_COMPRESSED_MOVIE)) {

--- a/Source/com/drew/metadata/mov/QuickTimeAtomTypes.java
+++ b/Source/com/drew/metadata/mov/QuickTimeAtomTypes.java
@@ -41,6 +41,7 @@ public class QuickTimeAtomTypes
     public static final String ATOM_MEDIA_HEADER             = "mdhd";
     public static final String ATOM_CANON_THUMBNAIL          = "CNTH";
     public static final String ATOM_ADOBE_XMP                = "XMP_";
+    public static final String ATOM_TRACK_HEADER             = "tkhd";
 
     private static final ArrayList<String> _atomList = new ArrayList<String>();
 
@@ -59,5 +60,6 @@ public class QuickTimeAtomTypes
         _atomList.add(ATOM_MEDIA_HEADER);
         _atomList.add(ATOM_CANON_THUMBNAIL);
         _atomList.add(ATOM_ADOBE_XMP);
+        _atomList.add(ATOM_TRACK_HEADER);
     }
 }

--- a/Source/com/drew/metadata/mov/QuickTimeDirectory.java
+++ b/Source/com/drew/metadata/mov/QuickTimeDirectory.java
@@ -45,6 +45,7 @@ public class QuickTimeDirectory extends Directory {
     public static final int TAG_SELECTION_DURATION                      = 0x010B;
     public static final int TAG_CURRENT_TIME                            = 0x010C;
     public static final int TAG_NEXT_TRACK_ID                           = 0x010D;
+    public static final int TAG_ROTATION                                = 0x010E;
 
     public static final int TAG_MEDIA_TIME_SCALE                        = 0x0306;
 
@@ -78,6 +79,7 @@ public class QuickTimeDirectory extends Directory {
         _tagNameMap.put(TAG_SELECTION_DURATION, "Selection Duration");
         _tagNameMap.put(TAG_CURRENT_TIME, "Current Time");
         _tagNameMap.put(TAG_NEXT_TRACK_ID, "Next Track ID");
+        _tagNameMap.put(TAG_ROTATION, "Rotation");
 
         _tagNameMap.put(TAG_MEDIA_TIME_SCALE, "Media Time Scale");
 

--- a/Source/com/drew/metadata/mov/atoms/TrackHeaderAtom.java
+++ b/Source/com/drew/metadata/mov/atoms/TrackHeaderAtom.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2002-2019 Drew Noakes and contributors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ * More information about this project is available at:
+ *
+ *    https://drewnoakes.com/code/exif/
+ *    https://github.com/drewnoakes/metadata-extractor
+ */
+package com.drew.metadata.mov.atoms;
+
+import com.drew.lang.SequentialReader;
+import com.drew.metadata.mov.QuickTimeDirectory;
+import com.drew.metadata.mp4.Mp4Directory;
+
+import java.awt.*;
+import java.io.IOException;
+
+/**
+ * Extracts rotation information only
+ *
+ * https://developer.apple.com/library/content/documentation/QuickTime/QTFF/QTFFChap2/qtff2.html#//apple_ref/doc/uid/TP40000939-CH204-SW34
+ *
+ * @author Ferenc Balogh
+ */
+public class TrackHeaderAtom extends FullAtom {
+    int[] matrix = new int[9];
+    long width;
+    long height;
+
+    public TrackHeaderAtom(SequentialReader reader, Atom atom) throws IOException {
+        super(reader, atom);
+
+        if (version == 1) {
+            reader.skip(48);
+        } else {
+            reader.skip(36);
+        }
+
+        for (int i = 0; i < 9; i++) {
+            matrix[i] = reader.getInt32();
+        }
+        width = reader.getInt32();
+        height = reader.getInt32();
+    }
+
+    public void addMetadata(QuickTimeDirectory directory) {
+        if (width != 0 && height != 0 && directory.getDoubleObject(Mp4Directory.TAG_ROTATION) == null) {
+            Point p = new Point(matrix[1] + matrix[4], matrix[0] + matrix[3]);
+            double theta = Math.atan2(p.y, p.x);
+            double degree = Math.toDegrees(theta);
+            degree -= 45;
+            directory.setDouble(QuickTimeDirectory.TAG_ROTATION, Math.abs(degree));
+        }
+    }
+}

--- a/Source/com/drew/metadata/mp4/Mp4BoxHandler.java
+++ b/Source/com/drew/metadata/mp4/Mp4BoxHandler.java
@@ -58,6 +58,7 @@ public class Mp4BoxHandler extends Mp4Handler<Mp4Directory>
             || box.type.equals(Mp4BoxTypes.BOX_HANDLER)
             || box.type.equals(Mp4BoxTypes.BOX_MEDIA_HEADER)
             || box.type.equals(Mp4BoxTypes.BOX_TRACK_HEADER)
+            || box.type.equals(Mp4BoxTypes.BOX_USER_DATA)
             || box.type.equals(Mp4BoxTypes.BOX_USER_DEFINED);
     }
 
@@ -89,6 +90,8 @@ public class Mp4BoxHandler extends Mp4Handler<Mp4Directory>
             } else if (box.type.equals(Mp4BoxTypes.BOX_USER_DEFINED)) {
                 Mp4UuidBoxHandler userBoxHandler = new Mp4UuidBoxHandler(metadata);
                 userBoxHandler.processBox(box, payload, context);
+            } else if (box.type.equals(Mp4BoxTypes.BOX_USER_DATA)) {
+                processUserData(box, reader);
             }
         } else {
             if (box.type.equals(Mp4ContainerTypes.BOX_COMPRESSED_MOVIE)) {
@@ -96,6 +99,11 @@ public class Mp4BoxHandler extends Mp4Handler<Mp4Directory>
             }
         }
         return this;
+    }
+
+    private void processUserData(@NotNull Box box, SequentialReader reader) throws IOException
+    {
+        new UserDataBox(reader, box).addMetadata(directory);
     }
 
     private void processFileType(@NotNull SequentialReader reader, @NotNull Box box) throws IOException

--- a/Source/com/drew/metadata/mp4/Mp4BoxTypes.java
+++ b/Source/com/drew/metadata/mp4/Mp4BoxTypes.java
@@ -39,6 +39,7 @@ public class Mp4BoxTypes
     public static final String BOX_MEDIA_HEADER                     = "mdhd";
     public static final String BOX_TRACK_HEADER                     = "tkhd";
     public static final String BOX_USER_DEFINED                     = "uuid";
+    public static final String BOX_USER_DATA                        = "udta";
 
     private static final ArrayList<String> _boxList = new ArrayList<String>();
 

--- a/Source/com/drew/metadata/mp4/Mp4Directory.java
+++ b/Source/com/drew/metadata/mp4/Mp4Directory.java
@@ -44,6 +44,8 @@ public class Mp4Directory extends Directory {
     public static final int TAG_NEXT_TRACK_ID                           = 0x010E;
     public static final int TAG_TRANSFORMATION_MATRIX                   = 0x010F;
     public static final int TAG_ROTATION                                = 0x0200;
+    public static final int TAG_LATITUDE                                = 0x2001;
+    public static final int TAG_LONGITUDE                               = 0x2002;
     public static final int TAG_MEDIA_TIME_SCALE                        = 0x0306;
 
     public static final int TAG_MAJOR_BRAND                             = 1;
@@ -52,6 +54,7 @@ public class Mp4Directory extends Directory {
 
     @NotNull
     private static final HashMap<Integer, String> _tagNameMap = new HashMap<Integer, String>();
+
 
     static {
         _tagNameMap.put(TAG_MAJOR_BRAND, "Major Brand");
@@ -74,6 +77,8 @@ public class Mp4Directory extends Directory {
         _tagNameMap.put(TAG_NEXT_TRACK_ID, "Next Track ID");
         _tagNameMap.put(TAG_TRANSFORMATION_MATRIX, "Transformation Matrix");
         _tagNameMap.put(TAG_ROTATION, "Rotation");
+        _tagNameMap.put(TAG_LATITUDE, "Latitude");
+        _tagNameMap.put(TAG_LONGITUDE, "Longitude");
 
         _tagNameMap.put(TAG_MEDIA_TIME_SCALE, "Media Time Scale");
     }

--- a/Source/com/drew/metadata/mp4/boxes/UserDataBox.java
+++ b/Source/com/drew/metadata/mp4/boxes/UserDataBox.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2002-2019 Drew Noakes and contributors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ * More information about this project is available at:
+ *
+ *    https://drewnoakes.com/code/exif/
+ *    https://github.com/drewnoakes/metadata-extractor
+ */
+package com.drew.metadata.mp4.boxes;
+
+import com.drew.lang.SequentialReader;
+import com.drew.metadata.mp4.Mp4Directory;
+
+import java.io.IOException;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static com.drew.metadata.mp4.Mp4Directory.TAG_LATITUDE;
+import static com.drew.metadata.mp4.Mp4Directory.TAG_LONGITUDE;
+
+public class UserDataBox extends FullBox {
+
+    private static final String LOCATION_CODE = "©xyz";
+
+    private static final Pattern COORDINATE_PATTERN = Pattern.compile("([+-]\\d+\\.\\d+)([+-]\\d+\\.\\d+)");
+
+    private String coordinateString;
+
+    public UserDataBox(final SequentialReader reader, final Box box) throws IOException {
+        super(reader, box);
+
+        final String fourCC = getFourCc(reader);
+
+        if (LOCATION_CODE.equals(fourCC)) {
+            extractLocation(reader);
+        }
+    }
+
+    private String getFourCc(final SequentialReader reader) throws IOException {
+        final byte[] codeBytes = reader.getBytes(4);
+        return new String(codeBytes, "ISO-8859-1");
+    }
+
+    private void extractLocation(final SequentialReader reader) throws IOException {
+        final int length = reader.getUInt16();
+        reader.skip(2);
+        final byte[] bytes = reader.getBytes(length);
+        coordinateString = new String(bytes, "UTF-8");
+    }
+
+    public void addMetadata(final Mp4Directory directory) {
+        final Matcher matcher = COORDINATE_PATTERN.matcher(coordinateString);
+        if (matcher.find()) {
+            final double latitude = Double.parseDouble(matcher.group(1));
+            final double longitude = Double.parseDouble(matcher.group(2));
+
+            directory.setDouble(TAG_LATITUDE, latitude);
+            directory.setDouble(TAG_LONGITUDE, longitude);
+        }
+    }
+}


### PR DESCRIPTION
Hi Drew,

I did some improvements in the library:

- I found that timezone information gets lost when extracting metadata from some images, because the library expects it to be in `HH:mm` format, but actually it is in `HHmm`. 

- We needed to extract rotation angle from MOV files, so I implemented very basic handling of track headers.

Best regards,
Ferenc