### PR TITLE
Fujifilm enhancements

### DIFF
--- a/Source/com/drew/metadata/exif/makernotes/FujifilmMakernoteDescriptor.java
+++ b/Source/com/drew/metadata/exif/makernotes/FujifilmMakernoteDescriptor.java
@@ -115,7 +115,7 @@ public class FujifilmMakernoteDescriptor extends TagDescriptor<FujifilmMakernote
     }
 
     @Nullable
-    private String getMakernoteVersionDescription()
+    public String getMakernoteVersionDescription()
     {
         return getVersionBytesDescription(TAG_MAKERNOTE_VERSION, 2);
     }
@@ -444,6 +444,11 @@ public class FujifilmMakernoteDescriptor extends TagDescriptor<FujifilmMakernote
             case 0x400: return "F4/Velvia";
             case 0x500: return "Pro Neg. Std";
             case 0x501: return "Pro Neg. Hi";
+            case 0x600: return "Classic Chrome";
+            case 0x700: return "Eterna";
+            case 0x800: return "Classic Negative";
+            case 0x900: return "Bleach Bypass";
+            case 0xa00: return "Nostalgic Neg";
             default:
                 return "Unknown (" + value + ")";
         }
@@ -466,4 +471,11 @@ public class FujifilmMakernoteDescriptor extends TagDescriptor<FujifilmMakernote
                 return "Unknown (" + value + ")";
         }
     }
+    @Nullable
+    public int getImageNumber()
+    {
+        final Integer value = _directory.getInteger(TAG_IMAGE_NUMBER);
+        return value;
+    }
 }
+

--- a/Source/com/drew/metadata/exif/makernotes/FujifilmMakernoteDescriptor.java
+++ b/Source/com/drew/metadata/exif/makernotes/FujifilmMakernoteDescriptor.java
@@ -471,11 +471,5 @@ public class FujifilmMakernoteDescriptor extends TagDescriptor<FujifilmMakernote
                 return "Unknown (" + value + ")";
         }
     }
-    @Nullable
-    public int getImageNumber()
-    {
-        final Integer value = _directory.getInteger(TAG_IMAGE_NUMBER);
-        return value;
-    }
 }
 

--- a/Source/com/drew/metadata/exif/makernotes/FujifilmMakernoteDirectory.java
+++ b/Source/com/drew/metadata/exif/makernotes/FujifilmMakernoteDirectory.java
@@ -93,6 +93,7 @@ public class FujifilmMakernoteDirectory extends Directory
     public static final int TAG_FRAME_NUMBER = 0x8003;
 
     public static final int TAG_PARALLAX = 0xb211;
+    public static final int TAG_IMAGE_NUMBER = 0x1438;
 
     @NotNull
     private static final HashMap<Integer, String> _tagNameMap = new HashMap<Integer, String>();
@@ -156,6 +157,7 @@ public class FujifilmMakernoteDirectory extends Directory
         _tagNameMap.put(TAG_FRAME_NUMBER, "Frame Number");
 
         _tagNameMap.put(TAG_PARALLAX, "Parallax");
+        _tagNameMap.put(TAG_IMAGE_NUMBER, "Image Number");
     }
 
     public FujifilmMakernoteDirectory()


### PR DESCRIPTION
This commit brings the following:
-  adds the ability to retrieve the image actuation for Fuji cameras
-  completes the list of Film simulations
-  turns method getMakerNoteVersionDescription from private to public


Nice work! Thank you!