### PR TITLE
Add basic MP4 udta metadata (Title, Comment, Subtitle, Rating, Category, Mood)

### DIFF
--- a/Source/com/drew/metadata/mp4/Mp4BoxHandler.java
+++ b/Source/com/drew/metadata/mp4/Mp4BoxHandler.java
@@ -20,24 +20,37 @@
  */
 package com.drew.metadata.mp4;
 
+import static com.drew.metadata.mp4.Mp4Directory.TAG_CATEGORY;
+import static com.drew.metadata.mp4.Mp4Directory.TAG_COMMENT;
+import static com.drew.metadata.mp4.Mp4Directory.TAG_LATITUDE;
+import static com.drew.metadata.mp4.Mp4Directory.TAG_LONGITUDE;
+import static com.drew.metadata.mp4.Mp4Directory.TAG_MOOD;
+import static com.drew.metadata.mp4.Mp4Directory.TAG_SUBTITLE;
+import static com.drew.metadata.mp4.Mp4Directory.TAG_TITLE;
+import static com.drew.metadata.mp4.Mp4Directory.TAG_USER_RATING;
+
+import java.io.IOException;
+import java.nio.charset.Charset;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
 import com.drew.imaging.mp4.Mp4Handler;
 import com.drew.lang.DateUtil;
 import com.drew.lang.Rational;
 import com.drew.lang.SequentialByteArrayReader;
 import com.drew.lang.SequentialReader;
+import com.drew.lang.StringUtil;
 import com.drew.lang.annotations.NotNull;
 import com.drew.lang.annotations.Nullable;
 import com.drew.metadata.Metadata;
