### PR TITLE
Issue #685 | Fix StringIndexOutOfBoundsException in ICC DESC tag processing

### DIFF
--- a/Source/com/drew/metadata/icc/IccDescriptor.java
+++ b/Source/com/drew/metadata/icc/IccDescriptor.java
@@ -21,6 +21,7 @@
 
 package com.drew.metadata.icc;
 
+import com.drew.lang.BufferBoundsException;
 import com.drew.lang.ByteArrayReader;
 import com.drew.lang.RandomAccessReader;
 import com.drew.lang.annotations.NotNull;
@@ -91,6 +92,11 @@ public class IccDescriptor extends TagDescriptor<IccDirectory>
                     }
                 case ICC_TAG_TYPE_DESC:
                     int stringLength = reader.getInt32(8);
+
+                    if (stringLength < 0 || stringLength > (bytes.length - 12)) {
+                        throw new BufferBoundsException(12, stringLength, bytes.length);
+                    }
+
                     return new String(bytes, 12, stringLength - 1);
                 case ICC_TAG_TYPE_SIG:
                     return IccReader.getStringFromInt32(reader.getInt32(8));


### PR DESCRIPTION
This PR resolves an issue where malformed ICC profiles could trigger a 
StringIndexOutOfBoundsException during the processing of the DESC tag.

- Validates `stringLength` to ensure it is not negative and does not exceed 
  `bytes.length - 12`.
- Throws a `BufferBoundsException` with a detailed message for invalid cases.
- Ensures the library gracefully handles corrupted ICC profiles.

This fix improves robustness in handling ICC metadata and prevents crashes 
caused by malformed data.
