### PR TITLE
Remove Class-Path entry from MANIFEST in jar

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -140,7 +140,6 @@
                 <configuration>
                     <archive>
                         <manifest>
-                            <addClasspath>true</addClasspath>
                             <mainClass>com.drew.imaging.ImageMetadataReader</mainClass>
                             <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
                         </manifest>


### PR DESCRIPTION
When including this library using Apache Ivy (for instance), `javac`  reports the following warning:

```
[javac] warning: [path] bad path element "/home/simon/.ivy2/cache/com.drewnoakes/metadata-extractor/jars/xmpcore-6.0.6.jar": no such file or directory
```

This is due to `Class-Path: xmpcore-6.0.6.jar` in `META-INF/MANIFEST.MF`

Ref: https://maven.apache.org/shared/maven-archiver/examples/classpath.html