### PR TITLE
Use Locale.ROOT when lowercasing hardcoded description strings (#364)

### DIFF
--- a/Source/com/drew/metadata/exif/ExifDescriptorBase.java
+++ b/Source/com/drew/metadata/exif/ExifDescriptorBase.java
@@ -32,6 +32,7 @@ import com.drew.metadata.TagDescriptor;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.text.DecimalFormat;
+import java.util.Locale;
 
 import static com.drew.metadata.exif.ExifDirectoryBase.*;
 
@@ -428,7 +429,7 @@ public abstract class ExifDescriptorBase<T extends Directory> extends TagDescrip
         final String unit = getResolutionDescription();
         return String.format("%s dots per %s",
             value.toSimpleString(_allowDecimalRepresentationOfRationals),
-            unit == null ? "unit" : unit.toLowerCase());
+            unit == null ? "unit" : unit.toLowerCase(Locale.ROOT));
     }
 
     @Nullable
@@ -440,7 +441,7 @@ public abstract class ExifDescriptorBase<T extends Directory> extends TagDescrip
         final String unit = getResolutionDescription();
         return String.format("%s dots per %s",
             value.toSimpleString(_allowDecimalRepresentationOfRationals),
-            unit == null ? "unit" : unit.toLowerCase());
+            unit == null ? "unit" : unit.toLowerCase(Locale.ROOT));
     }
 
     @Nullable
@@ -1034,7 +1035,7 @@ public abstract class ExifDescriptorBase<T extends Directory> extends TagDescrip
             return null;
         final String unit = getFocalPlaneResolutionUnitDescription();
         return rational.getReciprocal().toSimpleString(_allowDecimalRepresentationOfRationals)
-            + (unit == null ? "" : " " + unit.toLowerCase());
+            + (unit == null ? "" : " " + unit.toLowerCase(Locale.ROOT));
     }
 
     @Nullable
@@ -1045,7 +1046,7 @@ public abstract class ExifDescriptorBase<T extends Directory> extends TagDescrip
             return null;
         final String unit = getFocalPlaneResolutionUnitDescription();
         return rational.getReciprocal().toSimpleString(_allowDecimalRepresentationOfRationals)
-            + (unit == null ? "" : " " + unit.toLowerCase());
+            + (unit == null ? "" : " " + unit.toLowerCase(Locale.ROOT));
     }
 
     @Nullable

--- a/Source/com/drew/metadata/exif/GpsDescriptor.java
+++ b/Source/com/drew/metadata/exif/GpsDescriptor.java
@@ -27,6 +27,7 @@ import com.drew.lang.annotations.Nullable;
 import com.drew.metadata.TagDescriptor;
 
 import java.text.DecimalFormat;
+import java.util.Locale;
 
 import static com.drew.metadata.exif.GpsDirectory.*;
 
@@ -189,7 +190,7 @@ public class GpsDescriptor extends TagDescriptor<GpsDirectory>
         final String unit = getGpsDestinationReferenceDescription();
         return String.format("%s %s",
             new DecimalFormat("0.##").format(value.doubleValue()),
-            unit == null ? "unit" : unit.toLowerCase());
+            unit == null ? "unit" : unit.toLowerCase(Locale.ROOT));
     }
 
     @Nullable
@@ -253,7 +254,7 @@ public class GpsDescriptor extends TagDescriptor<GpsDirectory>
         final String unit = getGpsSpeedRefDescription();
         return String.format("%s %s",
             new DecimalFormat("0.##").format(value.doubleValue()),
-            unit == null ? "unit" : unit.toLowerCase());
+            unit == null ? "unit" : unit.toLowerCase(Locale.ROOT));
     }
 
     @Nullable

--- a/Tests/com/drew/metadata/exif/ExifIFD0DescriptorTest.java
+++ b/Tests/com/drew/metadata/exif/ExifIFD0DescriptorTest.java
@@ -22,7 +22,11 @@
 package com.drew.metadata.exif;
 
 import com.drew.lang.Rational;
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
+
+import java.util.Locale;
 
 import static com.drew.metadata.exif.ExifIFD0Directory.*;
 import static org.junit.Assert.assertEquals;
@@ -34,6 +38,20 @@ import static org.junit.Assert.assertEquals;
  */
 public class ExifIFD0DescriptorTest
 {
+    private Locale _originalDefaultLocale;
+
+    @Before
+    public void setUp()
+    {
+        _originalDefaultLocale = Locale.getDefault();
+    }
+
+    @After
+    public void tearDown()
+    {
+        Locale.setDefault(_originalDefaultLocale);
+    }
+
     @Test
     public void testXResolutionDescription() throws Exception
     {
@@ -43,6 +61,22 @@ public class ExifIFD0DescriptorTest
         directory.setInt(TAG_RESOLUTION_UNIT, 2);
         ExifIFD0Descriptor descriptor = new ExifIFD0Descriptor(directory);
         assertEquals("72 dots per inch", descriptor.getDescription(TAG_X_RESOLUTION));
+    }
+
+    @Test
+    public void testXResolutionDescriptionWithTurkishLocale() throws Exception
+    {
+        // Regression test for https://github.com/drewnoakes/metadata-extractor/issues/364
+        // Turkish case rules lowercase 'I' to a dotless 'ı', which corrupts hardcoded ASCII
+        // description strings such as "Inch" unless the conversion is locale-independent.
+        Locale.setDefault(new Locale("tr", "TR"));
+
+        ExifIFD0Directory directory = new ExifIFD0Directory();
+        directory.setRational(TAG_X_RESOLUTION, new Rational(300, 1));
+        // 2 is for 'Inch'
+        directory.setInt(TAG_RESOLUTION_UNIT, 2);
+        ExifIFD0Descriptor descriptor = new ExifIFD0Descriptor(directory);
+        assertEquals("300 dots per inch", descriptor.getDescription(TAG_X_RESOLUTION));
     }
 
     @Test


### PR DESCRIPTION
Fixes #364.

`ExifDescriptorBase` and `GpsDescriptor` build unit strings like "300 dots per inch" by calling `toLowerCase()` on a hardcoded, ASCII description string ("Inch", "cm", "kilometers", "miles", "knots"). That call uses the JVM's default locale. Under a Turkish locale, `"Inch".toLowerCase()` produces "ınch" (dotless ı), because Turkish case rules treat 'I' differently than every other locale. Same problem for any user whose default locale is Turkish - the reported metadata comes out with corrupted words.

This only touches the six `toLowerCase()` calls that operate on these hardcoded description strings, not the wider locale/encoding discussion in the issue thread (MetadataContext, byte encoding, etc.). Those strings never need locale-sensitive casing since they're not user-facing translated text, so `Locale.ROOT` is the right fix: it makes the conversion always behave the same regardless of the runtime's default locale.

Changed:
- `Source/com/drew/metadata/exif/ExifDescriptorBase.java`: `getXResolutionDescription()`, `getYResolutionDescription()`, `getFocalPlaneXResolutionDescription()`, `getFocalPlaneYResolutionDescription()`
- `Source/com/drew/metadata/exif/GpsDescriptor.java`: `getGpsDestDistanceDescription()`, `getGpsSpeedDescription()`

Added a test in `ExifIFD0DescriptorTest` that sets the default locale to Turkish, exercises `getXResolutionDescription()`, and asserts the result is "300 dots per inch" rather than "300 dots per ınch". Verified it fails against the current code and passes with the fix, and ran the full test suite (306 tests) with no other regressions.
