### PR TITLE
fix:set locale to en/us to format numbers with ".", not ","

### DIFF
--- a/Source/com/drew/tools/ProcessAllImagesInFolderUtility.java
+++ b/Source/com/drew/tools/ProcessAllImagesInFolderUtility.java
@@ -51,6 +51,8 @@ public class ProcessAllImagesInFolderUtility
 {
     public static void main(String[] args) throws IOException
     {
+        Locale.setDefault(new Locale("en", "US"));
+
         List<String> directories = new ArrayList<String>();
 
         FileHandler handler = null;

--- a/Source/com/drew/tools/ProcessAllImagesInFolderUtility.java
+++ b/Source/com/drew/tools/ProcessAllImagesInFolderUtility.java
@@ -52,6 +52,7 @@ public class ProcessAllImagesInFolderUtility
     public static void main(String[] args) throws IOException
     {
         Locale.setDefault(new Locale("en", "US"));
+        System.setProperty("user.timezone", "Australia/Sydney");
 
         List<String> directories = new ArrayList<String>();
 


### PR DESCRIPTION
Running the test suite on a German OS causes all numbers to appear as "5,2" instead of "5.2", marking every file as diffs. Setting the global locale of java to en/US seems to resolve it.
Furthermore, due to a different timezone, creation+modifiy dates appear in different style