### PR TITLE
Extract Exif data from HEIF file types

### DIFF
--- a/Source/com/drew/metadata/exif/makernotes/AppleMakernoteDirectory.java
+++ b/Source/com/drew/metadata/exif/makernotes/AppleMakernoteDirectory.java
@@ -41,6 +41,7 @@ public class AppleMakernoteDirectory extends Directory
     public static final int TAG_BURST_UUID = 0x000b;
     public static final int TAG_CONTENT_IDENTIFIER = 0x0011;
     public static final int TAG_IMAGE_UNIQUE_ID = 0x0015; // TODO is this actually 0x0016?
+    public static final int TAG_LIVE_PHOTO_ID = 0x0017;
 
     @NotNull
     private static final HashMap<Integer, String> _tagNameMap = new HashMap<Integer, String>();
@@ -53,6 +54,7 @@ public class AppleMakernoteDirectory extends Directory
         _tagNameMap.put(TAG_BURST_UUID, "Burst UUID");
         _tagNameMap.put(TAG_CONTENT_IDENTIFIER, "Content Identifier");
         _tagNameMap.put(TAG_IMAGE_UNIQUE_ID, "Image Unique ID");
+        _tagNameMap.put(TAG_LIVE_PHOTO_ID, "Live Photo ID");
     }
 
     public AppleMakernoteDirectory()

--- a/Source/com/drew/metadata/heif/HeifItemTypes.java
+++ b/Source/com/drew/metadata/heif/HeifItemTypes.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2019 Drew Noakes and contributors
+ * Copyright 2002-2020 Drew Noakes and contributors
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -20,23 +20,12 @@
  */
 package com.drew.metadata.heif;
 
-import java.util.ArrayList;
-
 /**
- * @author Payton Garland
+ * @author Arthur Normand
+ *
+ * Describes the types of items that can be found in the "mdat" HEIF container.
  */
-public class HeifContainerTypes
+public class HeifItemTypes
 {
-    public static final String BOX_METADATA                         = "meta";
-    public static final String BOX_IMAGE_PROPERTY                   = "iprp";
-    public static final String BOX_ITEM_PROPERTY                    = "ipco";
-    public static final String BOX_MEDIA_DATA                       = "mdat";
-
-    private static final ArrayList<String> _containerList = new ArrayList<String>();
-
-    static {
-        _containerList.add(BOX_METADATA);
-        _containerList.add(BOX_IMAGE_PROPERTY);
-        _containerList.add(BOX_ITEM_PROPERTY);
-    }
+    public static final String ITEM_EXIF                        = "Exif";
 }

--- a/Source/com/drew/metadata/heif/HeifPictureHandler.java
+++ b/Source/com/drew/metadata/heif/HeifPictureHandler.java
@@ -21,21 +21,48 @@
 package com.drew.metadata.heif;
 
 import com.drew.imaging.heif.HeifHandler;
+import com.drew.lang.RandomAccessStreamReader;
 import com.drew.lang.SequentialByteArrayReader;
 import com.drew.lang.SequentialReader;
 import com.drew.lang.annotations.NotNull;
 import com.drew.metadata.Metadata;
