### PR TITLE
Add HEIC/HEIF to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ It will process files of type:
 * PNG
 * BMP
 * GIF
+* HEIF / HEIC
 * ICO
 * PCX
 * QuickTime


### PR DESCRIPTION
As pointed out in #631, the README doesn't mention HEIF/HEIC support as it should.