### PR TITLE
Support AVIF / AV1 images

### DIFF
--- a/Source/com/drew/imaging/FileType.java
+++ b/Source/com/drew/imaging/FileType.java
@@ -47,6 +47,7 @@ public enum FileType
     QuickTime("MOV", "QuickTime Movie", "video/quicktime", "mov", "qt"),
     Mp4("MP4", "MPEG-4 Part 14", "video/mp4", "mp4", "m4a", "m4p", "m4b", "m4r", "m4v"),
     Heif("HEIF", "High Efficiency Image File Format", "image/heif", "heif", "heic"),
+    Avif("AVIF", "AV1 Image File Format", "image/avif", "avif"),
     Eps("EPS", "Encapsulated PostScript", "application/postscript", "eps", "epsf", "epsi"),
     Mp3("MP3", "MPEG Audio Layer III", "audio/mpeg", "mp3"),
 

--- a/Source/com/drew/imaging/ImageMetadataReader.java
+++ b/Source/com/drew/imaging/ImageMetadataReader.java
@@ -180,6 +180,7 @@ public class ImageMetadataReader
             case Eps:
                 return EpsMetadataReader.readMetadata(inputStream);
             case Heif:
+            case Avif:
                 return HeifMetadataReader.readMetadata(inputStream);
             case Unknown:
                 throw new ImageProcessingException("File format could not be determined");

--- a/Source/com/drew/imaging/quicktime/QuickTimeTypeChecker.java
+++ b/Source/com/drew/imaging/quicktime/QuickTimeTypeChecker.java
@@ -80,6 +80,9 @@ public class QuickTimeTypeChecker implements TypeChecker
         _ftypMap.put("hevc", FileType.Heif);
         _ftypMap.put("hevx", FileType.Heif);
 
+        // AVIF
+        _ftypMap.put("avif", FileType.Avif);
+
         // CRX
         _ftypMap.put("crx ", FileType.Crx);
     }


### PR DESCRIPTION
The AVIF closely resembles the HEIF format, with the primary distinction lying in the compression algorithm applied to the pixel data. For extracting container metadata, one can employ the same logic, as AVIF utilizes the ISO BMFF boxes outlined in the HEIC standard.

Resolves #608.

Tested and verified using this sample file: [photo_74.avif.zip](https://github.com/drewnoakes/metadata-extractor/files/14151981/photo_74.avif.zip)
