### PR TITLE
Support LONG8 and SLONG8 TIFF data formats

### DIFF
--- a/Source/com/drew/imaging/tiff/TiffDataFormat.java
+++ b/Source/com/drew/imaging/tiff/TiffDataFormat.java
@@ -42,6 +42,10 @@ public class TiffDataFormat
     public static final int CODE_RATIONAL_S = 10;
     public static final int CODE_SINGLE = 11;
     public static final int CODE_DOUBLE = 12;
+    // the following types are defined by BigTIFF, but can also occur in regular
+    // TIFF streams (e.g. Apple maker notes use LONG8 for some tags)
+    public static final int CODE_INT64_U = 16;
+    public static final int CODE_INT64_S = 17;
 
     @NotNull public static final TiffDataFormat INT8_U = new TiffDataFormat("BYTE", CODE_INT8_U, 1);
     @NotNull public static final TiffDataFormat STRING = new TiffDataFormat("STRING", CODE_STRING, 1);
@@ -55,6 +59,8 @@ public class TiffDataFormat
     @NotNull public static final TiffDataFormat RATIONAL_S = new TiffDataFormat("SRATIONAL", CODE_RATIONAL_S, 8);
     @NotNull public static final TiffDataFormat SINGLE = new TiffDataFormat("SINGLE", CODE_SINGLE, 4);
     @NotNull public static final TiffDataFormat DOUBLE = new TiffDataFormat("DOUBLE", CODE_DOUBLE, 8);
+    @NotNull public static final TiffDataFormat INT64_U = new TiffDataFormat("LONG8", CODE_INT64_U, 8);
+    @NotNull public static final TiffDataFormat INT64_S = new TiffDataFormat("SLONG8", CODE_INT64_S, 8);
 
     @NotNull
     private final String _name;
@@ -77,6 +83,8 @@ public class TiffDataFormat
             case 10: return RATIONAL_S;
             case 11: return SINGLE;
             case 12: return DOUBLE;
+            case 16: return INT64_U;
+            case 17: return INT64_S;
         }
         return null;
     }

--- a/Source/com/drew/imaging/tiff/TiffHandler.java
+++ b/Source/com/drew/imaging/tiff/TiffHandler.java
@@ -85,4 +85,8 @@ public interface TiffHandler
     void setInt32sArray(int tagId, @NotNull int[] array);
     void setInt32u(int tagId, long int32u);
     void setInt32uArray(int tagId, @NotNull long[] array);
+    void setInt64s(int tagId, long int64s);
+    void setInt64sArray(int tagId, @NotNull long[] array);
+    void setInt64u(int tagId, long int64u);
+    void setInt64uArray(int tagId, @NotNull long[] array);
 }

--- a/Source/com/drew/imaging/tiff/TiffReader.java
+++ b/Source/com/drew/imaging/tiff/TiffReader.java
@@ -366,6 +366,26 @@ public class TiffReader
                     handler.setInt32uArray(tagId, array);
                 }
                 break;
+            case TiffDataFormat.CODE_INT64_S:
+                if (componentCount == 1) {
+                    handler.setInt64s(tagId, reader.getInt64(tagValueOffset));
+                } else {
+                    long[] array = new long[componentCount];
+                    for (int i = 0; i < componentCount; i++)
+                        array[i] = reader.getInt64(tagValueOffset + (i * 8));
+                    handler.setInt64sArray(tagId, array);
+                }
+                break;
+            case TiffDataFormat.CODE_INT64_U:
+                if (componentCount == 1) {
+                    handler.setInt64u(tagId, reader.getInt64(tagValueOffset));
+                } else {
+                    long[] array = new long[componentCount];
+                    for (int i = 0; i < componentCount; i++)
+                        array[i] = reader.getInt64(tagValueOffset + (i * 8));
+                    handler.setInt64uArray(tagId, array);
+                }
+                break;
             default:
                 handler.error(String.format("Invalid TIFF tag format code %d for tag 0x%04X", formatCode, tagId));
         }

