### PR TITLE
Add CRX and other MP4/QuickTime file type detection

### DIFF
--- a/Source/com/drew/imaging/FileType.java
+++ b/Source/com/drew/imaging/FileType.java
@@ -64,6 +64,8 @@ public enum FileType
     Raf("RAF", "FujiFilm Camera Raw", null, "raf"),
     /** Panasonic camera raw. */
     Rw2("RW2", "Panasonic Camera Raw", null, "rw2"),
+    /** Canon camera raw (version 3). Shared by CR3 (image) and CRM (video). */
+    Crx("CRX", "Canon Camera Raw", null, "cr3", "crm"),
 
     // Only file detection
     Aac("AAC", "Advanced Audio Coding", "audio/aac", "m4a"),

--- a/Source/com/drew/imaging/quicktime/QuickTimeTypeChecker.java
+++ b/Source/com/drew/imaging/quicktime/QuickTimeTypeChecker.java
@@ -41,6 +41,7 @@ public class QuickTimeTypeChecker implements TypeChecker
         _ftypMap.put("ftypmdat", FileType.QuickTime);
         _ftypMap.put("ftypfree", FileType.QuickTime);
         _ftypMap.put("ftypqt  ", FileType.QuickTime);
+        _ftypMap.put("ftyp3g2a", FileType.QuickTime);
 
         // MP4
         _ftypMap.put("ftypavc1", FileType.Mp4);
@@ -68,6 +69,7 @@ public class QuickTimeTypeChecker implements TypeChecker
         _ftypMap.put("ftypNDXM", FileType.Mp4);
         _ftypMap.put("ftypNDXP", FileType.Mp4);
         _ftypMap.put("ftypNDXS", FileType.Mp4);
+        _ftypMap.put("ftypnvr1", FileType.Mp4);
 
         // HEIF
         _ftypMap.put("ftypmif1", FileType.Heif);
@@ -76,6 +78,9 @@ public class QuickTimeTypeChecker implements TypeChecker
         _ftypMap.put("ftypheix", FileType.Heif);
         _ftypMap.put("ftyphevc", FileType.Heif);
         _ftypMap.put("ftyphevx", FileType.Heif);
+
+        // CRX
+        _ftypMap.put("ftypcrx ", FileType.Crx);
     }
 
     @Override


### PR DESCRIPTION
This brings parity with the .NET implementation.

Closes #490.