### PR TITLE
Allow Application Notes (XMP) in SubIFD

### DIFF
--- a/Source/com/drew/metadata/exif/ExifTiffHandler.java
+++ b/Source/com/drew/metadata/exif/ExifTiffHandler.java
@@ -231,7 +231,7 @@ public class ExifTiffHandler extends DirectoryTiffHandler
         }
 
         // Custom processing for embedded XMP data
-        if (tagId == ExifSubIFDDirectory.TAG_APPLICATION_NOTES && _currentDirectory instanceof ExifIFD0Directory) {
+        if (tagId == ExifSubIFDDirectory.TAG_APPLICATION_NOTES && (_currentDirectory instanceof ExifIFD0Directory || _currentDirectory instanceof ExifSubIFDDirectory)) {
             new XmpReader().extract(reader.getNullTerminatedBytes(tagOffset, byteCount), _metadata, _currentDirectory);
             return true;
         }


### PR DESCRIPTION
Fixes #539

This is a port of https://github.com/drewnoakes/metadata-extractor-dotnet/pull/298/

This fixes an issue where XMP data was not being extracted from some DJI images, and allows presentation of data such as:

```
[XMPMeta - http://www.dji.com/drone-dji/1.0/] drone-dji:AbsoluteAltitude = -30.037239
[XMPMeta - http://www.dji.com/drone-dji/1.0/] drone-dji:RelativeAltitude = 19.700001
[XMPMeta - http://www.dji.com/drone-dji/1.0/] drone-dji:GimbalRollDegree = 0.000000
[XMPMeta - http://www.dji.com/drone-dji/1.0/] drone-dji:GimbalYawDegree = 69.400002
[XMPMeta - http://www.dji.com/drone-dji/1.0/] drone-dji:GimbalPitchDegree = -60.000000
[XMPMeta - http://www.dji.com/drone-dji/1.0/] drone-dji:FlightRollDegree = -2.100000
[XMPMeta - http://www.dji.com/drone-dji/1.0/] drone-dji:FlightYawDegree = 69.699997
[XMPMeta - http://www.dji.com/drone-dji/1.0/] drone-dji:FlightPitchDegree = -0.500000
[XMPMeta - http://www.dji.com/drone-dji/1.0/] drone-dji:CamReverse = 0
[XMPMeta - http://www.dji.com/drone-dji/1.0/] drone-dji:GimbalReverse = 0
[XMPMeta - http://www.dji.com/drone-dji/1.0/] drone-dji:RtkFlag = 0
```