--- a/Source/com/drew/metadata/tiff/DirectoryTiffHandler.java
+++ b/Source/com/drew/metadata/tiff/DirectoryTiffHandler.java
@@ -220,4 +220,25 @@ public abstract class DirectoryTiffHandler implements TiffHandler
         // TODO create and use a proper setter for short[]
         _currentDirectory.setObjectArray(tagId, array);
     }
+
+    public void setInt64s(int tagId, long int64s)
+    {
+        _currentDirectory.setLong(tagId, int64s);
+    }
+
+    public void setInt64sArray(int tagId, @NotNull long[] array)
+    {
+        _currentDirectory.setObjectArray(tagId, array);
+    }
+
+    public void setInt64u(int tagId, long int64u)
+    {
+        // values above Long.MAX_VALUE will wrap, but do not occur in practice
+        _currentDirectory.setLong(tagId, int64u);
+    }
+
+    public void setInt64uArray(int tagId, @NotNull long[] array)
+    {
+        _currentDirectory.setObjectArray(tagId, array);
+    }
 }

--- a/Tests/com/drew/metadata/exif/ExifReaderTest.java
+++ b/Tests/com/drew/metadata/exif/ExifReaderTest.java
@@ -95,6 +95,32 @@ public class ExifReaderTest
     }
 
     @Test
+    public void testLong8AndSLong8Values() throws Exception
+    {
+        // LONG8 (16) and SLONG8 (17) are BigTIFF data formats that also occur in
+        // regular TIFF streams, e.g. Apple maker notes store the Live Photo video
+        // index (tag 0x0017) as LONG8
+        byte[] exifData = new byte[] {
+            'E','x','i','f',0,0,
+            'M','M', 0,42, 0,0,0,8,                 // TIFF header, IFD0 at offset 8
+            0,2,                                    // two entries
+            0x10,0x01, 0,16, 0,0,0,1, 0,0,0,38,     // tag 0x1001, LONG8, count 1, value at offset 38
+            0x10,0x02, 0,17, 0,0,0,1, 0,0,0,46,     // tag 0x1002, SLONG8, count 1, value at offset 46
+            0,0,0,0,                                // next IFD offset (none)
+            0,0,0,0, 0,0x50,(byte)0xA0,0x24,        // 5283876
+            (byte)0xFF,(byte)0xFF,(byte)0xFF,(byte)0xFF,
+            (byte)0xFF,(byte)0xFF,(byte)0xFF,(byte)0xD6 // -42
+        };
+        Metadata metadata = new Metadata();
+        new ExifReader().extract(new ByteArrayReader(exifData), metadata, ExifReader.JPEG_SEGMENT_PREAMBLE.length(), null);
+        ExifIFD0Directory directory = metadata.getFirstDirectoryOfType(ExifIFD0Directory.class);
+        assertNotNull(directory);
+        assertFalse(metadata.hasErrors());
+        assertEquals(5283876L, directory.getLong(0x1001));
+        assertEquals(-42L, directory.getLong(0x1002));
+    }
+
+    @Test
     public void testCrashRegressionTest() throws Exception
     {
         // This image was created via a resize in ACDSee.


### PR DESCRIPTION
Fixes #738

The TIFF format codes 16 (LONG8) and 17 (SLONG8) are defined by BigTIFF
but also occur in regular TIFF streams: current Apple maker notes store
several tags as LONG8, e.g. the Live Photo video index (tag 0x0017),
which `AppleMakernoteDirectory` already names but never receives because
`TiffReader` rejected the format code as invalid.

This decodes both formats and routes them through new
`TiffHandler.setInt64s/u` setters, mirroring the existing 32-bit integer
handling. Unsigned values above `Long.MAX_VALUE` would wrap, but do not
occur in practice.

Format code 18 (IFD8) is deliberately not added: it is a 64-bit IFD
pointer, not a data value, and handling it properly would mean real
BigTIFF container support (header magic 43, 8-byte offsets, 20-byte IFD
entries), which is a separate topic.

Verified against a real Live Photo still (iPhone 15 Pro, iOS 18.5):
`Live Photo ID = 5283876` now appears in the Apple maker note directory
alongside the content identifier. Includes a regression test with a
synthetic TIFF stream containing one LONG8 and one SLONG8 entry.
