### PR TITLE
Fix AssertionError issues in RandomAccessStreamReader

### DIFF
--- a/Source/com/drew/lang/RandomAccessStreamReader.java
+++ b/Source/com/drew/lang/RandomAccessStreamReader.java
@@ -79,7 +79,9 @@ public class RandomAccessStreamReader extends RandomAccessReader
         }
 
         isValidIndex(Integer.MAX_VALUE, 1);
-        assert(_isStreamFinished);
+        if (!_isStreamFinished) {
+            throw new IOException("Failed to determine stream length: stream not finished after reading to end");
+        }
         return _streamLength;
     }
 
@@ -105,7 +107,9 @@ public class RandomAccessStreamReader extends RandomAccessReader
         }
 
         if (!isValidIndex(index, bytesRequested)) {
-            assert(_isStreamFinished);
+            if (!_isStreamFinished) {
+                throw new BufferBoundsException("Stream validation failed: not finished reading stream");
+            }
             // TODO test that can continue using an instance of this type after this exception
             throw new BufferBoundsException(index, bytesRequested, _streamLength);
         }
@@ -134,7 +138,9 @@ public class RandomAccessStreamReader extends RandomAccessReader
 
         // TODO test loading several chunks for a single request
         while (chunkIndex >= _chunks.size()) {
-            assert (!_isStreamFinished);
+            if (_isStreamFinished) {
+                throw new BufferBoundsException("Cannot read more chunks: stream already finished");
+            }
 
             byte[] chunk = new byte[_chunkLength];
             int totalBytesRead = 0;
@@ -147,7 +153,9 @@ public class RandomAccessStreamReader extends RandomAccessReader
                     if (_streamLength == -1) {
                         _streamLength = observedStreamLength;
                     } else if (_streamLength != observedStreamLength) {
-                        assert(false);
+                        throw new IOException(String.format(
+                            "Stream length mismatch: expected %d but observed %d",
+                            _streamLength, observedStreamLength));
                     }
 
                     // check we have enough bytes for the requested index
@@ -175,7 +183,12 @@ public class RandomAccessStreamReader extends RandomAccessReader
     @Override
     public byte getByte(int index) throws IOException
     {
-        assert(index >= 0);
+        if (index < 0) {
+            throw new BufferBoundsException(String.format(
+                "Attempt to read from buffer using a negative index (%d)", index));
+        }
+        
+        validateIndex(index, 1);
 
         final int chunkIndex = index / _chunkLength;
         final int innerIndex = index % _chunkLength;

--- a/Tests/com/drew/lang/RandomAccessStreamReaderTest.java
+++ b/Tests/com/drew/lang/RandomAccessStreamReaderTest.java
@@ -24,6 +24,9 @@ package com.drew.lang;
 import org.junit.Test;
 
 import java.io.ByteArrayInputStream;
+import java.io.IOException;
+
+import static org.junit.Assert.*;
 
 /**
  * @author Drew Noakes https://drewnoakes.com
@@ -35,6 +38,37 @@ public class RandomAccessStreamReaderTest extends RandomAccessTestBase
     public void testConstructWithNullBufferThrows()
     {
         new RandomAccessStreamReader(null);
+    }
+    
+    @Test(expected = BufferBoundsException.class)
+    public void testGetByteWithNegativeIndexThrowsBufferBoundsException() throws IOException
+    {
+        RandomAccessStreamReader reader = new RandomAccessStreamReader(
+            new ByteArrayInputStream(new byte[]{1, 2, 3, 4, 5}));
+        
+        reader.getByte(-1);
+    }
+    
+    @Test
+    public void testAssertionReplacementWithProperExceptions() throws IOException
+    {
+        // This test verifies that our assertion fixes work properly without throwing AssertionError
+        RandomAccessStreamReader reader = new RandomAccessStreamReader(
+            new ByteArrayInputStream(new byte[]{1, 2, 3, 4, 5}), 2, 5);
+        
+        // Should work without assertions failing
+        assertEquals(5, reader.getLength());
+        assertEquals(1, reader.getByte(0));
+        assertEquals(5, reader.getByte(4));
+    }
+    
+    @Test
+    public void testGetLengthWithEmptyStream() throws IOException
+    {
+        RandomAccessStreamReader reader = new RandomAccessStreamReader(
+            new ByteArrayInputStream(new byte[0]));
+        
+        assertEquals(0, reader.getLength());
     }
 
     @Override


### PR DESCRIPTION
## Problem
Fixes `java.lang.AssertionError` in `RandomAccessStreamReader` validation methods when JVM assertions are enabled (`-ea` flag).

**Root Cause**: Code relies on `assert()` statements for error handling. When assertions are enabled and conditions fail, `AssertionError` is thrown instead of proper exceptions.

## Solution
Replaced assertions with explicit exception handling:
- `assert(_isStreamFinished)` → proper IOException with descriptive message
- `assert(!_isStreamFinished)` → BufferBoundsException validation  
- `assert(false)` → IOException for stream length mismatch
- `assert(index >= 0)` → BufferBoundsException with bounds checking

## Changes Made
- **getLength()**: Replace stream finished assertion with IOException
- **validateIndex()**: Replace assertion with BufferBoundsException  
- **isValidIndex()**: Replace stream state assertions with proper error handling
- **getByte()**: Replace index assertion with explicit validation + validateIndex() call
- **Stream validation**: Handle length mismatches without assertion failures

## Testing  
- Enhanced `RandomAccessStreamReaderTest` with assertion-specific tests
- Properly throw BufferBoundsException instead of AssertionError
- Handle Empty streams gracefully without assertion failures
- Stream length validation works regardless of JVM assertion settings

## Impact
- Proper exceptions with descriptive messages instead of AssertionError
- Eliminates potential for assertion-based crashes
