### PR TITLE
properly strip trailing null characters (\0) from tag data

### DIFF
--- a/Source/com/drew/lang/SequentialReader.java
+++ b/Source/com/drew/lang/SequentialReader.java
@@ -362,7 +362,9 @@ public abstract class SequentialReader
 
     /**
      * Returns the sequence of bytes punctuated by a <code>\0</code> value.
-     *
+     * It will place the cursor after the first occurrence of  <code>\0</code>.
+     * <br/>
+     * Use <code>getNullTerminatedStringAndSkipToNextPosition</code> if you want the cursor to move moved at the end of <code>maxLengthBytes</code>.
      * @param maxLengthBytes The maximum number of bytes to read. If a <code>\0</code> byte is not reached within this limit,
      * the returned array will be <code>maxLengthBytes</code> long.
      * @return The read byte array, excluding the null terminator.
@@ -385,5 +387,21 @@ public abstract class SequentialReader
         if (length > 0)
             System.arraycopy(buffer, 0, bytes, 0, length);
         return bytes;
+    }
+
+
+    /**
+     * Read until the null terminated byte and automatically move the end of the requested position.
+     * @param maxLengthBytes
+     * @param charset
+     * @return
+     * @throws IOException
+     */
+    public StringValue getNullTerminatedStringAndSkipToNextPosition(int maxLengthBytes, Charset charset) throws IOException {
+        byte[] bytes = this.getNullTerminatedBytes(maxLengthBytes);
+        if (bytes.length < maxLengthBytes - 1) {
+            this.trySkip(maxLengthBytes - bytes.length - 1);
+        }
+        return new StringValue(bytes, charset);
     }
 }

--- a/Source/com/drew/metadata/exif/makernotes/NikonPictureControl1Directory.java
+++ b/Source/com/drew/metadata/exif/makernotes/NikonPictureControl1Directory.java
@@ -78,9 +78,9 @@ public final class NikonPictureControl1Directory extends Directory
 
         NikonPictureControl1Directory directory = new NikonPictureControl1Directory();
 
-        directory.setObject(TAG_PICTURE_CONTROL_VERSION, reader.getStringValue(4, Charsets.UTF_8));
-        directory.setObject(TAG_PICTURE_CONTROL_NAME, reader.getStringValue(20, Charsets.UTF_8));
-        directory.setObject(TAG_PICTURE_CONTROL_BASE, reader.getStringValue(20, Charsets.UTF_8));
+        directory.setString(TAG_PICTURE_CONTROL_VERSION, reader.getNullTerminatedStringAndSkipToNextPosition(4, Charsets.UTF_8).toString());
+        directory.setString(TAG_PICTURE_CONTROL_NAME, reader.getNullTerminatedStringAndSkipToNextPosition(20, Charsets.UTF_8).toString());
+        directory.setString(TAG_PICTURE_CONTROL_BASE, reader.getNullTerminatedStringAndSkipToNextPosition(20, Charsets.UTF_8).toString());
         reader.skip(4);
         directory.setObject(TAG_PICTURE_CONTROL_ADJUST, reader.getUInt8());
         directory.setObject(TAG_PICTURE_CONTROL_QUICK_ADJUST, reader.getUInt8());

--- a/Source/com/drew/metadata/exif/makernotes/NikonPictureControl2Directory.java
+++ b/Source/com/drew/metadata/exif/makernotes/NikonPictureControl2Directory.java
@@ -86,9 +86,9 @@ public final class NikonPictureControl2Directory extends Directory
 
         NikonPictureControl2Directory directory = new NikonPictureControl2Directory();
 
-        directory.setString(TAG_PICTURE_CONTROL_VERSION, reader.getStringValue(4, Charsets.UTF_8).toString());
-        directory.setString(TAG_PICTURE_CONTROL_NAME, reader.getStringValue(20, Charsets.UTF_8).toString());
-        directory.setString(TAG_PICTURE_CONTROL_BASE, reader.getStringValue(20, Charsets.UTF_8).toString());
+        directory.setString(TAG_PICTURE_CONTROL_VERSION, reader.getNullTerminatedStringAndSkipToNextPosition(4, Charsets.UTF_8).toString());
+        directory.setString(TAG_PICTURE_CONTROL_NAME, reader.getNullTerminatedStringAndSkipToNextPosition(20, Charsets.UTF_8).toString());
+        directory.setString(TAG_PICTURE_CONTROL_BASE, reader.getNullTerminatedStringAndSkipToNextPosition(20, Charsets.UTF_8).toString());
 
         reader.skip(4);
         directory.setObject(TAG_PICTURE_CONTROL_ADJUST, reader.getByte());

--- a/Tests/com/drew/lang/SequentialAccessTestBase.java
+++ b/Tests/com/drew/lang/SequentialAccessTestBase.java
@@ -241,24 +241,39 @@ public abstract class SequentialAccessTestBase
     }
 
     @Test
-    public void testGetNullTerminatedStringCursorPositionTest() throws IOException
-    {
+    public void testGetNullTerminatedStringCursorPositionTest() throws IOException {
         byte NULL = 0x00;
         byte[] bytes = new byte[]{0x41, 0x42, NULL, NULL, NULL, 0x43, 0x44, NULL, 0x41, 0x42, 0x43, 0x44, 0x45, 0x46}; //AB\0\0\0CD\0ABCDEF
         SequentialReader reader = createReader(bytes);
 
-        // try to read first five values
-        assertEquals("AB", reader.getNullTerminatedString(5, Charsets.UTF_8));
+        /*
+        tried to read first five values
+         */
+        assertEquals("AB", reader.getNullTerminatedString(5, Charsets.UTF_8).toString());
 
-        // the cursor is after B (third) position
+        /*
+        the cursor is after B (third) position
+         */
         assertEquals(reader.getPosition(), 3);
         reader.skip(2);
 
-        assertEquals("CD", reader.getNullTerminatedString(3, Charsets.UTF_8));
+        assertEquals("CD", reader.getNullTerminatedString(3, Charsets.UTF_8).toString());
 
         assertEquals(reader.getPosition(), 8);
         //no need to skip to next position. since there's only one \0 character after "CD"
-        assertEquals("ABCDEF", reader.getNullTerminatedString(6, Charsets.UTF_8));
+
+        assertEquals("ABCDEF", reader.getNullTerminatedString(6, Charsets.UTF_8).toString());
+    }
+
+    @Test
+    public void testGetNullTerminatedStringAndSkipToNextPosition() throws IOException {
+        byte NULL = 0x00;
+        byte[] bytes = new byte[]{0x41, 0x42, NULL, NULL, NULL, 0x43, 0x44, NULL, 0x41, 0x42, 0x43, 0x44, 0x45, 0x46};
+        SequentialReader reader = createReader(bytes);
+
+        assertEquals("AB", reader.getNullTerminatedStringAndSkipToNextPosition(5, Charsets.UTF_8).toString());
+        assertEquals("CD", reader.getNullTerminatedStringAndSkipToNextPosition(3, Charsets.UTF_8).toString());
+        assertEquals("ABCDEF", reader.getNullTerminatedStringAndSkipToNextPosition(6, Charsets.UTF_8).toString());
     }
 
     @Test


### PR DESCRIPTION
A change from https://github.com/drewnoakes/metadata-extractor/pull/634/files#diff-7df436f0258b5156fd15792db94b4cab6119180ad7d605533ffb53213f048ba2R400 got missed in earlier merge. 

https://github.com/drewnoakes/metadata-extractor/pull/635