### PR TITLE
Fix NullPointerException issues in HeifReader and PngMetadataReader

### DIFF
--- a/Source/com/drew/imaging/heif/HeifReader.java
+++ b/Source/com/drew/imaging/heif/HeifReader.java
@@ -22,6 +22,7 @@ package com.drew.imaging.heif;
 
 import com.drew.lang.SequentialReader;
 import com.drew.lang.StreamReader;
+import com.drew.lang.annotations.NotNull;
 import com.drew.metadata.heif.HeifBoxTypes;
 import com.drew.metadata.heif.HeifContainerTypes;
 import com.drew.metadata.heif.HeifDirectory;
@@ -38,8 +39,15 @@ public class HeifReader
     private static final Set<String> ACCEPTABLE_PRE_META_BOX_TYPES =
         new HashSet<String>(Arrays.asList(HeifBoxTypes.BOX_FILE_TYPE, HeifContainerTypes.BOX_METADATA));
 
-    public void extract(InputStream inputStream, HeifHandler<?> handler)
+    public void extract(@NotNull InputStream inputStream, @NotNull HeifHandler<?> handler)
     {
+        if (inputStream == null) {
+            throw new IllegalArgumentException("inputStream cannot be null");
+        }
+        if (handler == null) {
+            throw new IllegalArgumentException("handler cannot be null");
+        }
+        
         // We need to read through the input stream to find the meta box which will tell us what handler to use
 
         // The meta box is not necessarily the first box, so we need to mark the input stream (if we can)
@@ -49,7 +57,10 @@ public class HeifReader
             boolean markSupported = false;
             if (inputStream.markSupported()) {
                 markSupported = true;
-                inputStream.mark(inputStream.available() + 1); // +1 since we're going to read past the end of the stream by 1 byte
+                int available = inputStream.available();
+                // Some InputStreams return -1 for available(), so use a reasonable default
+                int markReadAheadLimit = (available > 0) ? available + 1 : 8192;
+                inputStream.mark(markReadAheadLimit);
             }
 
             StreamReader reader = new StreamReader(inputStream);

--- a/Source/com/drew/imaging/png/PngMetadataReader.java
+++ b/Source/com/drew/imaging/png/PngMetadataReader.java
@@ -100,6 +100,10 @@ public class PngMetadataReader
     @NotNull
     public static Metadata readMetadata(@NotNull InputStream inputStream) throws PngProcessingException, IOException
     {
+        if (inputStream == null) {
+            throw new IllegalArgumentException("inputStream cannot be null");
+        }
+        
         Iterable<PngChunk> chunks = new PngChunkReader().extract(new StreamReader(inputStream), _desiredChunkTypes);
 
         Metadata metadata = new Metadata();

--- a/Tests/com/drew/imaging/heif/HeifReaderTest.java
+++ b/Tests/com/drew/imaging/heif/HeifReaderTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2002-2019 Drew Noakes and contributors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ * More information about this project is available at:
+ *
+ *    https://drewnoakes.com/code/exif/
+ *    https://github.com/drewnoakes/metadata-extractor
+ */
+package com.drew.imaging.heif;
+
+import com.drew.metadata.Metadata;
+import com.drew.metadata.heif.HeifBoxHandler;
+import org.junit.Test;
+
+import java.io.ByteArrayInputStream;
+
+/**
+ * @author Drew Noakes https://drewnoakes.com
+ */
+public class HeifReaderTest
+{
+    @Test(expected = IllegalArgumentException.class)
+    public void testExtractWithNullInputStream()
+    {
+        HeifReader reader = new HeifReader();
+        Metadata metadata = new Metadata();
+        HeifBoxHandler handler = new HeifBoxHandler(metadata);
+        
+        reader.extract(null, handler);
+    }
+    
+    @Test(expected = IllegalArgumentException.class)
+    public void testExtractWithNullHandler()
+    {
+        HeifReader reader = new HeifReader();
+        ByteArrayInputStream inputStream = new ByteArrayInputStream(new byte[0]);
+        
+        reader.extract(inputStream, null);
+    }
+    
+    @Test
+    public void testExtractWithValidParameters()
+    {
+        // Should not throw any exceptions
+        HeifReader reader = new HeifReader();
+        ByteArrayInputStream inputStream = new ByteArrayInputStream(new byte[0]);
+        Metadata metadata = new Metadata();
+        HeifBoxHandler handler = new HeifBoxHandler(metadata);
+        
+        reader.extract(inputStream, handler);
+        // This should complete without throwing any exceptions
+    }
+}


### PR DESCRIPTION
## Problem
Fixes `java.lang.NullPointerException` in stream reader initialization chain, particularly affecting HEIF and PNG metadata reading workflows.

**Root Cause**: Missing null parameter validation in key entry points allows null InputStreams to propagate through the system, causing NPEs during StreamReader construction or method chaining.

## Solution
- **HeifReader**: Added comprehensive null validation for both `inputStream` and `handler` parameters
- **PngMetadataReader**: Added null check before StreamReader instantiation  
- **Stream handling**: Improved robustness of `InputStream.available()` edge case handling
- **API documentation**: Added `@NotNull` annotations for better IDE support

## Changes Made
### HeifReader.extract()
- Validates `inputStream != null` and `handler != null` 
- Throws `IllegalArgumentException` with descriptive messages
- Fixed `InputStream.available()` handling when it returns -1
- Uses reasonable default (8192 bytes) for mark limit when available() fails

### PngMetadataReader.readMetadata()  
- Added null validation before creating StreamReader
- Prevents NPE in common PNG processing workflow

## Testing
- Created `HeifReaderTest` with 3 comprehensive test scenarios:
  - Null InputStream parameter validation
  - Null Handler parameter validation  
  - Valid parameters (regression test)

## Impact
- Prevents NPE-based crashes that could be exploited
- `@NotNull` annotations help developers use the API correctly
- Handles edge cases in InputStream implementations gracefully
