### PR TITLE
Exploration: Make Locale configurable for formatting of tags (not to be merged)

### DIFF
--- a/Source/com/drew/imaging/jpeg/JpegSegmentMetadataReader.java
+++ b/Source/com/drew/imaging/jpeg/JpegSegmentMetadataReader.java
@@ -3,6 +3,8 @@ package com.drew.imaging.jpeg;
 import com.drew.lang.annotations.NotNull;
 import com.drew.metadata.Metadata;
 
+import java.util.Locale;
+
 /**
  * Defines an object that extracts metadata from in JPEG segments.
  */
@@ -21,6 +23,7 @@ public interface JpegSegmentMetadataReader
      *                 encountered in the original file.
      * @param metadata The {@link Metadata} object into which extracted values should be merged.
      * @param segmentType The {@link JpegSegmentType} being read.
+     * @param locale TODO document this
      */
-    void readJpegSegments(@NotNull final Iterable<byte[]> segments, @NotNull final Metadata metadata, @NotNull final JpegSegmentType segmentType);
+    void readJpegSegments(@NotNull final Iterable<byte[]> segments, @NotNull final Metadata metadata, @NotNull final JpegSegmentType segmentType, Locale locale);
 }

--- a/Source/com/drew/imaging/jpeg/JpegSegmentMetadataReader.java
+++ b/Source/com/drew/imaging/jpeg/JpegSegmentMetadataReader.java
@@ -1,6 +1,7 @@
 package com.drew.imaging.jpeg;
 
 import com.drew.lang.annotations.NotNull;
+import com.drew.lang.annotations.Nullable;
 import com.drew.metadata.Metadata;
 
 import java.util.Locale;
@@ -25,5 +26,5 @@ public interface JpegSegmentMetadataReader
      * @param segmentType The {@link JpegSegmentType} being read.
      * @param locale TODO document this
      */
-    void readJpegSegments(@NotNull final Iterable<byte[]> segments, @NotNull final Metadata metadata, @NotNull final JpegSegmentType segmentType, Locale locale);
+    void readJpegSegments(@NotNull final Iterable<byte[]> segments, @NotNull final Metadata metadata, @NotNull final JpegSegmentType segmentType, @Nullable Locale locale);
 }

