### PR TITLE
Fix reading arrays of Float64 in TIFF files

### DIFF
--- a/Source/com/drew/imaging/tiff/TiffReader.java
+++ b/Source/com/drew/imaging/tiff/TiffReader.java
@@ -300,7 +300,7 @@ public class TiffReader
                 } else {
                     double[] array = new double[componentCount];
                     for (int i = 0; i < componentCount; i++)
-                        array[i] = reader.getDouble64(tagValueOffset + (i * 4));
+                        array[i] = reader.getDouble64(tagValueOffset + (i * 8));
                     handler.setDoubleArray(tagId, array);
                 }
                 break;


### PR DESCRIPTION
Double64 should take 8 bytes, instead of 4. 

I found this bug when I tried to read tags from a geotiff.

The original data was 
7B 14 AE 47 E1 7A 84 3F  ----- 0.01  index 0 - 7 
7B 14 AE 47 E1 7A 84 3F  ----- 0.01  index 8 - 15 
00 00 00 00 00 00 00 00  ----- 0       index 16 - 23 

but metadata-extractor read it like this:
7B 14 AE 47 E1 7A 84 3F   ------- index 0 - 7
E1 7A 84 3F 7B 14 AE 47   ------- index 4 - 11 [should be 8 - 15]
7B 14 AE 47 E1 7A 84 3F   ------- index 8 - 15 [should be 16 - 23]
