### PR TITLE
Fix NegativeArraySizeException in SequentialByteArrayReader

### DIFF
--- a/Source/com/drew/lang/SequentialByteArrayReader.java
+++ b/Source/com/drew/lang/SequentialByteArrayReader.java
@@ -70,6 +70,9 @@ public class SequentialByteArrayReader extends SequentialReader
     @Override
     public byte[] getBytes(int count) throws IOException
     {
+        if (count < 0) {
+            throw new IllegalArgumentException("Requested byte count must not be negative");
+        }
         if ((long)_index + count > _bytes.length) {
             throw new EOFException("End of data reached.");
         }
@@ -84,6 +87,12 @@ public class SequentialByteArrayReader extends SequentialReader
     @Override
     public void getBytes(@NotNull byte[] buffer, int offset, int count) throws IOException
     {
+        if (count < 0) {
+            throw new IllegalArgumentException("Requested byte count must not be negative");
+        }
+        if (offset < 0) {
+            throw new IllegalArgumentException("Buffer offset must not be negative");
+        }
         if ((long)_index + count > _bytes.length) {
             throw new EOFException("End of data reached.");
         }

--- a/Tests/com/drew/lang/SequentialByteArrayReaderTest.java
+++ b/Tests/com/drew/lang/SequentialByteArrayReaderTest.java
@@ -22,6 +22,8 @@ package com.drew.lang;
 
 import org.junit.Test;
 
+import java.io.IOException;
+
 /**
  * @author Drew Noakes https://drewnoakes.com
  */
@@ -32,6 +34,29 @@ public class SequentialByteArrayReaderTest extends SequentialAccessTestBase
     public void testConstructWithNullStreamThrows()
     {
         new SequentialByteArrayReader(null);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testGetBytesWithNegativeCountThrows() throws IOException
+    {
+        SequentialByteArrayReader reader = new SequentialByteArrayReader(new byte[10]);
+        reader.getBytes(-1);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testGetBytesWithNegativeOffsetThrows() throws IOException
+    {
+        SequentialByteArrayReader reader = new SequentialByteArrayReader(new byte[10]);
+        byte[] buffer = new byte[5];
+        reader.getBytes(buffer, -1, 5);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testGetBytesWithNegativeCountInOverloadThrows() throws IOException
+    {
+        SequentialByteArrayReader reader = new SequentialByteArrayReader(new byte[10]);
+        byte[] buffer = new byte[5];
+        reader.getBytes(buffer, 0, -1);
     }
 
     @Override


### PR DESCRIPTION
Fixes `java.lang.NegativeArraySizeException` in `SequentialByteArrayReader.getBytes()` when processing malformed files with negative size fields.

## Solution
- Added validation for negative `count` and `offset` parameters
- Throws `IllegalArgumentException` with descriptive message instead of crashing
- Added comprehensive unit tests for edge cases

## Testing
- Added 3 new test methods in `SequentialByteArrayReaderTest`
- Verified fix handles malformed input gracefully

## Impact
Prevents crashes when parsing corrupted or malicious files, improving library robustness