+import com.drew.metadata.exif.ExifReader;
 import com.drew.metadata.heif.boxes.*;
 
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 /**
  * @author Payton Garland
  */
 public class HeifPictureHandler extends HeifHandler<HeifDirectory>
 {
+    private static final Set<String> boxesCanProcess = new HashSet<String>(Arrays.asList(
+        HeifBoxTypes.BOX_ITEM_PROTECTION,
+        HeifBoxTypes.BOX_PRIMARY_ITEM,
+        HeifBoxTypes.BOX_ITEM_INFO,
+        HeifBoxTypes.BOX_ITEM_LOCATION,
+        HeifBoxTypes.BOX_IMAGE_SPATIAL_EXTENTS,
+        HeifBoxTypes.BOX_AUXILIARY_TYPE_PROPERTY,
+        HeifBoxTypes.BOX_IMAGE_ROTATION,
+        HeifBoxTypes.BOX_COLOUR_INFO,
+        HeifBoxTypes.BOX_PIXEL_INFORMATION
+    ));
+
+    private static final Set<String> itemsCanProcess = new HashSet<String>(Arrays.asList(
+        HeifItemTypes.ITEM_EXIF
+    ));
+
+    private static final Set<String> containersCanProcess = new HashSet<String>(Arrays.asList(
+        HeifContainerTypes.BOX_IMAGE_PROPERTY,
+        HeifContainerTypes.BOX_ITEM_PROPERTY,
+        HeifContainerTypes.BOX_MEDIA_DATA
+    ));
+
     ItemProtectionBox itemProtectionBox;
     PrimaryItemBox primaryItemBox;
     ItemInfoBox itemInfoBox;
@@ -44,34 +71,18 @@ public class HeifPictureHandler extends HeifHandler<HeifDirectory>
     public HeifPictureHandler(Metadata metadata)
     {
         super(metadata);
-
-        itemProtectionBox = null;
-        primaryItemBox = null;
-        itemInfoBox = null;
-        itemLocationBox = null;
     }
 
     @Override
     protected boolean shouldAcceptBox(@NotNull Box box)
     {
-        List<String> boxes = Arrays.asList(HeifBoxTypes.BOX_ITEM_PROTECTION,
-            HeifBoxTypes.BOX_PRIMARY_ITEM,
-            HeifBoxTypes.BOX_ITEM_INFO,
-            HeifBoxTypes.BOX_ITEM_LOCATION,
-            HeifBoxTypes.BOX_IMAGE_SPATIAL_EXTENTS,
-            HeifBoxTypes.BOX_AUXILIARY_TYPE_PROPERTY,
-            HeifBoxTypes.BOX_IMAGE_ROTATION,
-            HeifBoxTypes.BOX_COLOUR_INFO,
-            HeifBoxTypes.BOX_PIXEL_INFORMATION);
-
-        return boxes.contains(box.type);
+        return boxesCanProcess.contains(box.type);
     }
 
     @Override
     protected boolean shouldAcceptContainer(@NotNull Box box)
     {
-        return box.type.equals(HeifContainerTypes.BOX_IMAGE_PROPERTY)
-            || box.type.equals(HeifContainerTypes.BOX_ITEM_PROPERTY);
+        return containersCanProcess.contains(box.type);
     }
 
     @Override
@@ -108,7 +119,29 @@ public class HeifPictureHandler extends HeifHandler<HeifDirectory>
     @Override
     protected void processContainer(@NotNull Box box, @NotNull SequentialReader reader) throws IOException
     {
+        if (box.type.equals(HeifContainerTypes.BOX_MEDIA_DATA) && itemInfoBox != null && itemLocationBox != null) {
+            // We've reached the media data box, this contains all the items referred to by the info/location boxes
 
+            // Extents should already be sorted, this way we know we can traverse the one direction stream correctly
+            for (ItemLocationBox.Extent extent : itemLocationBox.getExtents()) {
+                ItemInfoBox.ItemInfoEntry infoEntry = itemInfoBox.getEntry(extent.getItemId());
+                long bytesToSkip = extent.getOffset() - reader.getPosition();
+                if (shouldHandleItem(infoEntry) && bytesToSkip > 0) {
+                    reader.skip(bytesToSkip);
+                    handleItem(infoEntry, reader.getBytes((int) extent.getLength()));
+                }
+            }
+        }
+    }
+
+    private boolean shouldHandleItem(ItemInfoBox.ItemInfoEntry infoEntry) {
+        return itemsCanProcess.contains(infoEntry.getItemType());
+    }
+
+    private void handleItem(ItemInfoBox.ItemInfoEntry entry, byte[] payload) {
+        if (entry.getItemType().equals(HeifItemTypes.ITEM_EXIF)) {
+            new ExifReader().extract(new RandomAccessStreamReader(new ByteArrayInputStream(payload)), metadata);
+        }
     }
 
     @Override

--- a/Source/com/drew/metadata/heif/HeifPictureHandler.java
+++ b/Source/com/drew/metadata/heif/HeifPictureHandler.java
@@ -31,10 +31,7 @@ import com.drew.metadata.heif.boxes.*;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
-import java.util.Arrays;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
 
 /**
  * @author Payton Garland
@@ -53,7 +50,7 @@ public class HeifPictureHandler extends HeifHandler<HeifDirectory>
         HeifBoxTypes.BOX_PIXEL_INFORMATION
     ));
 
-    private static final Set<String> itemsCanProcess = new HashSet<String>(Arrays.asList(
+    private static final Set<String> itemsCanProcess = new HashSet<String>(Collections.singletonList(
         HeifItemTypes.ITEM_EXIF
     ));
 
@@ -126,8 +123,10 @@ public class HeifPictureHandler extends HeifHandler<HeifDirectory>
             for (ItemLocationBox.Extent extent : itemLocationBox.getExtents()) {
                 ItemInfoBox.ItemInfoEntry infoEntry = itemInfoBox.getEntry(extent.getItemId());
                 long bytesToSkip = extent.getOffset() - reader.getPosition();
-                if (shouldHandleItem(infoEntry) && bytesToSkip > 0) {
+                if (bytesToSkip > 0) {
                     reader.skip(bytesToSkip);
+                }
+                if (shouldHandleItem(infoEntry)) {
                     handleItem(infoEntry, reader.getBytes((int) extent.getLength()));
                 }
             }

--- a/Source/com/drew/metadata/heif/boxes/ItemInfoBox.java
+++ b/Source/com/drew/metadata/heif/boxes/ItemInfoBox.java
@@ -26,7 +26,8 @@ import com.drew.lang.SequentialReader;
 import com.drew.metadata.heif.HeifDirectory;
 
 import java.io.IOException;
-import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * ISO/IEC 14496-12:2015 pg.81-83
@@ -34,7 +35,7 @@ import java.util.ArrayList;
 public class ItemInfoBox extends FullBox
 {
     long entryCount;
-    ArrayList<ItemInfoEntry> entries;
+    Map<Long, ItemInfoEntry> entries;
 
     public ItemInfoBox(SequentialReader reader, Box box) throws IOException
     {
@@ -45,16 +46,17 @@ public class ItemInfoBox extends FullBox
         } else {
             entryCount = reader.getUInt32();
         }
-        entries = new ArrayList<ItemInfoEntry>();
+        entries = new HashMap<Long, ItemInfoEntry>();
         for (int i = 1; i <= entryCount; i++)
         {
             Box entryBox = new Box(reader);
             SequentialByteArrayReader byteReader = new SequentialByteArrayReader(reader.getBytes((int)entryBox.size - 8));
-            entries.add(new ItemInfoEntry(byteReader, entryBox));
+            ItemInfoEntry itemInfoEntry = new ItemInfoEntry(byteReader, entryBox);
+            entries.put(itemInfoEntry.itemID, itemInfoEntry);
         }
     }
 
-    static class ItemInfoEntry extends FullBox
+    public static class ItemInfoEntry extends FullBox
     {
         long itemID;
         long itemProtectionIndex;
@@ -106,10 +108,18 @@ public class ItemInfoBox extends FullBox
                 }
             }
         }
+
+        public String getItemType() {
+            return itemType;
+        }
     }
 
     public void addMetadata(HeifDirectory directory)
     {
 
+    }
+
+    public ItemInfoEntry getEntry(final long id) {
+        return entries.get(id);
     }
 }

--- a/Source/com/drew/metadata/heif/boxes/ItemLocationBox.java
+++ b/Source/com/drew/metadata/heif/boxes/ItemLocationBox.java
@@ -23,6 +23,7 @@ package com.drew.metadata.heif.boxes;
 import com.drew.lang.SequentialReader;
 
 import java.io.IOException;
+import java.util.*;
 
 /**
  * ISO/IEC 14496-12:2015 pg.77-80
@@ -37,9 +38,14 @@ public class ItemLocationBox extends FullBox
     long itemID;
     int constructionMethod;
     int dataReferenceIndex;
-    byte[] baseOffset;
+    long baseOffset;
     int extentCount;
-    Extent[] extents;
+    SortedSet<Extent> extents = new TreeSet<Extent>(new Comparator<Extent>() {
+        @Override
+        public int compare(Extent left, Extent right) {
+            return (left.offset < right.offset) ? -1 : ((left.offset == right.offset) ? 0 : 1);
+        }
+    });
 
     public ItemLocationBox(SequentialReader reader, Box box) throws IOException
     {
@@ -72,20 +78,25 @@ public class ItemLocationBox extends FullBox
                 constructionMethod = (holder & 0x000F);
             }
             dataReferenceIndex = reader.getUInt16();
-            baseOffset = reader.getBytes(baseOffsetSize);
+            if (baseOffsetSize == 4) {
+                baseOffset = reader.getInt32();
+            } else if (baseOffsetSize == 8){
+                baseOffset = reader.getInt64();
+            } else {
+                baseOffset = 0;
+            }
             extentCount = reader.getUInt16();
 
             Long extentIndex = null;
             long extentOffset;
             long extentLength;
-            extents = new Extent[extentCount];
             for (int j = 0; j < extentCount; j++) {
                 if ((version == 1) || (version == 2) && (indexSize > 0)) {
                     extentIndex = getIntFromUnknownByte(indexSize, reader);
                 }
                 extentOffset = getIntFromUnknownByte(offsetSize, reader);
                 extentLength = getIntFromUnknownByte(lengthSize, reader);
-                extents[j] = new Extent(extentIndex == null ? null : extentIndex, extentOffset, extentLength);
+                extents.add(new Extent(itemID, extentIndex, extentOffset + baseOffset, extentLength));
             }
         }
     }
@@ -106,16 +117,34 @@ public class ItemLocationBox extends FullBox
         }
     }
 
-    static class Extent
+    public static class Extent
     {
+        long itemId;
         Long index;
         long offset;
         long length;
 
-        public Extent(Long index, long offset, long length) {
+        public Extent(long itemId, Long index, long offset, long length) {
+            this.itemId = itemId;
             this.index = index;
             this.offset = offset;
             this.length = length;
         }
+
+        public long getOffset() {
+            return offset;
+        }
+
+        public long getLength() {
+            return length;
+        }
+
+        public long getItemId() {
+            return itemId;
+        }
+    }
+
+    public SortedSet<Extent> getExtents() {
+        return extents;
     }
 }


### PR DESCRIPTION
We now process the "mdat" container in HEIF images and handle any items in it that have the "Exif" type

We can see that Exif is successfully pulled out of all the HEIC images in metadata-extractor-images: https://github.com/drewnoakes/metadata-extractor-images/pull/36

NOTE: Doesn't work with the Nokia HEIF reference images because it seems that they don't follow the spec outlined in ISO/IEC 23008-12:2017 Annex A?