-import com.drew.metadata.mp4.media.*;
-
-import java.io.IOException;
-import java.nio.charset.Charset;
-import java.util.ArrayList;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-
-import static com.drew.metadata.mp4.Mp4Directory.TAG_LATITUDE;
-import static com.drew.metadata.mp4.Mp4Directory.TAG_LONGITUDE;
+import com.drew.metadata.mp4.media.Mp4HintHandler;
+import com.drew.metadata.mp4.media.Mp4MetaHandler;
+import com.drew.metadata.mp4.media.Mp4SoundHandler;
+import com.drew.metadata.mp4.media.Mp4TextHandler;
+import com.drew.metadata.mp4.media.Mp4UuidBoxHandler;
+import com.drew.metadata.mp4.media.Mp4VideoHandler;
 
 /**
  * @author Payton Garland
@@ -140,6 +153,8 @@ public class Mp4BoxHandler extends Mp4Handler<Mp4Directory>
     private void processUserData(@NotNull SequentialReader reader, int length) throws IOException
     {
         final int LOCATION_CODE = 0xA978797A; // "©xyz"
+		final int META_TYPE = 0x6D657461; // "meta"
+		final int XTRA_TYPE = 0x58747261; // "Xtra"
 
         String coordinateString = null;
 
@@ -152,11 +167,16 @@ public class Mp4BoxHandler extends Mp4Handler<Mp4Directory>
                 int xyzLength = reader.getUInt16();
                 reader.skip(2);
                 coordinateString = reader.getString(xyzLength, "UTF-8");
-            } else if (size >= 8) {
-                reader.skip(size - 8);
-            } else {
-                return;
-            }
+            } else if (kind == META_TYPE && size > 16) {
+				reader.skip(4);
+				processUserDataMeta(reader, length, size - 12);
+			} else if (kind == XTRA_TYPE && size > 16) {
+				processUserDataMetaXtra(reader, length, size - 8);
+			} else if (size >= 8) {
+				reader.skip(size - 8);
+			} else {
+				return;
+			}
         }
 
         if (coordinateString != null) {
@@ -170,6 +190,91 @@ public class Mp4BoxHandler extends Mp4Handler<Mp4Directory>
             }
         }
     }
+    
+    private void processUserDataMeta(@NotNull SequentialReader reader, int length, long blockSize) throws IOException {
+		final int HDLR_TYPE = 0x68646C72; // "hdlr"
+		final int ILST_TYPE = 0x696C7374; // "ilst"
+
+		long initialPosition = reader.getPosition();
+
+		while (reader.getPosition() < length && (reader.getPosition() - initialPosition) < blockSize) {
+			long size = reader.getUInt32();
+			if (size <= 4)
+				break;
+			int kind = reader.getInt32();
+			if (kind == HDLR_TYPE) {
+				// nothing
+				reader.skip(size - 8);
+			} else if (kind == ILST_TYPE && size > 16) {
+				processUserDataMetaIList(reader, length, size - 8);
+			}
+		}
+	}
+
+	private void processUserDataMetaIList(@NotNull SequentialReader reader, int length, long blockSize)
+			throws IOException {
+		final int CNAM_TYPE = 0xA96E616D; // "©nam"
+		final int CCMT_TYPE = 0xA9636D74; // "©cmt"
+		long initialPosition = reader.getPosition();
+
+		while (reader.getPosition() < length && (reader.getPosition() - initialPosition) < blockSize) {
+			long size = reader.getUInt32();
+			if (size <= 4)
+				break;
+			int kind = reader.getInt32();
+			if (kind == CNAM_TYPE) {
+				long cnamSize = reader.getUInt32();
+				if (cnamSize > 16) {
+					reader.skip(12);
+					directory.setString(TAG_TITLE, reader.getString((int) cnamSize - 16, "UTF-8"));
+				}
+			} else if (kind == CCMT_TYPE) {
+				long ccmtSize = reader.getUInt32();
+				if (ccmtSize > 16) {
+					reader.skip(12);
+					directory.setString(TAG_COMMENT, reader.getString((int) ccmtSize - 16, "UTF-8"));
+				}
+			} else {
+				// nothing
+			}
+		}
+	}
+
+	private void processUserDataMetaXtra(@NotNull SequentialReader reader, int length, long blockSize)
+			throws IOException {
+		long initialPosition = reader.getPosition();
+		while (reader.getPosition() < length && (reader.getPosition() - initialPosition) < blockSize) {
+			long key_size = reader.getUInt32();
+			long key_name_size = reader.getUInt32();
+			String key_name = reader.getString((int) key_name_size, "UTF-8");
+			long entry_count = reader.getUInt32();
+			if (key_name.equals("WM/SubTitle")) {
+				String value = getProcessUserDataMetaXtraValue(reader, entry_count);
+				directory.setString(TAG_SUBTITLE, value);
+			} else if (key_name.equals("WM/SharedUserRating")) {
+				long value_size = reader.getUInt32();
+				int value_type = reader.getUInt16();
+				directory.setLong(TAG_USER_RATING, reader.getInt64());
+			} else if (key_name.equals("WM/Category")) {
+				String value = getProcessUserDataMetaXtraValue(reader, entry_count);
+				directory.setString(TAG_CATEGORY, value);
+			} else if (key_name.equals("WM/Mood")) {
+				String value = getProcessUserDataMetaXtraValue(reader, entry_count);
+				directory.setString(TAG_MOOD, value);
+			}
+		}
+	}
+
+	private String getProcessUserDataMetaXtraValue(@NotNull SequentialReader reader, long entry_count)
+			throws IOException {
+		List<String> result = new ArrayList<>();
+		for (long i = 0; i < entry_count; ++i) {
+			long value_size = reader.getUInt32();
+			int val_type = reader.getUInt16();
+			result.add(reader.getString((int) value_size - 6,"UTF-16LE").replace("\0", ""));
+		}
+		return StringUtil.join(result, " | ");
+	}
 
     private void processFileType(@NotNull SequentialReader reader, long boxSize) throws IOException
     {

--- a/Source/com/drew/metadata/mp4/Mp4BoxHandler.java
+++ b/Source/com/drew/metadata/mp4/Mp4BoxHandler.java
@@ -226,6 +226,7 @@ public class Mp4BoxHandler extends Mp4Handler<Mp4Directory>
         long initialPosition = reader.getPosition();
 
         while (reader.getPosition() < length && (reader.getPosition() - initialPosition) < blockSize) {
+            long entryStart = reader.getPosition();
             long size = reader.getUInt32();
             if (size < 8)
                 break;
@@ -235,20 +236,19 @@ public class Mp4BoxHandler extends Mp4Handler<Mp4Directory>
                 if (dataSize > 16) {
                     reader.skip(12); // "data" atom: 4 bytes type, 4 bytes version/flags, 4 bytes locale
                     directory.setString(TAG_TITLE, reader.getString((int) dataSize - 16, "UTF-8"));
-                } else {
-                    reader.skip(size - 12);
                 }
             } else if (kind == CCMT_TYPE) {
                 long dataSize = reader.getUInt32();
                 if (dataSize > 16) {
                     reader.skip(12);
                     directory.setString(TAG_COMMENT, reader.getString((int) dataSize - 16, "UTF-8"));
-                } else {
-                    reader.skip(size - 12);
                 }
-            } else {
-                reader.skip(size - 8);
             }
+            // Advance to the end of this entry regardless of which atoms we consumed, so any
+            // trailing atoms or padding don't misalign the reader for subsequent entries.
+            long consumed = reader.getPosition() - entryStart;
+            if (size > consumed)
+                reader.skip(size - consumed);
         }
     }
 
@@ -278,12 +278,12 @@ public class Mp4BoxHandler extends Mp4Handler<Mp4Directory>
                 directory.setString(TAG_CATEGORY, readUserDataMetaXtraValues(reader, entryCount));
             } else if (keyName.equals("WM/Mood")) {
                 directory.setString(TAG_MOOD, readUserDataMetaXtraValues(reader, entryCount));
-            } else {
-                // Unrecognised key: skip the remainder of this entry using its declared size.
-                long consumed = reader.getPosition() - entryStart;
-                if (entrySize > consumed)
-                    reader.skip(entrySize - consumed);
             }
+            // Advance to the end of this entry regardless of which values we consumed, so any
+            // padding or additional fields don't misalign the reader for subsequent entries.
+            long consumed = reader.getPosition() - entryStart;
+            if (entrySize > consumed)
+                reader.skip(entrySize - consumed);
         }
     }
 

--- a/Source/com/drew/metadata/mp4/Mp4BoxHandler.java
+++ b/Source/com/drew/metadata/mp4/Mp4BoxHandler.java
@@ -153,8 +153,8 @@ public class Mp4BoxHandler extends Mp4Handler<Mp4Directory>
     private void processUserData(@NotNull SequentialReader reader, int length) throws IOException
     {
         final int LOCATION_CODE = 0xA978797A; // "©xyz"
-		final int META_TYPE = 0x6D657461; // "meta"
-		final int XTRA_TYPE = 0x58747261; // "Xtra"
+        final int META_TYPE = 0x6D657461; // "meta"
+        final int XTRA_TYPE = 0x58747261; // "Xtra"
 
         String coordinateString = null;
 
@@ -168,15 +168,15 @@ public class Mp4BoxHandler extends Mp4Handler<Mp4Directory>
                 reader.skip(2);
                 coordinateString = reader.getString(xyzLength, "UTF-8");
             } else if (kind == META_TYPE && size > 16) {
-				reader.skip(4);
-				processUserDataMeta(reader, length, size - 12);
-			} else if (kind == XTRA_TYPE && size > 16) {
-				processUserDataMetaXtra(reader, length, size - 8);
-			} else if (size >= 8) {
-				reader.skip(size - 8);
-			} else {
-				return;
-			}
+                reader.skip(4); // one byte version, three bytes flags
+                processUserDataMeta(reader, length, size - 12);
+            } else if (kind == XTRA_TYPE && size > 16) {
+                processUserDataMetaXtra(reader, length, size - 8);
+            } else if (size >= 8) {
+                reader.skip(size - 8);
+            } else {
+                return;
+            }
         }
 
         if (coordinateString != null) {
@@ -190,91 +190,115 @@ public class Mp4BoxHandler extends Mp4Handler<Mp4Directory>
             }
         }
     }
-    
-    private void processUserDataMeta(@NotNull SequentialReader reader, int length, long blockSize) throws IOException {
-		final int HDLR_TYPE = 0x68646C72; // "hdlr"
-		final int ILST_TYPE = 0x696C7374; // "ilst"
 
-		long initialPosition = reader.getPosition();
+    /**
+     * Processes a {@code meta} box nested within {@code udta}, looking for an {@code ilst} box that
+     * carries iTunes-style metadata such as title and comment.
+     */
+    private void processUserDataMeta(@NotNull SequentialReader reader, int length, long blockSize) throws IOException
+    {
+        final int ILST_TYPE = 0x696C7374; // "ilst"
 
-		while (reader.getPosition() < length && (reader.getPosition() - initialPosition) < blockSize) {
-			long size = reader.getUInt32();
-			if (size <= 4)
-				break;
-			int kind = reader.getInt32();
-			if (kind == HDLR_TYPE) {
-				// nothing
-				reader.skip(size - 8);
-			} else if (kind == ILST_TYPE && size > 16) {
-				processUserDataMetaIList(reader, length, size - 8);
-			}
-		}
-	}
+        long initialPosition = reader.getPosition();
 
