### PR TITLE
Read exif chunk from a PNG image

### DIFF
--- a/Source/com/drew/imaging/png/PngChunkType.java
+++ b/Source/com/drew/imaging/png/PngChunkType.java
@@ -87,6 +87,7 @@ public class PngChunkType
     public static final PngChunkType sPLT;
     public static final PngChunkType tIME;
     public static final PngChunkType iTXt;
+    public static final PngChunkType eXIF;
 
     /**
      * Denotes an ancillary {@link PngChunk} that contains textual data, having first a keyword and then a value.
@@ -124,6 +125,7 @@ public class PngChunkType
             iTXt = new PngChunkType("iTXt", true);
             tEXt = new PngChunkType("tEXt", true);
             zTXt = new PngChunkType("zTXt", true);
+            eXIF = new PngChunkType("eXIf");
         } catch (PngProcessingException e) {
             throw new IllegalArgumentException(e);
         }

--- a/Source/com/drew/imaging/png/PngMetadataReader.java
+++ b/Source/com/drew/imaging/png/PngMetadataReader.java
@@ -330,16 +330,10 @@ public class PngMetadataReader
         } else if (chunkType.equals(PngChunkType.eXIF)) {
             try {
                 ExifTiffHandler handler = new ExifTiffHandler(metadata, null);
-                RandomAccessStreamReader reader = new RandomAccessStreamReader(new ByteArrayInputStream(bytes));
-                int tiffHeaderOffset = 0;
-                new TiffReader().processTiff(reader, handler, tiffHeaderOffset);
-            } catch (TiffProcessingException e) {
+                new TiffReader().processTiff(new ByteArrayReader(bytes), handler, 0);
+            } catch (TiffProcessingException | IOException e) {
                 PngDirectory directory = new PngDirectory(PngChunkType.eXIF);
-                directory.addError("Exception processing the PNG image exif information.");
-                metadata.addDirectory(directory);
-            } catch (IOException e) {
-                PngDirectory directory = new PngDirectory(PngChunkType.eXIF);
-                directory.addError("Exception reading the PNG image exif information.");
+                directory.addError(ex.getMessage());
                 metadata.addDirectory(directory);
             }
         }


### PR DESCRIPTION
By making use of the Tiff exif functionality, we can read the PNG exif information.

The following information was read from the file sampleWithExifData.png:

```
[Exif IFD0 - 0x8298] Copyright = Acme
[Exif IFD0 - 0x0131] Software = Acme-software: 1.0.0.0
[Exif IFD0 - 0x010e] Image Description = This is an image with exif data
[Exif SubIFD - 0x927c] Makernote = [33 values]
```