--- a/Source/com/drew/imaging/png/PngMetadataReader.java
+++ b/Source/com/drew/imaging/png/PngMetadataReader.java
@@ -329,7 +329,7 @@ public class PngMetadataReader
             metadata.addDirectory(directory);
         } else if (chunkType.equals(PngChunkType.eXIf)) {
             try {
-                ExifTiffHandler handler = new ExifTiffHandler(metadata, null);
+                ExifTiffHandler handler = new ExifTiffHandler(metadata, null, null);
                 new TiffReader().processTiff(new ByteArrayReader(bytes), handler, 0);
             } catch (TiffProcessingException ex) {
                 PngDirectory directory = new PngDirectory(PngChunkType.eXIf);

--- a/Source/com/drew/imaging/tiff/TiffMetadataReader.java
+++ b/Source/com/drew/imaging/tiff/TiffMetadataReader.java
@@ -67,7 +67,7 @@ public class TiffMetadataReader
     public static Metadata readMetadata(@NotNull RandomAccessReader reader) throws IOException, TiffProcessingException
     {
         Metadata metadata = new Metadata();
-        ExifTiffHandler handler = new ExifTiffHandler(metadata, null);
+        ExifTiffHandler handler = new ExifTiffHandler(metadata, null, null);
         new TiffReader().processTiff(reader, handler, 0);
         return metadata;
     }

--- a/Source/com/drew/lang/GeoLocation.java
+++ b/Source/com/drew/lang/GeoLocation.java
@@ -25,6 +25,8 @@ import com.drew.lang.annotations.NotNull;
 import com.drew.lang.annotations.Nullable;
 
 import java.text.DecimalFormat;
+import java.text.DecimalFormatSymbols;
+import java.util.Locale;
 
 /**
  * Represents a latitude and longitude pair, giving a position on earth in spherical coordinates.
@@ -74,15 +76,23 @@ public final class GeoLocation
         return _latitude == 0 && _longitude == 0;
     }
 
+    // TODO document this
+    @NotNull
+    public static String decimalToDegreesMinutesSecondsString(double decimal)
+    {
+        return decimalToDegreesMinutesSecondsString(decimal, null);
+    }
+
     /**
      * Converts a decimal degree angle into its corresponding DMS (degrees-minutes-seconds) representation as a string,
      * of format: {@code -1° 23' 4.56"}
      */
     @NotNull
-    public static String decimalToDegreesMinutesSecondsString(double decimal)
+    public static String decimalToDegreesMinutesSecondsString(double decimal, Locale locale)
     {
         double[] dms = decimalToDegreesMinutesSeconds(decimal);
-        DecimalFormat format = new DecimalFormat("0.##");
+        DecimalFormatSymbols symbols = locale == null ? DecimalFormatSymbols.getInstance() : DecimalFormatSymbols.getInstance(locale);
+        DecimalFormat format = new DecimalFormat("0.##", symbols);
         return String.format("%s\u00B0 %s' %s\"", format.format(dms[0]), format.format(dms[1]), format.format(dms[2]));
     }
 
@@ -158,6 +168,7 @@ public final class GeoLocation
     @NotNull
     public String toDMSString()
     {
+        // TODO add a Locale version of this method?
         return decimalToDegreesMinutesSecondsString(_latitude) + ", " + decimalToDegreesMinutesSecondsString(_longitude);
     }
 }

--- a/Source/com/drew/metadata/TagDescriptor.java
+++ b/Source/com/drew/metadata/TagDescriptor.java
@@ -30,6 +30,7 @@ import java.lang.reflect.Array;
 import java.math.RoundingMode;
 import java.nio.charset.Charset;
 import java.text.DecimalFormat;
+import java.text.DecimalFormatSymbols;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Date;
@@ -303,7 +304,14 @@ public class TagDescriptor<T extends Directory>
     @Nullable
     protected static String getFStopDescription(double fStop)
     {
-        DecimalFormat format = new DecimalFormat("0.0");
+        return getFStopDescription(fStop, null);
+    }
+
+    @Nullable
+    protected static String getFStopDescription(double fStop, Locale locale)
+    {
+        DecimalFormatSymbols symbols = locale == null ? DecimalFormatSymbols.getInstance() : DecimalFormatSymbols.getInstance(locale);
+        DecimalFormat format = new DecimalFormat("0.0", symbols);
         format.setRoundingMode(RoundingMode.HALF_UP);
         return "f/" + format.format(fStop);
     }

--- a/Source/com/drew/metadata/TagDescriptor.java
+++ b/Source/com/drew/metadata/TagDescriptor.java
@@ -36,6 +36,7 @@ import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 
 /**

--- a/Source/com/drew/metadata/adobe/AdobeJpegReader.java
+++ b/Source/com/drew/metadata/adobe/AdobeJpegReader.java
@@ -31,6 +31,7 @@ import com.drew.metadata.Metadata;
 
 import java.io.IOException;
 import java.util.Collections;
+import java.util.Locale;
 
 /**
  * Decodes Adobe formatted data stored in JPEG files, normally in the APPE (App14) segment.
@@ -49,7 +50,7 @@ public class AdobeJpegReader implements JpegSegmentMetadataReader
         return Collections.singletonList(JpegSegmentType.APPE);
     }
 
-    public void readJpegSegments(@NotNull Iterable<byte[]> segments, @NotNull Metadata metadata, @NotNull JpegSegmentType segmentType)
+    public void readJpegSegments(@NotNull Iterable<byte[]> segments, @NotNull Metadata metadata, @NotNull JpegSegmentType segmentType, Locale locale)
     {
         for (byte[] bytes : segments) {
             if (bytes.length == 12 && PREAMBLE.equalsIgnoreCase(new String(bytes, 0, PREAMBLE.length())))

--- a/Source/com/drew/metadata/adobe/AdobeJpegReader.java
+++ b/Source/com/drew/metadata/adobe/AdobeJpegReader.java
@@ -26,6 +26,7 @@ import com.drew.imaging.jpeg.JpegSegmentType;
 import com.drew.lang.SequentialByteArrayReader;
 import com.drew.lang.SequentialReader;
 import com.drew.lang.annotations.NotNull;
+import com.drew.lang.annotations.Nullable;
 import com.drew.metadata.Directory;
 import com.drew.metadata.Metadata;
 
@@ -50,7 +51,7 @@ public class AdobeJpegReader implements JpegSegmentMetadataReader
         return Collections.singletonList(JpegSegmentType.APPE);
     }
 
-    public void readJpegSegments(@NotNull Iterable<byte[]> segments, @NotNull Metadata metadata, @NotNull JpegSegmentType segmentType, Locale locale)
+    public void readJpegSegments(@NotNull Iterable<byte[]> segments, @NotNull Metadata metadata, @NotNull JpegSegmentType segmentType, @Nullable Locale locale)
     {
         for (byte[] bytes : segments) {
             if (bytes.length == 12 && PREAMBLE.equalsIgnoreCase(new String(bytes, 0, PREAMBLE.length())))

--- a/Source/com/drew/metadata/exif/ExifDescriptorBase.java
+++ b/Source/com/drew/metadata/exif/ExifDescriptorBase.java
@@ -32,6 +32,7 @@ import com.drew.metadata.TagDescriptor;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.text.DecimalFormat;
+import java.util.Locale;
 
 import static com.drew.metadata.exif.ExifDirectoryBase.*;
 
@@ -48,6 +49,7 @@ public abstract class ExifDescriptorBase<T extends Directory> extends TagDescrip
      * where decimal notation is elegant (such as 1/2 -> 0.5, but not 1/3).
      */
     private final boolean _allowDecimalRepresentationOfRationals = true;
+    private Locale _locale;
 
     // Note for the potential addition of brightness presentation in eV:
     // Brightness of taken subject. To calculate Exposure(Ev) from BrightnessValue(Bv),
@@ -58,6 +60,12 @@ public abstract class ExifDescriptorBase<T extends Directory> extends TagDescrip
     public ExifDescriptorBase(@NotNull T directory)
     {
         super(directory);
+    }
+
+    public ExifDescriptorBase(@NotNull T directory, @Nullable Locale locale)
+    {
+        super(directory);
+        _locale = locale;
     }
 
     @Nullable
@@ -610,7 +618,7 @@ public abstract class ExifDescriptorBase<T extends Directory> extends TagDescrip
         Rational value = _directory.getRational(TAG_FNUMBER);
         if (value == null)
             return null;
-        return getFStopDescription(value.doubleValue());
+        return getFStopDescription(value.doubleValue(), _locale);
     }
 
     @Nullable

--- a/Source/com/drew/metadata/exif/ExifReader.java
+++ b/Source/com/drew/metadata/exif/ExifReader.java
@@ -79,13 +79,13 @@ public class ExifReader implements JpegSegmentMetadataReader
         extract(reader, metadata, 0);
     }
 
-    /** Reads TIFF formatted Exif data a specified offset within a {@link RandomAccessReader}. */
+    /** Reads TIFF formatted Exif data at a specified offset within a {@link RandomAccessReader}. */
     public void extract(@NotNull final RandomAccessReader reader, @NotNull final Metadata metadata, int readerOffset)
     {
         extract(reader, metadata, readerOffset, null);
     }
 
