### PR TITLE
ItemInfoBox no longer throws exception when no content encoding is present

### DIFF
--- a/Source/com/drew/metadata/heif/boxes/ItemInfoBox.java
+++ b/Source/com/drew/metadata/heif/boxes/ItemInfoBox.java
@@ -69,13 +69,16 @@ public class ItemInfoBox extends FullBox
         {
             super(reader, box);
 
+            // 4 Bytes for length, 4 Bytes for type. Reader is indexed from AFTER type but box.size INCLUDES the aforementioned 8 bytes
+            int headerLength = 8;
+
             if ((version == 0) || (version == 1)) {
                 itemID = reader.getUInt16();
                 itemProtectionIndex = reader.getUInt16();
-                itemName = reader.getNullTerminatedString((int)(box.size - reader.getPosition()), Charsets.UTF_8);
-                contentType = reader.getNullTerminatedString((int)(box.size - reader.getPosition()), Charsets.UTF_8);
-                if (box.size - reader.getPosition() > 0) {
-                    extensionType = reader.getNullTerminatedString((int) (box.size - reader.getPosition()), Charsets.UTF_8);
+                itemName = reader.getNullTerminatedString((int)(box.size - reader.getPosition() - headerLength), Charsets.UTF_8);
+                contentType = reader.getNullTerminatedString((int)(box.size - reader.getPosition() - headerLength), Charsets.UTF_8);
+                if (box.size - reader.getPosition() - headerLength > 0) {
+                    extensionType = reader.getNullTerminatedString((int) (box.size - reader.getPosition() - headerLength), Charsets.UTF_8);
                 }
             }
             if (version == 1) {
@@ -92,14 +95,14 @@ public class ItemInfoBox extends FullBox
                 itemProtectionIndex = reader.getUInt16();
                 itemType = reader.getString(4);
 
-                itemName = reader.getNullTerminatedString((int)(box.size - reader.getPosition()), Charsets.UTF_8);
+                itemName = reader.getNullTerminatedString((int)(box.size - reader.getPosition() - headerLength), Charsets.UTF_8);
                 if (itemType.equals("mime")) {
-                    contentType = reader.getNullTerminatedString((int)(box.size - reader.getPosition()), Charsets.UTF_8);
-                    if (box.size - reader.getPosition() > 0) {
-                        contentEncoding = reader.getNullTerminatedString((int)(box.size - reader.getPosition()), Charsets.UTF_8);
+                    contentType = reader.getNullTerminatedString((int)(box.size - reader.getPosition() - headerLength), Charsets.UTF_8);
+                    if (box.size - reader.getPosition() - headerLength > 0) {
+                        contentEncoding = reader.getNullTerminatedString((int)(box.size - reader.getPosition() - headerLength), Charsets.UTF_8);
                     }
                 } else if (itemType.equals("uri ")) {
-                    itemUriType = reader.getString((int)(box.size - reader.getPosition()));
+                    itemUriType = reader.getString((int)(box.size - reader.getPosition() - headerLength));
                 }
             }
         }


### PR DESCRIPTION
Hi Drew,

Very cool library you've made here.

I noticed that there were some silent IOExceptions being thrown when trying to extract metadata from some HEIF images I've taken.

My one comment explains what's happening pretty well. Essentially the ItemInfoBox was reading off the end of the bytes it was given because it was not taking into account that 8 bytes had already been read.

I thought I'd start small, I have another working branch that can actually pull EXIF data from HEIFs which shouldn't be impacted by the directory-per-image refactor mentioned in #445. I'll put that PR in after this one gets merged (First time contributing to open source, long time Java developer)