### PR TITLE
Issue #698 | add DJI metadata support (ported from .NET)

### DIFF
--- a/Source/com/drew/metadata/exif/ExifTiffHandler.java
+++ b/Source/com/drew/metadata/exif/ExifTiffHandler.java
@@ -642,6 +642,10 @@ public class ExifTiffHandler extends DirectoryTiffHandler
             // Only handles Type2 notes correctly. Others aren't implemented, and it's complex to determine which ones to use
             pushDirectory(SamsungType2MakernoteDirectory.class);
             TiffReader.processIfd(this, reader, processedIfdOffsets, makernoteOffset, tiffHeaderOffset);
+        } else if ("DJI".equalsIgnoreCase(cameraMake)) {
+            // Only handles Type2 notes correctly. Others aren't implemented, and it's complex to determine which ones to use
+            pushDirectory(DjiMakernoteDirectory.class);
+            TiffReader.processIfd(this, reader, processedIfdOffsets, makernoteOffset, tiffHeaderOffset);
         } else {
             // The makernote is not comprehended by this library.
             // If you are reading this and believe a particular camera's image should be processed, get in touch.

--- a/Source/com/drew/metadata/exif/makernotes/DjiMakernoteDescriptor.java
+++ b/Source/com/drew/metadata/exif/makernotes/DjiMakernoteDescriptor.java
@@ -1,5 +1,22 @@
 /*
- *Copyright (c) Drew Noakes and contributors. All Rights Reserved. Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+ * Copyright 2002-2019 Drew Noakes and contributors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ * More information about this project is available at:
+ *
+ *    https://drewnoakes.com/code/exif/
+ *    https://github.com/drewnoakes/metadata-extractor
  */
 package com.drew.metadata.exif.makernotes;
 
@@ -8,11 +25,12 @@ import com.drew.lang.annotations.Nullable;
 import com.drew.metadata.TagDescriptor;
 
 /**
- *  <summary>
- *  Provides human-readable string representations of tag values stored in a <see cref="DjiMakernoteDirectory"/>.
- *  </summary>
- *  <remarks>Using information from https://metacpan.org/pod/distribution/Image-ExifTool/lib/Image/ExifTool/TagNames.pod#DJI-Tags</remarks>
- *  <author>SeanJay Zeng, adapted from Drew Noakes https://drewnoakes.com</author>
+ * Provides human-readable string representations of tag values stored in a {@link DjiMakernoteDirectory}.
+ * <p>
+ * Using information from <a href="https://metacpan.org/pod/distribution/Image-ExifTool/lib/Image/ExifTool/TagNames.pod#DJI-Tags">DJI Tags Documentation</a>.
+ *
+ * @author SeanJay Zeng
+ * @author Adapted from Drew Noakes (https://drewnoakes.com)
  */
 @SuppressWarnings("WeakerAccess")
 public class DjiMakernoteDescriptor extends TagDescriptor<DjiMakernoteDirectory>

--- a/Source/com/drew/metadata/exif/makernotes/DjiMakernoteDescriptor.java
+++ b/Source/com/drew/metadata/exif/makernotes/DjiMakernoteDescriptor.java
@@ -1,0 +1,31 @@
+/*
+ *Copyright (c) Drew Noakes and contributors. All Rights Reserved. Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+ */
+package com.drew.metadata.exif.makernotes;
+
+import com.drew.lang.annotations.NotNull;
+import com.drew.lang.annotations.Nullable;
+import com.drew.metadata.TagDescriptor;
+
+/**
+ *  <summary>
+ *  Provides human-readable string representations of tag values stored in a <see cref="DjiMakernoteDirectory"/>.
+ *  </summary>
+ *  <remarks>Using information from https://metacpan.org/pod/distribution/Image-ExifTool/lib/Image/ExifTool/TagNames.pod#DJI-Tags</remarks>
+ *  <author>SeanJay Zeng, adapted from Drew Noakes https://drewnoakes.com</author>
+ */
+@SuppressWarnings("WeakerAccess")
+public class DjiMakernoteDescriptor extends TagDescriptor<DjiMakernoteDirectory>
+{
+
+    public DjiMakernoteDescriptor(@NotNull DjiMakernoteDirectory directory) {
+        super(directory);
+    }
+
+    @Override
+    @Nullable
+    public String getDescription(int tagType)
+    {
+        return super.getDescription(tagType);
+    }
+}

--- a/Source/com/drew/metadata/exif/makernotes/DjiMakernoteDescriptor.java
+++ b/Source/com/drew/metadata/exif/makernotes/DjiMakernoteDescriptor.java
@@ -17,8 +17,8 @@ import com.drew.metadata.TagDescriptor;
 @SuppressWarnings("WeakerAccess")
 public class DjiMakernoteDescriptor extends TagDescriptor<DjiMakernoteDirectory>
 {
-
-    public DjiMakernoteDescriptor(@NotNull DjiMakernoteDirectory directory) {
+    public DjiMakernoteDescriptor(@NotNull DjiMakernoteDirectory directory)
+    {
         super(directory);
     }
 

--- a/Source/com/drew/metadata/exif/makernotes/DjiMakernoteDescriptor.java
+++ b/Source/com/drew/metadata/exif/makernotes/DjiMakernoteDescriptor.java
@@ -28,9 +28,6 @@ import com.drew.metadata.TagDescriptor;
  * Provides human-readable string representations of tag values stored in a {@link DjiMakernoteDirectory}.
  * <p>
  * Using information from <a href="https://metacpan.org/pod/distribution/Image-ExifTool/lib/Image/ExifTool/TagNames.pod#DJI-Tags">DJI Tags Documentation</a>.
- *
- * @author SeanJay Zeng
- * @author Adapted from Drew Noakes (https://drewnoakes.com)
  */
 @SuppressWarnings("WeakerAccess")
 public class DjiMakernoteDescriptor extends TagDescriptor<DjiMakernoteDirectory>

--- a/Source/com/drew/metadata/exif/makernotes/DjiMakernoteDirectory.java
+++ b/Source/com/drew/metadata/exif/makernotes/DjiMakernoteDirectory.java
@@ -16,7 +16,6 @@ import java.util.HashMap;
 @SuppressWarnings("WeakerAccess")
 public class DjiMakernoteDirectory extends Directory
 {
-
     public static final int TAG_MAKE = 0x0001;
     public static final int TAG_SPEED_X = 0x0003;
     public static final int TAG_SPEED_Y = 0x0004;

--- a/Source/com/drew/metadata/exif/makernotes/DjiMakernoteDirectory.java
+++ b/Source/com/drew/metadata/exif/makernotes/DjiMakernoteDirectory.java
@@ -1,5 +1,22 @@
 /*
- *   Copyright (c) Drew Noakes and contributors. All Rights Reserved. Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+ * Copyright 2002-2019 Drew Noakes and contributors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ * More information about this project is available at:
+ *
+ *    https://drewnoakes.com/code/exif/
+ *    https://github.com/drewnoakes/metadata-extractor
  */
 package com.drew.metadata.exif.makernotes;
 
@@ -9,9 +26,12 @@ import com.drew.metadata.Directory;
 import java.util.HashMap;
 
 /**
- *  <summary>Describes tags specific to DJI aircraft cameras.</summary>
- *  <remarks>Using information from https://metacpan.org/pod/distribution/Image-ExifTool/lib/Image/ExifTool/TagNames.pod#DJI-Tags</remarks>
- *  <author>SeanJay Zeng, adapted from Drew Noakes https://drewnoakes.com</author>
+ * Describes tags specific to DJI aircraft cameras.
+ * <p>
+ * Using information from <a href="https://metacpan.org/pod/distribution/Image-ExifTool/lib/Image/ExifTool/TagNames.pod#DJI-Tags">DJI Tags Documentation</a>.
+ *
+ * @author SeanJay Zeng
+ * @author Adapted from Drew Noakes (<a href="https://drewnoakes.com">https://drewnoakes.com</a>)
  */
 @SuppressWarnings("WeakerAccess")
 public class DjiMakernoteDirectory extends Directory

--- a/Source/com/drew/metadata/exif/makernotes/DjiMakernoteDirectory.java
+++ b/Source/com/drew/metadata/exif/makernotes/DjiMakernoteDirectory.java
@@ -29,9 +29,6 @@ import java.util.HashMap;
  * Describes tags specific to DJI aircraft cameras.
  * <p>
  * Using information from <a href="https://metacpan.org/pod/distribution/Image-ExifTool/lib/Image/ExifTool/TagNames.pod#DJI-Tags">DJI Tags Documentation</a>.
- *
- * @author SeanJay Zeng
- * @author Adapted from Drew Noakes (<a href="https://drewnoakes.com">https://drewnoakes.com</a>)
  */
 @SuppressWarnings("WeakerAccess")
 public class DjiMakernoteDirectory extends Directory
@@ -52,15 +49,15 @@ public class DjiMakernoteDirectory extends Directory
 
     static
     {
-        _tagNameMap.put(TAG_MAKE, "Make" );
-        _tagNameMap.put(TAG_SPEED_X, "Aircraft X Speed" );
-        _tagNameMap.put(TAG_SPEED_Y, "Aircraft Y Speed" );
-        _tagNameMap.put(TAG_SPEED_Z, "Aircraft Z Speed" );
-        _tagNameMap.put(TAG_AIRCRAFT_PITCH, "Aircraft Pitch" );
-        _tagNameMap.put(TAG_AIRCRAFT_YAW, "Aircraft Yaw" );
-        _tagNameMap.put(TAG_AIRCRAFT_ROLL, "Aircraft Roll" );
-        _tagNameMap.put(TAG_CAMERA_PITCH, "Camera Pitch" );
-        _tagNameMap.put(TAG_CAMERA_YAW, "Camera Yaw" );
+        _tagNameMap.put(TAG_MAKE, "Make");
+        _tagNameMap.put(TAG_SPEED_X, "Aircraft X Speed");
+        _tagNameMap.put(TAG_SPEED_Y, "Aircraft Y Speed");
+        _tagNameMap.put(TAG_SPEED_Z, "Aircraft Z Speed");
+        _tagNameMap.put(TAG_AIRCRAFT_PITCH, "Aircraft Pitch");
+        _tagNameMap.put(TAG_AIRCRAFT_YAW, "Aircraft Yaw");
+        _tagNameMap.put(TAG_AIRCRAFT_ROLL, "Aircraft Roll");
+        _tagNameMap.put(TAG_CAMERA_PITCH, "Camera Pitch");
+        _tagNameMap.put(TAG_CAMERA_YAW, "Camera Yaw");
         _tagNameMap.put(TAG_CAMERA_ROLL, "Camera Roll");
     }
 

--- a/Source/com/drew/metadata/exif/makernotes/DjiMakernoteDirectory.java
+++ b/Source/com/drew/metadata/exif/makernotes/DjiMakernoteDirectory.java
@@ -1,0 +1,64 @@
+/*
+ *   Copyright (c) Drew Noakes and contributors. All Rights Reserved. Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+ */
+package com.drew.metadata.exif.makernotes;
+
+import com.drew.lang.annotations.NotNull;
+import com.drew.metadata.Directory;
+
+import java.util.HashMap;
+
+/**
+ *  <summary>Describes tags specific to DJI aircraft cameras.</summary>
+ *  <remarks>Using information from https://metacpan.org/pod/distribution/Image-ExifTool/lib/Image/ExifTool/TagNames.pod#DJI-Tags</remarks>
+ *  <author>SeanJay Zeng, adapted from Drew Noakes https://drewnoakes.com</author>
+ */
+@SuppressWarnings("WeakerAccess")
+public class DjiMakernoteDirectory extends Directory
+{
+
+    public static final int TAG_MAKE = 0x0001;
+    public static final int TAG_SPEED_X = 0x0003;
+    public static final int TAG_SPEED_Y = 0x0004;
+    public static final int TAG_SPEED_Z = 0x0005;
+    public static final int TAG_AIRCRAFT_PITCH = 0x0006;
+    public static final int TAG_AIRCRAFT_YAW = 0x0007;
+    public static final int TAG_AIRCRAFT_ROLL = 0x0008;
+    public static final int TAG_CAMERA_PITCH = 0x0009;
+    public static final int TAG_CAMERA_YAW = 0x000A;
+    public static final int TAG_CAMERA_ROLL = 0x000B;
+
+    @NotNull
+    private static final HashMap<Integer, String> _tagNameMap = new HashMap<Integer, String>();
+
+    static
+    {
+        _tagNameMap.put(TAG_MAKE, "Make" );
+        _tagNameMap.put(TAG_SPEED_X, "Aircraft X Speed" );
+        _tagNameMap.put(TAG_SPEED_Y, "Aircraft Y Speed" );
+        _tagNameMap.put(TAG_SPEED_Z, "Aircraft Z Speed" );
+        _tagNameMap.put(TAG_AIRCRAFT_PITCH, "Aircraft Pitch" );
+        _tagNameMap.put(TAG_AIRCRAFT_YAW, "Aircraft Yaw" );
+        _tagNameMap.put(TAG_AIRCRAFT_ROLL, "Aircraft Roll" );
+        _tagNameMap.put(TAG_CAMERA_PITCH, "Camera Pitch" );
+        _tagNameMap.put(TAG_CAMERA_YAW, "Camera Yaw" );
+        _tagNameMap.put(TAG_CAMERA_ROLL, "Camera Roll");
+    }
+
+    public DjiMakernoteDirectory()
+    {
+        this.setDescriptor(new DjiMakernoteDescriptor(this));
+    }
+
+    @Override
+    public String getName() {
+        return "DJI Makernote";
+    }
+
+    @Override
+    @NotNull
+    protected HashMap<Integer, String> getTagNameMap()
+    {
+        return _tagNameMap;
+    }
+}

--- a/Source/com/drew/metadata/exif/makernotes/DjiMakernoteDirectory.java
+++ b/Source/com/drew/metadata/exif/makernotes/DjiMakernoteDirectory.java
@@ -51,7 +51,8 @@ public class DjiMakernoteDirectory extends Directory
     }
 
     @Override
-    public String getName() {
+    public String getName()
+    {
         return "DJI Makernote";
     }
 


### PR DESCRIPTION
- Ported from [drewnoakes/metadata-extractor](https://github.com/drewnoakes/metadata-extractor-dotnet/blob/main/MetadataExtractor/Formats/Exif/makernotes/DJIMakernoteDirectory.cs)'s .NET implementation

Fixes #698