### PR TITLE
Fix integer addition overflow.

### DIFF
--- a/Source/com/drew/lang/SequentialByteArrayReader.java
+++ b/Source/com/drew/lang/SequentialByteArrayReader.java
@@ -70,7 +70,7 @@ public class SequentialByteArrayReader extends SequentialReader
     @Override
     public byte[] getBytes(int count) throws IOException
     {
-        if (_index + count > _bytes.length) {
+        if ((long)_index + count > _bytes.length) {
             throw new EOFException("End of data reached.");
         }
 
@@ -84,7 +84,7 @@ public class SequentialByteArrayReader extends SequentialReader
     @Override
     public void getBytes(@NotNull byte[] buffer, int offset, int count) throws IOException
     {
-        if (_index + count > _bytes.length) {
+        if ((long)_index + count > _bytes.length) {
             throw new EOFException("End of data reached.");
         }
 
@@ -113,12 +113,12 @@ public class SequentialByteArrayReader extends SequentialReader
             throw new IllegalArgumentException("n must be zero or greater.");
         }
 
-        _index += n;
-
-        if (_index > _bytes.length) {
+        if (_index + n > _bytes.length)  {
             _index = _bytes.length;
             return false;
         }
+
+        _index += n;
 
         return true;
     }

--- a/Source/com/drew/lang/StreamReader.java
+++ b/Source/com/drew/lang/StreamReader.java
@@ -68,9 +68,14 @@ public class StreamReader extends SequentialReader
     @Override
     public byte[] getBytes(int count) throws IOException
     {
-        byte[] bytes = new byte[count];
-        getBytes(bytes, 0, count);
-        return bytes;
+        try {
+            byte[] bytes = new byte[count];
+            getBytes(bytes, 0, count);
+            return bytes;
+        } catch (OutOfMemoryError e) {
+            throw new EOFException("End of data reached.");
+        }
+
     }
 
     @Override

--- a/Tests/com/drew/lang/SequentialAccessTestBase.java
+++ b/Tests/com/drew/lang/SequentialAccessTestBase.java
@@ -40,7 +40,7 @@ public abstract class SequentialAccessTestBase
     @Test
     public void testDefaultEndianness()
     {
-        assertEquals(true, createReader(new byte[1]).isMotorolaByteOrder());
+        assertTrue(createReader(new byte[1]).isMotorolaByteOrder());
     }
 
     @Test
@@ -269,10 +269,17 @@ public abstract class SequentialAccessTestBase
     @Test
     public void testOverflowBoundsCalculation()
     {
-        SequentialReader reader = createReader(new byte[10]);
+        try {
+            SequentialReader reader = createReader(new byte[10]);
+            reader.getBytes(15);
+        } catch (IOException e) {
+            assertEquals("End of data reached.", e.getMessage());
+        }
 
         try {
-            reader.getBytes(15);
+            SequentialReader reader = createReader(new byte[10]);
+            reader.getBytes(5);
+            reader.getBytes(Integer.MAX_VALUE);
         } catch (IOException e) {
             assertEquals("End of data reached.", e.getMessage());
         }
@@ -325,6 +332,13 @@ public abstract class SequentialAccessTestBase
             reader.skip(1);
             fail("Expecting exception");
         } catch (EOFException ignored) {}
+
+        try {
+            reader = createReader(new byte[100]);
+            reader.skip(50);
+            reader.skip(Integer.MAX_VALUE);
+            fail("Expecting exception");
+        } catch (EOFException ignored) {}
     }
 
     @Test
@@ -336,5 +350,9 @@ public abstract class SequentialAccessTestBase
         assertTrue(reader.trySkip(1));
         assertTrue(reader.trySkip(1));
         assertFalse(reader.trySkip(1));
+
+        reader = createReader(new byte[100]);
+        reader.getBytes(50);
+        assertFalse(reader.trySkip(Integer.MAX_VALUE));
     }
 }


### PR DESCRIPTION
An integer overflow can occur when extending the index, preventing
guard statements from catching indices outside the expected buffer
range and resulting in OutOfMemory exceptions from array allocation.