### PR TITLE
Fix NPE in ItemLocationBox when offset_size/length_size is 0 (valid AVIF)

### DIFF
--- a/Source/com/drew/metadata/heif/boxes/ItemLocationBox.java
+++ b/Source/com/drew/metadata/heif/boxes/ItemLocationBox.java
@@ -91,7 +91,7 @@ public class ItemLocationBox extends FullBox
             long extentOffset;
             long extentLength;
             for (int j = 0; j < extentCount; j++) {
-                if ((version == 1) || (version == 2) && (indexSize > 0)) {
+                if (((version == 1) || (version == 2)) && (indexSize > 0)) {
                     extentIndex = getIntFromUnknownByte(indexSize, reader);
                 }
                 extentOffset = getIntFromUnknownByte(offsetSize, reader);
@@ -104,6 +104,10 @@ public class ItemLocationBox extends FullBox
     public Long getIntFromUnknownByte(int variable, SequentialReader reader) throws IOException
     {
         switch(variable) {
+            case (0):
+                // Per ISO/IEC 14496-12, offset_size/length_size/index_size of 0 means the field is
+                // absent and its value is 0 (e.g. the location is carried entirely by base_offset).
+                return 0L;
             case (1):
                 return (long)reader.getUInt8();
             case (2):

--- a/Tests/com/drew/metadata/heif/boxes/ItemLocationBoxTest.java
+++ b/Tests/com/drew/metadata/heif/boxes/ItemLocationBoxTest.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2002-2019 Drew Noakes and contributors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ * More information about this project is available at:
+ *
+ *    https://drewnoakes.com/code/exif/
+ *    https://github.com/drewnoakes/metadata-extractor
+ */
+package com.drew.metadata.heif.boxes;
+
+import com.drew.lang.SequentialByteArrayReader;
+import com.drew.lang.SequentialReader;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+/**
+ * @author Drew Noakes https://drewnoakes.com
+ */
+public class ItemLocationBoxTest
+{
+    /**
+     * An {@code iloc} box may declare {@code offset_size == 0}, meaning the per-extent offset field is
+     * absent and its value is 0 (the location is carried entirely by {@code base_offset}). This is valid
+     * per ISO/IEC 14496-12 and is emitted by real AVIF encoders (e.g. link-u/cavif).
+     *
+     * Previously {@code getIntFromUnknownByte(0, ...)} returned {@code null}, which was then unboxed into
+     * the primitive {@code long extentOffset}, throwing a {@link NullPointerException}.
+     */
+    @Test public void testZeroOffsetSizeDoesNotThrow() throws Exception
+    {
+        // A version-0 iloc box with offset_size=0, length_size=4, base_offset_size=4 and a single item
+        // holding a single extent. Bytes taken from link-u's avif-sample-images
+        // (fox.profile0.10bpc.yuv420.monochrome.avif).
+        final byte[] ilocData = new byte[] {
+            0x00, 0x00, 0x00, 0x1E,             // box size = 30
+            0x69, 0x6C, 0x6F, 0x63,             // box type = 'iloc'
+            0x00, 0x00, 0x00, 0x00,             // version = 0, flags = 0
+            0x04,                               // offset_size = 0, length_size = 4
+            0x40,                               // base_offset_size = 4, (reserved)
+            0x00, 0x01,                         // item_count = 1
+            0x00, 0x01,                         // item_ID = 1
+            0x00, 0x00,                         // data_reference_index = 0
+            0x00, 0x00, 0x01, 0x43,             // base_offset = 323
+            0x00, 0x01,                         // extent_count = 1
+            0x00, 0x00, 0x17, (byte) 0x87       // extent_length = 6023 (offset field absent: offset_size=0)
+        };
+
+        SequentialReader reader = new SequentialByteArrayReader(ilocData);
+        Box box = new Box(reader);
+        assertEquals("iloc", box.type);
+
+        ItemLocationBox itemLocationBox = new ItemLocationBox(reader, box);
+
+        assertEquals(1, itemLocationBox.getExtents().size());
+        ItemLocationBox.Extent extent = itemLocationBox.getExtents().first();
+        assertEquals(1, extent.getItemId());
+        assertNull(extent.index);                       // no index when index_size is absent
+        assertEquals(323, extent.getOffset());          // base_offset (323) + extent offset (0)
+        assertEquals(6023, extent.getLength());
+    }
+}


### PR DESCRIPTION
### Problem

Reading certain valid AVIF files throws:

```
java.lang.NullPointerException: Cannot invoke "java.lang.Long.longValue()" because the return value of "com.drew.metadata.heif.boxes.ItemLocationBox.getIntFromUnknownByte(int, com.drew.lang.SequentialReader)" is null
```

### Cause

In `ItemLocationBox`, `getIntFromUnknownByte()` returns a boxed `Long` and returns `null` for any size not in {1, 2, 4, 8}. The results are assigned to the **primitive** `long extentOffset` / `extentLength`, so an `offset_size` / `length_size` of **0** triggers an NPE on auto-unboxing.

A size of 0 is valid per ISO/IEC 14496-12 — the field is absent and its value is 0 (the location is carried by `base_offset`) — and is emitted by real encoders. Example: [link-u/avif-sample-images](https://github.com/link-u/avif-sample-images) `fox.profile0.10bpc.yuv420.monochrome.avif`, whose `iloc` box uses `offset_size = 0, length_size = 4, base_offset_size = 4`.

### Fix

- Return `0L` for size 0 in `getIntFromUnknownByte`.
- Fix an operator-precedence bug in the extent-index condition: `(version == 1) || (version == 2) && (indexSize > 0)` parsed as `(version == 1) || ((version == 2) && (indexSize > 0))` (because `&&` binds tighter than `||`), so a version-1 box read an index even when `index_size == 0`. Now parenthesized correctly.

### Test

Adds `ItemLocationBoxTest`, built from a real `iloc` box (from the link-u sample above). It fails on `main` with the NPE quoted above and passes with this change.