### PR TITLE
Update name of the 'cprt' tag

### DIFF
--- a/Source/com/drew/metadata/icc/IccDirectory.java
+++ b/Source/com/drew/metadata/icc/IccDirectory.java
@@ -143,7 +143,7 @@ public class IccDirectory extends Directory
         _tagNameMap.put(TAG_TAG_targ, "Char Target");
         _tagNameMap.put(TAG_TAG_chad, "Chromatic Adaptation");
         _tagNameMap.put(TAG_TAG_chrm, "Chromaticity");
-        _tagNameMap.put(TAG_TAG_cprt, "Copyright");
+        _tagNameMap.put(TAG_TAG_cprt, "Profile Copyright");
         _tagNameMap.put(TAG_TAG_crdi, "CrdInfo");
         _tagNameMap.put(TAG_TAG_dmnd, "Device Mfg Description");
         _tagNameMap.put(TAG_TAG_dmdd, "Device Model Description");


### PR DESCRIPTION
I believe the name of the ICC 'cprt' tag (0x63707274) would more accurately be described as the "Profile Copyright". It certainly isn't the copyright on the image which is what is implied by the unqualified name "Copyright".