### PR TITLE
Enable depedency caching for travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,6 +34,10 @@ matrix:
 
 install: mvn install -DskipTests=true -Dgpg.skip=true
 
+cache:
+  directories:
+  - $HOME/.m2
+
 script:
   - mvn clean verify -Dgpg.skip=true
 


### PR DESCRIPTION
Would be interested to know why maven dependencies haven't been cached on Travis. Thank you.