### PR TITLE
Detect QuickTime files that lack a leading ftyp box

### DIFF
--- a/Source/com/drew/imaging/quicktime/QuickTimeTypeChecker.java
+++ b/Source/com/drew/imaging/quicktime/QuickTimeTypeChecker.java
@@ -23,11 +23,21 @@ package com.drew.imaging.quicktime;
 import com.drew.imaging.FileType;
 import com.drew.imaging.TypeChecker;
 
+import java.util.Arrays;
 import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Set;
 
 public class QuickTimeTypeChecker implements TypeChecker
 {
     private static final HashMap<String, FileType> _ftypMap;
+
+    // Top-level atom types that identify a QuickTime file which omits the leading
+    // 'ftyp' box. Real ".mov" recordings (e.g. Apple Live Photo videos) frequently
+    // place 'mdat' first with 'moov' at the end, often preceded by a 'wide'
+    // placeholder, and therefore have no major brand to key off.
+    private static final Set<String> _leadingQuickTimeAtoms = new HashSet<String>(Arrays.asList(
+        "moov", "mdat", "free", "skip", "wide", "pnot"));
 
     static
     {
@@ -113,6 +123,11 @@ public class QuickTimeTypeChecker implements TypeChecker
 
             return FileType.QuickTime;
         }
+
+        // Files without an 'ftyp' box (classic QuickTime .mov) are identified by their
+        // first top-level atom instead.
+        if (_leadingQuickTimeAtoms.contains(new String(bytes, 4, 4)))
+            return FileType.QuickTime;
 
         return FileType.Unknown;
     }

--- a/Tests/com/drew/imaging/FileTypeDetectorTest.java
+++ b/Tests/com/drew/imaging/FileTypeDetectorTest.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2002-2024 Drew Noakes and contributors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ * More information about this project is available at:
+ *
+ *    https://drewnoakes.com/code/exif/
+ *    https://github.com/drewnoakes/metadata-extractor
+ */
+package com.drew.imaging;
+
+import org.junit.Test;
+
+import java.io.BufferedInputStream;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * @author Drew Noakes https://drewnoakes.com
+ */
+public class FileTypeDetectorTest
+{
+    /** Builds an ISO base media file header: a 4-byte big-endian box size followed by a 4-byte box type. */
+    private static byte[] box(int size, String type, String remainder)
+    {
+        byte[] tail = remainder.getBytes();
+        byte[] bytes = new byte[8 + tail.length];
+        bytes[0] = (byte) (size >>> 24);
+        bytes[1] = (byte) (size >>> 16);
+        bytes[2] = (byte) (size >>> 8);
+        bytes[3] = (byte) size;
+        System.arraycopy(type.getBytes(), 0, bytes, 4, 4);
+        System.arraycopy(tail, 0, bytes, 8, tail.length);
+        return bytes;
+    }
+
+    private static FileType detect(byte[] bytes) throws IOException
+    {
+        return FileTypeDetector.detectFileType(new BufferedInputStream(new ByteArrayInputStream(bytes)));
+    }
+
+    @Test
+    public void testDetectQuickTimeWithFtypBrand() throws Exception
+    {
+        // Branded QuickTime, e.g. produced by tools that write a leading 'ftyp' box.
+        assertEquals(FileType.QuickTime, detect(box(0x14, "ftyp", "qt  \0\0\0\0")));
+    }
+
+    @Test
+    public void testDetectMp4AndHeifByFtypBrand() throws Exception
+    {
+        // The 'ftyp' branch must keep disambiguating MP4 and HEIF by major brand.
+        assertEquals(FileType.Mp4, detect(box(0x18, "ftyp", "isom\0\0\0\0")));
+        assertEquals(FileType.Heif, detect(box(0x18, "ftyp", "heic\0\0\0\0")));
+    }
+
+    @Test
+    public void testDetectQuickTimeWithoutFtypBox() throws Exception
+    {
+        // Classic QuickTime .mov recordings (e.g. Apple Live Photo videos) omit the
+        // 'ftyp' box and begin with a top-level atom instead. These must not be
+        // reported as Unknown, otherwise ImageMetadataReader refuses to parse them.
+        assertEquals(FileType.QuickTime, detect(box(0x08, "wide", "\0\0\0\0mdat")));
+        assertEquals(FileType.QuickTime, detect(box(0x08, "mdat", "\0\0\0\0moov")));
+        assertEquals(FileType.QuickTime, detect(box(0x6c, "moov", "\0\0\0\0mvhd")));
+        assertEquals(FileType.QuickTime, detect(box(0x08, "free", "\0\0\0\0mdat")));
+    }
+
+    @Test
+    public void testUnknownWhenNoRecognisedHeader() throws Exception
+    {
+        assertEquals(FileType.Unknown, detect(box(0x08, "junk", "\0\0\0\0junk")));
+    }
+}

--- a/Tests/com/drew/imaging/FileTypeDetectorTest.java
+++ b/Tests/com/drew/imaging/FileTypeDetectorTest.java
@@ -36,13 +36,13 @@ public class FileTypeDetectorTest
     /** Builds an ISO base media file header: a 4-byte big-endian box size followed by a 4-byte box type. */
     private static byte[] box(int size, String type, String remainder)
     {
-        byte[] tail = remainder.getBytes();
+        byte[] tail = remainder.getBytes(com.drew.lang.Charsets.ISO_8859_1);
         byte[] bytes = new byte[8 + tail.length];
         bytes[0] = (byte) (size >>> 24);
         bytes[1] = (byte) (size >>> 16);
         bytes[2] = (byte) (size >>> 8);
         bytes[3] = (byte) size;
-        System.arraycopy(type.getBytes(), 0, bytes, 4, 4);
+        System.arraycopy(type.getBytes(com.drew.lang.Charsets.ISO_8859_1), 0, bytes, 4, 4);
         System.arraycopy(tail, 0, bytes, 8, tail.length);
         return bytes;
     }
@@ -77,6 +77,8 @@ public class FileTypeDetectorTest
         assertEquals(FileType.QuickTime, detect(box(0x08, "mdat", "\0\0\0\0moov")));
         assertEquals(FileType.QuickTime, detect(box(0x6c, "moov", "\0\0\0\0mvhd")));
         assertEquals(FileType.QuickTime, detect(box(0x08, "free", "\0\0\0\0mdat")));
+        assertEquals(FileType.QuickTime, detect(box(0x08, "skip", "\0\0\0\0mdat")));
+        assertEquals(FileType.QuickTime, detect(box(0x08, "pnot", "\0\0\0\0mdat")));
     }
 
     @Test


### PR DESCRIPTION
Fixes #737

Classic `.mov` files (e.g. iPhone Live Photo videos) start with `mdat` and place `moov` at the end, with no `ftyp` box. `QuickTimeTypeChecker` only recognised `ftyp`-prefixed files, so these came back as `Unknown` and `ImageMetadataReader` rejected them with "File format could not be determined", even though `QuickTimeMetadataReader` reads them fine.

Falls back to the first top-level atom (`moov`/`mdat`/`wide`/`free`/`skip`/`pnot`) when there is no `ftyp` box. These are all documented atom types in the QuickTime File Format specification: https://developer.apple.com/standards/qtff-2001.pdf