### PR TITLE
Added reference to Beeld, another Clojure wrapper for metadata-extractor

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ Wherever possible, they have been credited in the source code and commit logs.
 - .NET  [metadata-extractor-dotnet](https://github.com/drewnoakes/metadata-extractor-dotnet) is a complete port to C#, maintained alongside this library
 - PHP [php-metadata-extractor](https://github.com/gomoob/php-metadata-extractor) wraps this Java project, making it available to users of PHP
 - Clojure [exif-processor](https://github.com/joshuamiller/exif-processor) wraps this Java project, returning a subset of data
-
+- Clojure [beeld](https://github.com/danielsz/beeld) wraps this Java project, returning all of the data. It also defines an interface for low-level image manipulation. It will resize an image while honoring the orientation tag, preserving portrait mode (something Java's _ImageIO_ doesn't do).
 ---
 
 More information about this project is available at:


### PR DESCRIPTION
Differences with exif-processor:

1. Does not hard-code a subset of IFDs, but returns all the tags reported by metadata-extractor . 
2. Does not flatten the results so no further loss of tags due due to key collisions. Returns the same hierarchical structure as metadata-extractor, with IFDs as logical groupings.
4. Contains additional functionality for low-level image manipulation (will resize an image while honoring the orientation tag, preserving portrait mode, something Java's _ImageIO_ doesn't do).