-    /** Reads TIFF formatted Exif data a specified offset within a {@link RandomAccessReader}. */
+    /** Reads TIFF formatted Exif data at a specified offset within a {@link RandomAccessReader}. */
     public void extract(@NotNull final RandomAccessReader reader, @NotNull final Metadata metadata, int readerOffset, @Nullable Directory parentDirectory)
     {
         extract(reader, metadata, readerOffset, parentDirectory, null);

--- a/Source/com/drew/metadata/exif/ExifReader.java
+++ b/Source/com/drew/metadata/exif/ExifReader.java
@@ -33,6 +33,7 @@ import com.drew.metadata.Metadata;
 
 import java.io.IOException;
 import java.util.Collections;
+import java.util.Locale;
 
 /**
  * Decodes Exif binary data, populating a {@link Metadata} object with tag values in {@link ExifSubIFDDirectory},
@@ -53,14 +54,14 @@ public class ExifReader implements JpegSegmentMetadataReader
         return Collections.singletonList(JpegSegmentType.APP1);
     }
 
-    public void readJpegSegments(@NotNull final Iterable<byte[]> segments, @NotNull final Metadata metadata, @NotNull final JpegSegmentType segmentType)
+    public void readJpegSegments(@NotNull final Iterable<byte[]> segments, @NotNull final Metadata metadata, @NotNull final JpegSegmentType segmentType, @Nullable Locale locale)
     {
         assert(segmentType == JpegSegmentType.APP1);
 
         for (byte[] segmentBytes : segments) {
             // Segment must have the expected preamble
             if (startsWithJpegExifPreamble(segmentBytes)) {
-                extract(new ByteArrayReader(segmentBytes), metadata, JPEG_SEGMENT_PREAMBLE.length());
+                extract(new ByteArrayReader(segmentBytes), metadata, JPEG_SEGMENT_PREAMBLE.length(), null, locale);
             }
         }
     }
@@ -84,10 +85,16 @@ public class ExifReader implements JpegSegmentMetadataReader
         extract(reader, metadata, readerOffset, null);
     }
 
-    /** Reads TIFF formatted Exif data at a specified offset within a {@link RandomAccessReader}. */
+    /** Reads TIFF formatted Exif data a specified offset within a {@link RandomAccessReader}. */
     public void extract(@NotNull final RandomAccessReader reader, @NotNull final Metadata metadata, int readerOffset, @Nullable Directory parentDirectory)
     {
-        ExifTiffHandler exifTiffHandler = new ExifTiffHandler(metadata, parentDirectory);
+        extract(reader, metadata, readerOffset, parentDirectory, null);
+    }
+
+    /** Reads TIFF formatted Exif data at a specified offset within a {@link RandomAccessReader}. */
+    public void extract(@NotNull final RandomAccessReader reader, @NotNull final Metadata metadata, int readerOffset, @Nullable Directory parentDirectory, @Nullable Locale locale)
+    {
+        ExifTiffHandler exifTiffHandler = new ExifTiffHandler(metadata, parentDirectory, locale);
 
         try {
             // Read the TIFF-formatted Exif data

--- a/Source/com/drew/metadata/exif/ExifSubIFDDescriptor.java
+++ b/Source/com/drew/metadata/exif/ExifSubIFDDescriptor.java
@@ -21,6 +21,9 @@
 package com.drew.metadata.exif;
 
 import com.drew.lang.annotations.NotNull;
+import com.drew.lang.annotations.Nullable;
+
+import java.util.Locale;
 
 /**
  * Provides human-readable string representations of tag values stored in a {@link ExifSubIFDDirectory}.
@@ -32,6 +35,11 @@ public class ExifSubIFDDescriptor extends ExifDescriptorBase<ExifSubIFDDirectory
 {
     public ExifSubIFDDescriptor(@NotNull ExifSubIFDDirectory directory)
     {
-        super(directory);
+        this(directory, null);
+    }
+
+    public ExifSubIFDDescriptor(@NotNull ExifSubIFDDirectory directory, @Nullable Locale locale)
+    {
+        super(directory, locale);
     }
 }

--- a/Source/com/drew/metadata/exif/ExifSubIFDDirectory.java
+++ b/Source/com/drew/metadata/exif/ExifSubIFDDirectory.java
@@ -26,6 +26,7 @@ import com.drew.metadata.Directory;
 
 import java.util.Date;
 import java.util.HashMap;
+import java.util.Locale;
 import java.util.TimeZone;
 
 /**
@@ -42,6 +43,11 @@ public class ExifSubIFDDirectory extends ExifDirectoryBase
     public ExifSubIFDDirectory()
     {
         this.setDescriptor(new ExifSubIFDDescriptor(this));
+    }
+
+    public ExifSubIFDDirectory(@Nullable Locale locale)
+    {
+        this.setDescriptor(new ExifSubIFDDescriptor(this, locale));
     }
 
     @NotNull

--- a/Source/com/drew/metadata/exif/ExifTiffHandler.java
+++ b/Source/com/drew/metadata/exif/ExifTiffHandler.java
@@ -59,9 +59,9 @@ import com.drew.metadata.plist.BplistReader;
  */
 public class ExifTiffHandler extends DirectoryTiffHandler
 {
-    public ExifTiffHandler(@NotNull Metadata metadata, @Nullable Directory parentDirectory)
+    public ExifTiffHandler(@NotNull Metadata metadata, @Nullable Directory parentDirectory, @Nullable Locale locale)
     {
-        super(metadata, parentDirectory);
+        super(metadata, parentDirectory, locale);
     }
 
     public void setTiffMarker(int marker) throws TiffProcessingException

--- a/Source/com/drew/metadata/exif/ExifTiffHandler.java
+++ b/Source/com/drew/metadata/exif/ExifTiffHandler.java
@@ -24,6 +24,7 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 

--- a/Source/com/drew/metadata/exif/GpsDescriptor.java
+++ b/Source/com/drew/metadata/exif/GpsDescriptor.java
@@ -27,6 +27,7 @@ import com.drew.lang.annotations.Nullable;
 import com.drew.metadata.TagDescriptor;
 
 import java.text.DecimalFormat;
+import java.util.Locale;
 
 import static com.drew.metadata.exif.GpsDirectory.*;
 
@@ -38,9 +39,13 @@ import static com.drew.metadata.exif.GpsDirectory.*;
 @SuppressWarnings("WeakerAccess")
 public class GpsDescriptor extends TagDescriptor<GpsDirectory>
 {
-    public GpsDescriptor(@NotNull GpsDirectory directory)
+    private Locale _locale;
+
+    public GpsDescriptor(@NotNull GpsDirectory directory, @Nullable Locale locale)
     {
         super(directory);
+        // TODO add locale to TagDescriptor superclass?
+        _locale = locale;
     }
 
     @Override
@@ -111,14 +116,14 @@ public class GpsDescriptor extends TagDescriptor<GpsDirectory>
     public String getGpsLatitudeDescription()
     {
         GeoLocation location = _directory.getGeoLocation();
-        return location == null ? null : GeoLocation.decimalToDegreesMinutesSecondsString(location.getLatitude());
+        return location == null ? null : GeoLocation.decimalToDegreesMinutesSecondsString(location.getLatitude(), _locale);
     }
 
     @Nullable
     public String getGpsLongitudeDescription()
     {
         GeoLocation location = _directory.getGeoLocation();
-        return location == null ? null : GeoLocation.decimalToDegreesMinutesSecondsString(location.getLongitude());
+        return location == null ? null : GeoLocation.decimalToDegreesMinutesSecondsString(location.getLongitude(), _locale);
     }
 
     @Nullable
@@ -159,7 +164,7 @@ public class GpsDescriptor extends TagDescriptor<GpsDirectory>
         Double dec = GeoLocation.degreesMinutesSecondsToDecimal(
             values[0], values[1], values[2], ref.equalsIgnoreCase(positiveRef));
 
-        return dec == null ? null : GeoLocation.decimalToDegreesMinutesSecondsString(dec);
+        return dec == null ? null : GeoLocation.decimalToDegreesMinutesSecondsString(dec, _locale);
     }
 
     @Nullable

--- a/Source/com/drew/metadata/exif/GpsDirectory.java
+++ b/Source/com/drew/metadata/exif/GpsDirectory.java
@@ -146,9 +146,14 @@ public class GpsDirectory extends ExifDirectoryBase
         _tagNameMap.put(TAG_H_POSITIONING_ERROR, "GPS H Positioning Error");
     }
 
+    // TODO remove this constructor?
     public GpsDirectory()
     {
-        this.setDescriptor(new GpsDescriptor(this));
+        this(null);
+    }
+
+    public GpsDirectory(@Nullable Locale locale) {
+        this.setDescriptor(new GpsDescriptor(this, locale));
     }
 
     @Override

--- a/Source/com/drew/metadata/icc/IccReader.java
+++ b/Source/com/drew/metadata/icc/IccReader.java
@@ -33,6 +33,7 @@ import com.drew.metadata.MetadataReader;
 
 import java.io.IOException;
 import java.util.Collections;
+import java.util.Locale;
 
 /**
  * Reads an ICC profile.
@@ -57,7 +58,7 @@ public class IccReader implements JpegSegmentMetadataReader, MetadataReader
         return Collections.singletonList(JpegSegmentType.APP2);
     }
 
-    public void readJpegSegments(@NotNull Iterable<byte[]> segments, @NotNull Metadata metadata, @NotNull JpegSegmentType segmentType)
+    public void readJpegSegments(@NotNull Iterable<byte[]> segments, @NotNull Metadata metadata, @NotNull JpegSegmentType segmentType, Locale locale)
     {
         final int preambleLength = JPEG_SEGMENT_PREAMBLE.length();
 

--- a/Source/com/drew/metadata/icc/IccReader.java
+++ b/Source/com/drew/metadata/icc/IccReader.java
@@ -58,7 +58,7 @@ public class IccReader implements JpegSegmentMetadataReader, MetadataReader
         return Collections.singletonList(JpegSegmentType.APP2);
     }
 
-    public void readJpegSegments(@NotNull Iterable<byte[]> segments, @NotNull Metadata metadata, @NotNull JpegSegmentType segmentType, Locale locale)
+    public void readJpegSegments(@NotNull Iterable<byte[]> segments, @NotNull Metadata metadata, @NotNull JpegSegmentType segmentType, @Nullable Locale locale)
     {
         final int preambleLength = JPEG_SEGMENT_PREAMBLE.length();
 

--- a/Source/com/drew/metadata/iptc/IptcReader.java
+++ b/Source/com/drew/metadata/iptc/IptcReader.java
@@ -66,7 +66,7 @@ public class IptcReader implements JpegSegmentMetadataReader
         return Collections.singletonList(JpegSegmentType.APPD);
     }
 
-    public void readJpegSegments(@NotNull Iterable<byte[]> segments, @NotNull Metadata metadata, @NotNull JpegSegmentType segmentType, Locale locale)
+    public void readJpegSegments(@NotNull Iterable<byte[]> segments, @NotNull Metadata metadata, @NotNull JpegSegmentType segmentType, @Nullable Locale locale)
     {
         for (byte[] segmentBytes : segments) {
             // Ensure data starts with the IPTC marker byte

--- a/Source/com/drew/metadata/iptc/IptcReader.java
+++ b/Source/com/drew/metadata/iptc/IptcReader.java
@@ -33,6 +33,7 @@ import com.drew.metadata.StringValue;
 import java.io.IOException;
 import java.nio.charset.Charset;
 import java.util.Collections;
+import java.util.Locale;
 
 /**
  * Decodes IPTC binary data, populating a {@link Metadata} object with tag values in an {@link IptcDirectory}.
@@ -65,7 +66,7 @@ public class IptcReader implements JpegSegmentMetadataReader
         return Collections.singletonList(JpegSegmentType.APPD);
     }
 
-    public void readJpegSegments(@NotNull Iterable<byte[]> segments, @NotNull Metadata metadata, @NotNull JpegSegmentType segmentType)
+    public void readJpegSegments(@NotNull Iterable<byte[]> segments, @NotNull Metadata metadata, @NotNull JpegSegmentType segmentType, Locale locale)
     {
         for (byte[] segmentBytes : segments) {
             // Ensure data starts with the IPTC marker byte

--- a/Source/com/drew/metadata/jfif/JfifReader.java
+++ b/Source/com/drew/metadata/jfif/JfifReader.java
@@ -30,6 +30,7 @@ import com.drew.metadata.MetadataReader;
 
 import java.io.IOException;
 import java.util.Collections;
+import java.util.Locale;
 
 /**
  * Reader for JFIF data, found in the APP0 JPEG segment.
@@ -51,7 +52,7 @@ public class JfifReader implements JpegSegmentMetadataReader, MetadataReader
         return Collections.singletonList(JpegSegmentType.APP0);
     }
 
-    public void readJpegSegments(@NotNull Iterable<byte[]> segments, @NotNull Metadata metadata, @NotNull JpegSegmentType segmentType)
+    public void readJpegSegments(@NotNull Iterable<byte[]> segments, @NotNull Metadata metadata, @NotNull JpegSegmentType segmentType, Locale locale)
     {
         for (byte[] segmentBytes : segments) {
             // Skip segments not starting with the required header

--- a/Source/com/drew/metadata/jfif/JfifReader.java
+++ b/Source/com/drew/metadata/jfif/JfifReader.java
@@ -25,6 +25,7 @@ import com.drew.imaging.jpeg.JpegSegmentType;
 import com.drew.lang.ByteArrayReader;
 import com.drew.lang.RandomAccessReader;
 import com.drew.lang.annotations.NotNull;
+import com.drew.lang.annotations.Nullable;
 import com.drew.metadata.Metadata;
 import com.drew.metadata.MetadataReader;
 
@@ -52,7 +53,7 @@ public class JfifReader implements JpegSegmentMetadataReader, MetadataReader
         return Collections.singletonList(JpegSegmentType.APP0);
     }
 
-    public void readJpegSegments(@NotNull Iterable<byte[]> segments, @NotNull Metadata metadata, @NotNull JpegSegmentType segmentType, Locale locale)
+    public void readJpegSegments(@NotNull Iterable<byte[]> segments, @NotNull Metadata metadata, @NotNull JpegSegmentType segmentType, @Nullable Locale locale)
     {
         for (byte[] segmentBytes : segments) {
             // Skip segments not starting with the required header

--- a/Source/com/drew/metadata/jfxx/JfxxReader.java
+++ b/Source/com/drew/metadata/jfxx/JfxxReader.java
@@ -30,6 +30,7 @@ import com.drew.metadata.MetadataReader;
 
 import java.io.IOException;
 import java.util.Collections;
+import java.util.Locale;
 
 /**
  * Reader for JFXX (JFIF extensions) data, found in the APP0 JPEG segment.
@@ -51,7 +52,7 @@ public class JfxxReader implements JpegSegmentMetadataReader, MetadataReader
         return Collections.singletonList(JpegSegmentType.APP0);
     }
 
-    public void readJpegSegments(@NotNull Iterable<byte[]> segments, @NotNull Metadata metadata, @NotNull JpegSegmentType segmentType)
+    public void readJpegSegments(@NotNull Iterable<byte[]> segments, @NotNull Metadata metadata, @NotNull JpegSegmentType segmentType, Locale locale)
     {
         for (byte[] segmentBytes : segments) {
             // Skip segments not starting with the required header

--- a/Source/com/drew/metadata/jfxx/JfxxReader.java
+++ b/Source/com/drew/metadata/jfxx/JfxxReader.java
@@ -25,6 +25,7 @@ import com.drew.imaging.jpeg.JpegSegmentType;
 import com.drew.lang.ByteArrayReader;
 import com.drew.lang.RandomAccessReader;
 import com.drew.lang.annotations.NotNull;
+import com.drew.lang.annotations.Nullable;
 import com.drew.metadata.Metadata;
 import com.drew.metadata.MetadataReader;
 
@@ -52,7 +53,7 @@ public class JfxxReader implements JpegSegmentMetadataReader, MetadataReader
         return Collections.singletonList(JpegSegmentType.APP0);
     }
 
-    public void readJpegSegments(@NotNull Iterable<byte[]> segments, @NotNull Metadata metadata, @NotNull JpegSegmentType segmentType, Locale locale)
+    public void readJpegSegments(@NotNull Iterable<byte[]> segments, @NotNull Metadata metadata, @NotNull JpegSegmentType segmentType, @Nullable Locale locale)
     {
         for (byte[] segmentBytes : segments) {
             // Skip segments not starting with the required header

--- a/Source/com/drew/metadata/jpeg/JpegCommentReader.java
+++ b/Source/com/drew/metadata/jpeg/JpegCommentReader.java
@@ -27,6 +27,7 @@ import com.drew.metadata.Metadata;
 import com.drew.metadata.StringValue;
 
 import java.util.Collections;
+import java.util.Locale;
 
 /**
  * Decodes the comment stored within JPEG files, populating a {@link Metadata} object with tag values in a
@@ -42,7 +43,7 @@ public class JpegCommentReader implements JpegSegmentMetadataReader
         return Collections.singletonList(JpegSegmentType.COM);
     }
 
-    public void readJpegSegments(@NotNull Iterable<byte[]> segments, @NotNull Metadata metadata, @NotNull JpegSegmentType segmentType)
+    public void readJpegSegments(@NotNull Iterable<byte[]> segments, @NotNull Metadata metadata, @NotNull JpegSegmentType segmentType, Locale locale)
     {
         for (byte[] segmentBytes : segments) {
             JpegCommentDirectory directory = new JpegCommentDirectory();

--- a/Source/com/drew/metadata/jpeg/JpegCommentReader.java
+++ b/Source/com/drew/metadata/jpeg/JpegCommentReader.java
@@ -23,6 +23,7 @@ package com.drew.metadata.jpeg;
 import com.drew.imaging.jpeg.JpegSegmentMetadataReader;
 import com.drew.imaging.jpeg.JpegSegmentType;
 import com.drew.lang.annotations.NotNull;
+import com.drew.lang.annotations.Nullable;
 import com.drew.metadata.Metadata;
 import com.drew.metadata.StringValue;
 
@@ -43,7 +44,7 @@ public class JpegCommentReader implements JpegSegmentMetadataReader
         return Collections.singletonList(JpegSegmentType.COM);
     }
 
-    public void readJpegSegments(@NotNull Iterable<byte[]> segments, @NotNull Metadata metadata, @NotNull JpegSegmentType segmentType, Locale locale)
+    public void readJpegSegments(@NotNull Iterable<byte[]> segments, @NotNull Metadata metadata, @NotNull JpegSegmentType segmentType, @Nullable Locale locale)
     {
         for (byte[] segmentBytes : segments) {
             JpegCommentDirectory directory = new JpegCommentDirectory();

--- a/Source/com/drew/metadata/jpeg/JpegDhtReader.java
+++ b/Source/com/drew/metadata/jpeg/JpegDhtReader.java
@@ -30,6 +30,7 @@ import com.drew.metadata.jpeg.HuffmanTablesDirectory.HuffmanTable;
 import com.drew.metadata.jpeg.HuffmanTablesDirectory.HuffmanTable.HuffmanTableClass;
 import java.io.IOException;
 import java.util.Collections;
+import java.util.Locale;
 
 /**
  * Reader for JPEG Huffman tables, found in the DHT JPEG segment.
@@ -44,7 +45,7 @@ public class JpegDhtReader implements JpegSegmentMetadataReader
         return Collections.singletonList(JpegSegmentType.DHT);
     }
 
-    public void readJpegSegments(@NotNull Iterable<byte[]> segments, @NotNull Metadata metadata, @NotNull JpegSegmentType segmentType)
+    public void readJpegSegments(@NotNull Iterable<byte[]> segments, @NotNull Metadata metadata, @NotNull JpegSegmentType segmentType, Locale locale)
     {
         for (byte[] segmentBytes : segments) {
             extract(new SequentialByteArrayReader(segmentBytes), metadata);

--- a/Source/com/drew/metadata/jpeg/JpegDhtReader.java
+++ b/Source/com/drew/metadata/jpeg/JpegDhtReader.java
@@ -25,6 +25,7 @@ import com.drew.imaging.jpeg.JpegSegmentType;
 import com.drew.lang.SequentialByteArrayReader;
 import com.drew.lang.SequentialReader;
 import com.drew.lang.annotations.NotNull;
+import com.drew.lang.annotations.Nullable;
 import com.drew.metadata.Metadata;
 import com.drew.metadata.jpeg.HuffmanTablesDirectory.HuffmanTable;
 import com.drew.metadata.jpeg.HuffmanTablesDirectory.HuffmanTable.HuffmanTableClass;
@@ -45,7 +46,7 @@ public class JpegDhtReader implements JpegSegmentMetadataReader
         return Collections.singletonList(JpegSegmentType.DHT);
     }
 
-    public void readJpegSegments(@NotNull Iterable<byte[]> segments, @NotNull Metadata metadata, @NotNull JpegSegmentType segmentType, Locale locale)
+    public void readJpegSegments(@NotNull Iterable<byte[]> segments, @NotNull Metadata metadata, @NotNull JpegSegmentType segmentType, @Nullable Locale locale)
     {
         for (byte[] segmentBytes : segments) {
             extract(new SequentialByteArrayReader(segmentBytes), metadata);

--- a/Source/com/drew/metadata/jpeg/JpegDnlReader.java
+++ b/Source/com/drew/metadata/jpeg/JpegDnlReader.java
@@ -25,6 +25,7 @@ import com.drew.imaging.jpeg.JpegSegmentType;
 import com.drew.lang.SequentialByteArrayReader;
 import com.drew.lang.SequentialReader;
 import com.drew.lang.annotations.NotNull;
+import com.drew.lang.annotations.Nullable;
 import com.drew.metadata.ErrorDirectory;
 import com.drew.metadata.Metadata;
 
@@ -45,7 +46,7 @@ public class JpegDnlReader implements JpegSegmentMetadataReader
         return Collections.singletonList(JpegSegmentType.DNL);
     }
 
-    public void readJpegSegments(@NotNull Iterable<byte[]> segments, @NotNull Metadata metadata, @NotNull JpegSegmentType segmentType, Locale locale)
+    public void readJpegSegments(@NotNull Iterable<byte[]> segments, @NotNull Metadata metadata, @NotNull JpegSegmentType segmentType, @Nullable Locale locale)
     {
         for (byte[] segmentBytes : segments) {
             extract(segmentBytes, metadata, segmentType);

--- a/Source/com/drew/metadata/jpeg/JpegDnlReader.java
+++ b/Source/com/drew/metadata/jpeg/JpegDnlReader.java
@@ -30,6 +30,7 @@ import com.drew.metadata.Metadata;
 
 import java.io.IOException;
 import java.util.Collections;
+import java.util.Locale;
 
 /**
  * Decodes JPEG DNL data, adjusting the image height with information missing from the JPEG SOFx segment.
@@ -44,7 +45,7 @@ public class JpegDnlReader implements JpegSegmentMetadataReader
         return Collections.singletonList(JpegSegmentType.DNL);
     }
 
-    public void readJpegSegments(@NotNull Iterable<byte[]> segments, @NotNull Metadata metadata, @NotNull JpegSegmentType segmentType)
+    public void readJpegSegments(@NotNull Iterable<byte[]> segments, @NotNull Metadata metadata, @NotNull JpegSegmentType segmentType, Locale locale)
     {
         for (byte[] segmentBytes : segments) {
             extract(segmentBytes, metadata, segmentType);

--- a/Source/com/drew/metadata/jpeg/JpegReader.java
+++ b/Source/com/drew/metadata/jpeg/JpegReader.java
@@ -29,6 +29,7 @@ import com.drew.metadata.Metadata;
 
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.Locale;
 
 /**
  * Decodes JPEG SOFn data, populating a {@link Metadata} object with tag values in a {@link JpegDirectory}.
@@ -62,7 +63,7 @@ public class JpegReader implements JpegSegmentMetadataReader
         );
     }
 
-    public void readJpegSegments(@NotNull Iterable<byte[]> segments, @NotNull Metadata metadata, @NotNull JpegSegmentType segmentType)
+    public void readJpegSegments(@NotNull Iterable<byte[]> segments, @NotNull Metadata metadata, @NotNull JpegSegmentType segmentType, Locale locale)
     {
         for (byte[] segmentBytes : segments) {
             extract(segmentBytes, metadata, segmentType);

--- a/Source/com/drew/metadata/jpeg/JpegReader.java
+++ b/Source/com/drew/metadata/jpeg/JpegReader.java
@@ -25,6 +25,7 @@ import com.drew.imaging.jpeg.JpegSegmentType;
 import com.drew.lang.SequentialByteArrayReader;
 import com.drew.lang.SequentialReader;
 import com.drew.lang.annotations.NotNull;
+import com.drew.lang.annotations.Nullable;
 import com.drew.metadata.Metadata;
 
 import java.io.IOException;
@@ -63,7 +64,7 @@ public class JpegReader implements JpegSegmentMetadataReader
         );
     }
 
-    public void readJpegSegments(@NotNull Iterable<byte[]> segments, @NotNull Metadata metadata, @NotNull JpegSegmentType segmentType, Locale locale)
+    public void readJpegSegments(@NotNull Iterable<byte[]> segments, @NotNull Metadata metadata, @NotNull JpegSegmentType segmentType, @Nullable Locale locale)
     {
         for (byte[] segmentBytes : segments) {
             extract(segmentBytes, metadata, segmentType);

--- a/Source/com/drew/metadata/mov/atoms/canon/CanonThumbnailAtom.java
+++ b/Source/com/drew/metadata/mov/atoms/canon/CanonThumbnailAtom.java
@@ -59,7 +59,7 @@ public class CanonThumbnailAtom extends Atom
             // TODO should we keep all extracted metadata here?
             Metadata metadata = new Metadata();
             for (JpegSegmentType segmentType : exifReader.getSegmentTypes()) {
-                exifReader.readJpegSegments(segmentData.getSegments(segmentType), metadata, segmentType);
+                exifReader.readJpegSegments(segmentData.getSegments(segmentType), metadata, segmentType, null);
             }
 
             Directory directory = metadata.getFirstDirectoryOfType(ExifIFD0Directory.class);

--- a/Source/com/drew/metadata/photoshop/DuckyReader.java
+++ b/Source/com/drew/metadata/photoshop/DuckyReader.java
@@ -30,6 +30,7 @@ import com.drew.metadata.Metadata;
 
 import java.io.IOException;
 import java.util.Collections;
+import java.util.Locale;
 
 /**
  * Reads Photoshop "ducky" segments, created during Save-for-Web.
@@ -48,7 +49,7 @@ public class DuckyReader implements JpegSegmentMetadataReader
         return Collections.singletonList(JpegSegmentType.APPC);
     }
 
-    public void readJpegSegments(@NotNull Iterable<byte[]> segments, @NotNull Metadata metadata, @NotNull JpegSegmentType segmentType)
+    public void readJpegSegments(@NotNull Iterable<byte[]> segments, @NotNull Metadata metadata, @NotNull JpegSegmentType segmentType, Locale locale)
     {
         final int preambleLength = JPEG_SEGMENT_PREAMBLE.length();
 

--- a/Source/com/drew/metadata/photoshop/DuckyReader.java
+++ b/Source/com/drew/metadata/photoshop/DuckyReader.java
@@ -26,6 +26,7 @@ import com.drew.lang.Charsets;
 import com.drew.lang.SequentialByteArrayReader;
 import com.drew.lang.SequentialReader;
 import com.drew.lang.annotations.NotNull;
+import com.drew.lang.annotations.Nullable;
 import com.drew.metadata.Metadata;
 
 import java.io.IOException;
@@ -49,7 +50,7 @@ public class DuckyReader implements JpegSegmentMetadataReader
         return Collections.singletonList(JpegSegmentType.APPC);
     }
 
-    public void readJpegSegments(@NotNull Iterable<byte[]> segments, @NotNull Metadata metadata, @NotNull JpegSegmentType segmentType, Locale locale)
+    public void readJpegSegments(@NotNull Iterable<byte[]> segments, @NotNull Metadata metadata, @NotNull JpegSegmentType segmentType, @Nullable Locale locale)
     {
         final int preambleLength = JPEG_SEGMENT_PREAMBLE.length();
 

--- a/Source/com/drew/metadata/photoshop/PhotoshopReader.java
+++ b/Source/com/drew/metadata/photoshop/PhotoshopReader.java
@@ -37,6 +37,7 @@ import com.drew.metadata.xmp.XmpReader;
 
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.Locale;
 
 /**
  * Reads metadata created by Photoshop and stored in the APPD segment of JPEG files.
@@ -58,7 +59,7 @@ public class PhotoshopReader implements JpegSegmentMetadataReader
         return Collections.singletonList(JpegSegmentType.APPD);
     }
 
-    public void readJpegSegments(@NotNull Iterable<byte[]> segments, @NotNull Metadata metadata, @NotNull JpegSegmentType segmentType)
+    public void readJpegSegments(@NotNull Iterable<byte[]> segments, @NotNull Metadata metadata, @NotNull JpegSegmentType segmentType, Locale locale)
     {
         final int preambleLength = JPEG_SEGMENT_PREAMBLE.length();
 

--- a/Source/com/drew/metadata/photoshop/PhotoshopReader.java
+++ b/Source/com/drew/metadata/photoshop/PhotoshopReader.java
@@ -59,7 +59,7 @@ public class PhotoshopReader implements JpegSegmentMetadataReader
         return Collections.singletonList(JpegSegmentType.APPD);
     }
 
-    public void readJpegSegments(@NotNull Iterable<byte[]> segments, @NotNull Metadata metadata, @NotNull JpegSegmentType segmentType, Locale locale)
+    public void readJpegSegments(@NotNull Iterable<byte[]> segments, @NotNull Metadata metadata, @NotNull JpegSegmentType segmentType, @Nullable Locale locale)
     {
         final int preambleLength = JPEG_SEGMENT_PREAMBLE.length();
 

--- a/Source/com/drew/metadata/photoshop/PhotoshopTiffHandler.java
+++ b/Source/com/drew/metadata/photoshop/PhotoshopTiffHandler.java
@@ -33,7 +33,7 @@ public class PhotoshopTiffHandler extends ExifTiffHandler
 
     public PhotoshopTiffHandler(Metadata metadata, Directory parentDirectory)
     {
-        super(metadata, parentDirectory);
+        super(metadata, parentDirectory, null);
     }
 
     public boolean customProcessTag(final int tagOffset,

--- a/Source/com/drew/metadata/xmp/XmpReader.java
+++ b/Source/com/drew/metadata/xmp/XmpReader.java
@@ -40,6 +40,7 @@ import com.drew.metadata.StringValue;
 import java.io.IOException;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Locale;
 
 /**
  * Extracts XMP data from JPEG APP1 segments.
@@ -85,12 +86,12 @@ public class XmpReader implements JpegSegmentMetadataReader
     /**
      * Version specifically for dealing with XMP found in JPEG segments. This form of XMP has a peculiar preamble, which
      * must be removed before parsing the XML.
-     *
      * @param segments The byte array from which the metadata should be extracted.
      * @param metadata The {@link Metadata} object into which extracted values should be merged.
      * @param segmentType The {@link JpegSegmentType} being read.
+     * @param locale
      */
-    public void readJpegSegments(@NotNull Iterable<byte[]> segments, @NotNull Metadata metadata, @NotNull JpegSegmentType segmentType)
+    public void readJpegSegments(@NotNull Iterable<byte[]> segments, @NotNull Metadata metadata, @NotNull JpegSegmentType segmentType, Locale locale)
     {
         final int preambleLength = XMP_JPEG_PREAMBLE.length();
         final int extensionPreambleLength = XMP_EXTENSION_JPEG_PREAMBLE.length();

--- a/Source/com/drew/metadata/xmp/XmpReader.java
+++ b/Source/com/drew/metadata/xmp/XmpReader.java
@@ -91,7 +91,7 @@ public class XmpReader implements JpegSegmentMetadataReader
      * @param segmentType The {@link JpegSegmentType} being read.
      * @param locale
      */
-    public void readJpegSegments(@NotNull Iterable<byte[]> segments, @NotNull Metadata metadata, @NotNull JpegSegmentType segmentType, Locale locale)
+    public void readJpegSegments(@NotNull Iterable<byte[]> segments, @NotNull Metadata metadata, @NotNull JpegSegmentType segmentType, @Nullable Locale locale)
     {
         final int preambleLength = XMP_JPEG_PREAMBLE.length();
         final int extensionPreambleLength = XMP_EXTENSION_JPEG_PREAMBLE.length();

--- a/Tests/com/drew/metadata/exif/ExifReaderTest.java
+++ b/Tests/com/drew/metadata/exif/ExifReaderTest.java
@@ -63,7 +63,7 @@ public class ExifReaderTest
     public void testExtractWithNullDataThrows() throws Exception
     {
         try{
-            new ExifReader().readJpegSegments(null, new Metadata(), JpegSegmentType.APP1);
+            new ExifReader().readJpegSegments(null, new Metadata(), JpegSegmentType.APP1, null);
             fail("Exception expected");
         } catch (NullPointerException npe) {
             // passed
@@ -89,7 +89,7 @@ public class ExifReaderTest
         Metadata metadata = new Metadata();
         ArrayList<byte[]> segments = new ArrayList<byte[]>();
         segments.add(badExifData);
-        new ExifReader().readJpegSegments(segments, metadata, JpegSegmentType.APP1);
+        new ExifReader().readJpegSegments(segments, metadata, JpegSegmentType.APP1, null);
         assertEquals(0, metadata.getDirectoryCount());
         assertFalse(metadata.hasErrors());
     }

--- a/Tests/com/drew/metadata/icc/IccReaderTest.java
+++ b/Tests/com/drew/metadata/icc/IccReaderTest.java
@@ -62,7 +62,7 @@ public class IccReaderTest
         byte[] app2Bytes = FileUtil.readBytes("Tests/Data/iccDataInvalid1.jpg.app2");
 
         Metadata metadata = new Metadata();
-        new IccReader().readJpegSegments(Arrays.asList(app2Bytes), metadata, JpegSegmentType.APP2);
+        new IccReader().readJpegSegments(Arrays.asList(app2Bytes), metadata, JpegSegmentType.APP2, null);
 
         IccDirectory directory = metadata.getFirstDirectoryOfType(IccDirectory.class);
 
@@ -76,7 +76,7 @@ public class IccReaderTest
         byte[] app2Bytes = FileUtil.readBytes("Tests/Data/withExifAndIptc.jpg.app2");
 
         Metadata metadata = new Metadata();
-        new IccReader().readJpegSegments(Arrays.asList(app2Bytes), metadata, JpegSegmentType.APP2);
+        new IccReader().readJpegSegments(Arrays.asList(app2Bytes), metadata, JpegSegmentType.APP2, null);
 
         IccDirectory directory = metadata.getFirstDirectoryOfType(IccDirectory.class);
 

--- a/Tests/com/drew/metadata/xmp/XmpReaderTest.java
+++ b/Tests/com/drew/metadata/xmp/XmpReaderTest.java
@@ -43,7 +43,7 @@ public class XmpReaderTest
         Metadata metadata = new Metadata();
         List<byte[]> jpegSegments = new ArrayList<byte[]>();
         jpegSegments.add(FileUtil.readBytes("Tests/Data/withXmpAndIptc.jpg.app1.1"));
-        new XmpReader().readJpegSegments(jpegSegments, metadata, JpegSegmentType.APP1);
+        new XmpReader().readJpegSegments(jpegSegments, metadata, JpegSegmentType.APP1, null);
 
         Collection<XmpDirectory> xmpDirectories = metadata.getDirectoriesOfType(XmpDirectory.class);
 


### PR DESCRIPTION
As initially discussed in https://github.com/drewnoakes/metadata-extractor-images/issues/35, the current formatting of certain tag descriptions are locale-dependent. The only way to influence the formatting is to set the locale globally, using `Locale#setLocale`. This can have undesirable effects when integrating `metadata-extractor` in a larger application.

This pull request explores the idea of making the `Locale` configurable. A specific `Locale` is passed to `JpegMetadataReader#readMetadata`, and all the way down to the `Descriptor`s that need it to format specific values. Two descriptors have been altered to show two specific examples:

* `ExifDescriptorBase` : to render the F-number (`f/6.0` vs `f/6,0`)
* `GpsDescriptor` : to render the longitude and latitude (`54° 59' 22.8"` vs `54° 59' 22,8"`)

See the two added tests in `JpegMetadataReaderTest` (`testConfigurableLocaleEnglish` and `testConfigurableLocaleDutch`).

There is still much left to be done:
* This pull request only addresses the above-mentioned JPEG descriptors formatting, there are many other cases that can be fixed in a similar way
* I've left some `TODO`s with further ideas, I did not want to make the pull request even larger
* This pull request probably violates the "Keep your PRs short and sweet"-guideline, not sure how to deal with that just yet

I am curious what you think of this, any feedback is welcome.