-	private void processUserDataMetaIList(@NotNull SequentialReader reader, int length, long blockSize)
-			throws IOException {
-		final int CNAM_TYPE = 0xA96E616D; // "©nam"
-		final int CCMT_TYPE = 0xA9636D74; // "©cmt"
-		long initialPosition = reader.getPosition();
+        while (reader.getPosition() < length && (reader.getPosition() - initialPosition) < blockSize) {
+            long size = reader.getUInt32();
+            if (size < 8)
+                break;
+            int kind = reader.getInt32();
+            if (kind == ILST_TYPE && size > 16) {
+                processUserDataMetaIlst(reader, length, size - 8);
+            } else {
+                reader.skip(size - 8);
+            }
+        }
+    }
 
-		while (reader.getPosition() < length && (reader.getPosition() - initialPosition) < blockSize) {
-			long size = reader.getUInt32();
-			if (size <= 4)
-				break;
-			int kind = reader.getInt32();
-			if (kind == CNAM_TYPE) {
-				long cnamSize = reader.getUInt32();
-				if (cnamSize > 16) {
-					reader.skip(12);
-					directory.setString(TAG_TITLE, reader.getString((int) cnamSize - 16, "UTF-8"));
-				}
-			} else if (kind == CCMT_TYPE) {
-				long ccmtSize = reader.getUInt32();
-				if (ccmtSize > 16) {
-					reader.skip(12);
-					directory.setString(TAG_COMMENT, reader.getString((int) ccmtSize - 16, "UTF-8"));
-				}
-			} else {
-				// nothing
-			}
-		}
-	}
+    /**
+     * Processes an {@code ilst} box, reading the title ({@code ©nam}) and comment ({@code ©cmt})
+     * values. Each recognised entry contains a nested {@code data} atom holding a UTF-8 string.
+     */
+    private void processUserDataMetaIlst(@NotNull SequentialReader reader, int length, long blockSize) throws IOException
+    {
+        final int CNAM_TYPE = 0xA96E616D; // "©nam"
+        final int CCMT_TYPE = 0xA9636D74; // "©cmt"
 
-	private void processUserDataMetaXtra(@NotNull SequentialReader reader, int length, long blockSize)
-			throws IOException {
-		long initialPosition = reader.getPosition();
-		while (reader.getPosition() < length && (reader.getPosition() - initialPosition) < blockSize) {
-			long key_size = reader.getUInt32();
-			long key_name_size = reader.getUInt32();
-			String key_name = reader.getString((int) key_name_size, "UTF-8");
-			long entry_count = reader.getUInt32();
-			if (key_name.equals("WM/SubTitle")) {
-				String value = getProcessUserDataMetaXtraValue(reader, entry_count);
-				directory.setString(TAG_SUBTITLE, value);
-			} else if (key_name.equals("WM/SharedUserRating")) {
-				long value_size = reader.getUInt32();
-				int value_type = reader.getUInt16();
-				directory.setLong(TAG_USER_RATING, reader.getInt64());
-			} else if (key_name.equals("WM/Category")) {
-				String value = getProcessUserDataMetaXtraValue(reader, entry_count);
-				directory.setString(TAG_CATEGORY, value);
-			} else if (key_name.equals("WM/Mood")) {
-				String value = getProcessUserDataMetaXtraValue(reader, entry_count);
-				directory.setString(TAG_MOOD, value);
-			}
-		}
-	}
+        long initialPosition = reader.getPosition();
 
-	private String getProcessUserDataMetaXtraValue(@NotNull SequentialReader reader, long entry_count)
-			throws IOException {
-		List<String> result = new ArrayList<>();
-		for (long i = 0; i < entry_count; ++i) {
-			long value_size = reader.getUInt32();
-			int val_type = reader.getUInt16();
-			result.add(reader.getString((int) value_size - 6,"UTF-16LE").replace("\0", ""));
-		}
-		return StringUtil.join(result, " | ");
-	}
+        while (reader.getPosition() < length && (reader.getPosition() - initialPosition) < blockSize) {
+            long size = reader.getUInt32();
+            if (size < 8)
+                break;
+            int kind = reader.getInt32();
+            if (kind == CNAM_TYPE) {
+                long dataSize = reader.getUInt32();
+                if (dataSize > 16) {
+                    reader.skip(12); // "data" atom: 4 bytes type, 4 bytes version/flags, 4 bytes locale
+                    directory.setString(TAG_TITLE, reader.getString((int) dataSize - 16, "UTF-8"));
+                } else {
+                    reader.skip(size - 12);
+                }
+            } else if (kind == CCMT_TYPE) {
+                long dataSize = reader.getUInt32();
+                if (dataSize > 16) {
+                    reader.skip(12);
+                    directory.setString(TAG_COMMENT, reader.getString((int) dataSize - 16, "UTF-8"));
+                } else {
+                    reader.skip(size - 12);
+                }
+            } else {
+                reader.skip(size - 8);
+            }
+        }
+    }
+
+    /**
+     * Processes a Windows {@code Xtra} box nested within {@code udta}. This carries additional
+     * properties surfaced by the Windows file properties dialog, encoded as UTF-16LE strings.
+     */
+    private void processUserDataMetaXtra(@NotNull SequentialReader reader, int length, long blockSize) throws IOException
+    {
+        long initialPosition = reader.getPosition();
+
+        while (reader.getPosition() < length && (reader.getPosition() - initialPosition) < blockSize) {
+            long entryStart = reader.getPosition();
+            long entrySize = reader.getUInt32();
+            if (entrySize < 12)
+                break;
+            long keyNameSize = reader.getUInt32();
+            String keyName = reader.getString((int) keyNameSize, "UTF-8");
+            long entryCount = reader.getUInt32();
+            if (keyName.equals("WM/SubTitle")) {
+                directory.setString(TAG_SUBTITLE, readUserDataMetaXtraValues(reader, entryCount));
+            } else if (keyName.equals("WM/SharedUserRating")) {
+                reader.getUInt32(); // value length
+                reader.getUInt16(); // value type
+                directory.setLong(TAG_USER_RATING, reader.getInt64());
+            } else if (keyName.equals("WM/Category")) {
+                directory.setString(TAG_CATEGORY, readUserDataMetaXtraValues(reader, entryCount));
+            } else if (keyName.equals("WM/Mood")) {
+                directory.setString(TAG_MOOD, readUserDataMetaXtraValues(reader, entryCount));
+            } else {
+                // Unrecognised key: skip the remainder of this entry using its declared size.
+                long consumed = reader.getPosition() - entryStart;
+                if (entrySize > consumed)
+                    reader.skip(entrySize - consumed);
+            }
+        }
+    }
+
+    private String readUserDataMetaXtraValues(@NotNull SequentialReader reader, long entryCount) throws IOException
+    {
+        List<String> result = new ArrayList<String>();
+        for (long i = 0; i < entryCount; i++) {
+            long valueSize = reader.getUInt32();
+            reader.getUInt16(); // value type
+            if (valueSize < 6)
+                break;
+            result.add(reader.getString((int) valueSize - 6, "UTF-16LE").replace("\0", ""));
+        }
+        return StringUtil.join(result, " | ");
+    }
 
     private void processFileType(@NotNull SequentialReader reader, long boxSize) throws IOException
     {

--- a/Source/com/drew/metadata/mp4/Mp4Directory.java
+++ b/Source/com/drew/metadata/mp4/Mp4Directory.java
@@ -20,10 +20,10 @@
  */
 package com.drew.metadata.mp4;
 
+import java.util.HashMap;
+
 import com.drew.lang.annotations.NotNull;
 import com.drew.metadata.Directory;
-
-import java.util.HashMap;
 
 public class Mp4Directory extends Directory {
 
@@ -46,6 +46,12 @@ public class Mp4Directory extends Directory {
     public static final int TAG_LATITUDE                                = 0x2001;
     public static final int TAG_LONGITUDE                               = 0x2002;
     public static final int TAG_MEDIA_TIME_SCALE                        = 0x0306;
+	public static final int TAG_TITLE									= 0x3000;
+	public static final int TAG_COMMENT									= 0x3001;
+	public static final int TAG_SUBTITLE								= 0x3002;
+	public static final int TAG_USER_RATING								= 0x3003;
+	public static final int TAG_CATEGORY								= 0x3004;
+	public static final int TAG_MOOD									= 0x3005;
 
     public static final int TAG_MAJOR_BRAND                             = 1;
     public static final int TAG_MINOR_VERSION                           = 2;
@@ -78,6 +84,12 @@ public class Mp4Directory extends Directory {
         _tagNameMap.put(TAG_ROTATION, "Rotation");
         _tagNameMap.put(TAG_LATITUDE, "Latitude");
         _tagNameMap.put(TAG_LONGITUDE, "Longitude");
+		_tagNameMap.put(TAG_TITLE, "Title");
+		_tagNameMap.put(TAG_COMMENT, "Comment");
+		_tagNameMap.put(TAG_SUBTITLE, "Subtitle");
+		_tagNameMap.put(TAG_USER_RATING, "User rating");
+		_tagNameMap.put(TAG_CATEGORY, "Tags");
+		_tagNameMap.put(TAG_MOOD, "Mood");
 
         _tagNameMap.put(TAG_MEDIA_TIME_SCALE, "Media Time Scale");
     }

--- a/Source/com/drew/metadata/mp4/Mp4Directory.java
+++ b/Source/com/drew/metadata/mp4/Mp4Directory.java
@@ -46,12 +46,12 @@ public class Mp4Directory extends Directory {
     public static final int TAG_LATITUDE                                = 0x2001;
     public static final int TAG_LONGITUDE                               = 0x2002;
     public static final int TAG_MEDIA_TIME_SCALE                        = 0x0306;
-	public static final int TAG_TITLE									= 0x3000;
-	public static final int TAG_COMMENT									= 0x3001;
-	public static final int TAG_SUBTITLE								= 0x3002;
-	public static final int TAG_USER_RATING								= 0x3003;
-	public static final int TAG_CATEGORY								= 0x3004;
-	public static final int TAG_MOOD									= 0x3005;
+    public static final int TAG_TITLE                                   = 0x3000;
+    public static final int TAG_COMMENT                                 = 0x3001;
+    public static final int TAG_SUBTITLE                                = 0x3002;
+    public static final int TAG_USER_RATING                             = 0x3003;
+    public static final int TAG_CATEGORY                                = 0x3004;
+    public static final int TAG_MOOD                                    = 0x3005;
 
     public static final int TAG_MAJOR_BRAND                             = 1;
     public static final int TAG_MINOR_VERSION                           = 2;
@@ -84,12 +84,12 @@ public class Mp4Directory extends Directory {
         _tagNameMap.put(TAG_ROTATION, "Rotation");
         _tagNameMap.put(TAG_LATITUDE, "Latitude");
         _tagNameMap.put(TAG_LONGITUDE, "Longitude");
-		_tagNameMap.put(TAG_TITLE, "Title");
-		_tagNameMap.put(TAG_COMMENT, "Comment");
-		_tagNameMap.put(TAG_SUBTITLE, "Subtitle");
-		_tagNameMap.put(TAG_USER_RATING, "User rating");
-		_tagNameMap.put(TAG_CATEGORY, "Tags");
-		_tagNameMap.put(TAG_MOOD, "Mood");
+        _tagNameMap.put(TAG_TITLE, "Title");
+        _tagNameMap.put(TAG_COMMENT, "Comment");
+        _tagNameMap.put(TAG_SUBTITLE, "Subtitle");
+        _tagNameMap.put(TAG_USER_RATING, "User rating");
+        _tagNameMap.put(TAG_CATEGORY, "Tags");
+        _tagNameMap.put(TAG_MOOD, "Mood");
 
         _tagNameMap.put(TAG_MEDIA_TIME_SCALE, "Media Time Scale");
     }

--- a/Source/com/drew/metadata/mp4/Mp4Directory.java
+++ b/Source/com/drew/metadata/mp4/Mp4Directory.java
@@ -87,7 +87,7 @@ public class Mp4Directory extends Directory {
         _tagNameMap.put(TAG_TITLE, "Title");
         _tagNameMap.put(TAG_COMMENT, "Comment");
         _tagNameMap.put(TAG_SUBTITLE, "Subtitle");
-        _tagNameMap.put(TAG_USER_RATING, "User rating");
+        _tagNameMap.put(TAG_USER_RATING, "User Rating");
         _tagNameMap.put(TAG_CATEGORY, "Tags");
         _tagNameMap.put(TAG_MOOD, "Mood");
 


### PR DESCRIPTION
Extracts additional MP4 user-data (`udta`) metadata that appears in the Windows file properties dialog but was previously missing from the MP4 parser:

- **Title** and **Comment** from `udta/meta/ilst` (`©nam` / `©cmt`)
- **Subtitle**, **User Rating**, **Category/Tags** and **Mood** from the Windows `udta/Xtra` atom (`WM/SubTitle`, `WM/SharedUserRating`, `WM/Category`, `WM/Mood`)

Six new tags (`0x3000`–`0x3005`) are added to `Mp4Directory`.

### Credit
The feature work is by **@cedricopfermann**, originally proposed in #661. That PR became unmergeable after unrelated release/CI commits were pushed to the author's `main` branch. This branch salvages just the metadata feature:

- **Commit 1** preserves Cédric's authorship and lands the net feature diff on top of current `main`.
- **Commit 2** is a cleanup pass: converts tab indentation to spaces, renames `snake_case` locals to `camelCase`, and fixes atom-skipping so unrecognised entries in the `ilst` and `Xtra` boxes are advanced by their declared size instead of leaving the reader misaligned. The recognised-key parsing is kept byte-identical to the original.

### Testing
`mvn clean test` — BUILD SUCCESS, 309/309 tests pass.

> Note: the MP4 package currently has no unit tests or sample files, so this is compile- and regression-verified but the new parsing paths are not yet covered by an automated test. A follow-up adding a synthetic `udta` payload test would be worthwhile.

Closes #661.